### PR TITLE
General Mod and Dev Mod fixes

### DIFF
--- a/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
+++ b/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
@@ -6,6 +6,7 @@ using Knossos.NET.Views.Windows;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.ObjectModel;
+using System.Data;
 using System.IO;
 using System.Linq;
 
@@ -97,6 +98,17 @@ namespace Knossos.NET.ViewModels
                 SelectedIndex = -1;
             }
             GC.Collect();
+        }
+
+
+        /// <summary>
+        /// Updates the Version Manager Version List
+        /// If modid is passed it will be only be updated IF loaded mod id matches the modid
+        /// </summary>
+        /// <param name="modid"></param>
+        public void UpdateVersionManager(string? modid = null)
+        {
+            ModEditor?.UpdateVersionManager(modid); 
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/Templates/DevModEditorViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModEditorViewModel.cs
@@ -336,5 +336,17 @@ namespace Knossos.NET.ViewModels
                 Log.Add(Log.LogSeverity.Error, "DevModEditorViewModel.InsertToolInOrder", ex);
             }
         }
+
+
+        /// <summary>
+        /// Updates the Version Manager Version List
+        /// If modid is passed it will be only be updated IF loaded mod id matches the modid
+        /// </summary>
+        /// <param name="modid"></param>
+        public void UpdateVersionManager(string? modid = null)
+        {
+            if(VersionsView != null && (modid == null || ActiveVersion.id == modid) )
+                VersionsView?.HackUpdateModList();
+        }
     }
 }

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -182,7 +182,7 @@ namespace Knossos.NET.ViewModels
         /// <summary>
         /// Hack to force to update the list in the ui, since Mod class dosent implement observable object
         /// </summary>
-        private void HackUpdateModList()
+        public void HackUpdateModList()
         {
             Mods = Mods.ToList();
         }

--- a/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
@@ -100,12 +100,14 @@ namespace Knossos.NET.ViewModels
                 if (ids != null && ids.Any() && ids.FirstOrDefault(x => x == id) != null)
                 {
                     HasWriteAccess = true;
+                    InstallInDevMode = true;
                 }
             }
             ModVersions = await Nebula.GetAllModsWithID(id);
             if(ModVersions.Any())
             {
-                if(preSelectedVersion == null)
+                ModVersions.Sort(Mod.CompareVersion);
+                if (preSelectedVersion == null)
                 {
                     SelectedIndex = ModVersions.Count() - 1;
                 }
@@ -185,7 +187,7 @@ namespace Knossos.NET.ViewModels
                     else
                     {
                         CanSelectDevMode = true;
-                        InstallInDevMode = false;
+                        InstallInDevMode = HasWriteAccess;
                     }
                 }
                 SelectedMod.isEnabled=false;


### PR DESCRIPTION
-Fix: Mod Version list would not update the version list data after upload / download new version 
-Fix: If a mod dependency is missing  in the devmod pkgmgr, display warning and keep saving the original data instead of overriding 
-Fix: devmod pkgMgr would save the wrong value for dependency >= version (IMPORTANT!)
-Fix: Display all mod versions in their proper order during mod install
-Fix: Do not disable update notification unless we a installing a new version that is newer than the currently installed ones 
-Fix: Install in devmode was using the pkg name string instead of pkg folder name string (IMPORTANT!)
-Change Install in Dev mod is how default if user has write access to the mod