### PR TITLE
Implement Ihttpclientfactory

### DIFF
--- a/Knossos.NET/Knossos.NET.csproj
+++ b/Knossos.NET/Knossos.NET.csproj
@@ -74,6 +74,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.5" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="SharpCompress" Version="0.33.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Knossos.NET/Models/GitHubApi.cs
+++ b/Knossos.NET/Models/GitHubApi.cs
@@ -15,22 +15,18 @@ namespace Knossos.NET.Models
         /// <returns>GitHubRelease or null if the api call failed</returns>
         public static async Task<GitHubRelease?> GetLastRelease()
         {
-
-            using (HttpClient client = new HttpClient())
+            try
             {
-                try
-                {
-                    client.Timeout = TimeSpan.FromSeconds(30);
-                    client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("product", "1"));
-                    HttpResponseMessage response = await client.GetAsync(Knossos.GitHubUpdateRepoURL + "/releases/latest");
-                    var json = await response.Content.ReadAsStringAsync();
-                    return JsonSerializer.Deserialize<GitHubRelease>(json)!;
-                }
-                catch (Exception ex)
-                {
-                    Log.Add(Log.LogSeverity.Error, "GitHubApi.GetLastRelease()", ex);
-                    return null;
-                }
+                var client = KnUtils.GetHttpClient();
+                client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("product", "1"));
+                HttpResponseMessage response = await client.GetAsync(Knossos.GitHubUpdateRepoURL + "/releases/latest");
+                var json = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<GitHubRelease>(json)!;
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "GitHubApi.GetLastRelease()", ex);
+                return null;
             }
         }
     }

--- a/Knossos.NET/ViewModels/PxoViewModel.cs
+++ b/Knossos.NET/ViewModels/PxoViewModel.cs
@@ -135,34 +135,30 @@ namespace Knossos.NET.ViewModels
         /// </summary>
         public async void RefreshData()
         {
-            
-            using (HttpClient client = new HttpClient())
+            try
             {
-                try
+                HttpResponseMessage response = await KnUtils.GetHttpClient().GetAsync("https://pxo.nottheeye.com/api/v1/games/active");
+                var json = await response.Content.ReadAsStringAsync();
+                ActiveGames = JsonSerializer.Deserialize<List<PxoGamesActive>>(json)!;
+                foreach (var result in ActiveGames)
                 {
-                    HttpResponseMessage response = await client.GetAsync("https://pxo.nottheeye.com/api/v1/games/active");
-                    var json = await response.Content.ReadAsStringAsync();
-                    ActiveGames = JsonSerializer.Deserialize<List<PxoGamesActive>>(json)!;
-                    foreach (var result in ActiveGames)
+                    foreach(var server in result.Servers)
                     {
-                        foreach(var server in result.Servers)
+                        foreach(var flag in server.Flags)
                         {
-                            foreach(var flag in server.Flags)
+                            if(flag.Contains("probe"))
                             {
-                                if(flag.Contains("probe"))
-                                {
-                                    server.Probe = flag;
-                                }
+                                server.Probe = flag;
                             }
                         }
                     }
                 }
-                catch (Exception ex)
+            }
+            catch (Exception ex)
+            {
+                if(MainWindow.instance != null)
                 {
-                    if(MainWindow.instance != null)
-                    {
-                        await MessageBox.Show(MainWindow.instance,ex.Message,"Error getting PXO Game list",MessageBox.MessageBoxButtons.OK);
-                    }
+                    await MessageBox.Show(MainWindow.instance,ex.Message,"Error getting PXO Game list",MessageBox.MessageBoxButtons.OK);
                 }
             }
         }

--- a/Knossos.NET/ViewModels/Templates/DevModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModDetailsViewModel.cs
@@ -39,14 +39,11 @@ namespace Knossos.NET.ViewModels
                         else
                         {
                             Task.Run(async () => {
-                                using (HttpClient client = new HttpClient())
+                                HttpResponseMessage response = await KnUtils.GetHttpClient().GetAsync(path);
+                                byte[] content = await response.Content.ReadAsByteArrayAsync();
+                                using (Stream stream = new MemoryStream(content))
                                 {
-                                    HttpResponseMessage response = await client.GetAsync(path);
-                                    byte[] content = await response.Content.ReadAsByteArrayAsync();
-                                    using (Stream stream = new MemoryStream(content))
-                                    {
-                                        Bitmap = new Bitmap(stream);
-                                    }
+                                    Bitmap = new Bitmap(stream);
                                 }
                             });
                         }
@@ -299,14 +296,12 @@ namespace Knossos.NET.ViewModels
                     else
                     {
                         Task.Run(async () => {
-                            using (HttpClient client = new HttpClient())
+                            
+                            HttpResponseMessage response = await KnUtils.GetHttpClient().GetAsync(TileImagePath);
+                            byte[] content = await response.Content.ReadAsByteArrayAsync();
+                            using (Stream stream = new MemoryStream(content))
                             {
-                                HttpResponseMessage response = await client.GetAsync(TileImagePath);
-                                byte[] content = await response.Content.ReadAsByteArrayAsync();
-                                using (Stream stream = new MemoryStream(content))
-                                {
-                                    BannerImage = new Bitmap(stream);
-                                }
+                                BannerImage = new Bitmap(stream);
                             }
                         });
                     }
@@ -331,14 +326,11 @@ namespace Knossos.NET.ViewModels
                     else
                     {
                         Task.Run( async () => { 
-                            using (HttpClient client = new HttpClient())
+                            HttpResponseMessage response = await KnUtils.GetHttpClient().GetAsync(TileImagePath);
+                            byte[] content =  await response.Content.ReadAsByteArrayAsync();
+                            using (Stream stream = new MemoryStream(content))
                             {
-                                HttpResponseMessage response = await client.GetAsync(TileImagePath);
-                                byte[] content =  await response.Content.ReadAsByteArrayAsync();
-                                using (Stream stream = new MemoryStream(content))
-                                {
-                                    TileImage = new Bitmap(stream);
-                                }
+                                TileImage = new Bitmap(stream);
                             }
                         });
                     }

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -4165,10 +4165,8 @@ namespace Knossos.NET.ViewModels
                 bool isJson = false;
                 Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.Download()", "Downloading file: " + downloadUrl);
                 System.Diagnostics.Stopwatch stopwatch = new System.Diagnostics.Stopwatch();
-                HttpClientHandler handler = new HttpClientHandler();
-                handler.AllowAutoRedirect = true;
-                handler.AutomaticDecompression = DecompressionMethods.All;
-                using HttpClient httpClient = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
+
+                var httpClient = KnUtils.GetHttpClient();
                 if (downloadUrl.ToString().ToLower().Contains(".json"))
                 {
                     httpClient.DefaultRequestHeaders.Add("Accept-Encoding", "br, gzip, deflate");
@@ -4185,7 +4183,7 @@ namespace Knossos.NET.ViewModels
                     {
                         if (s == "Accept-Encoding")
                         {
-                            var c = new HttpClient();
+                            var c = KnUtils.GetHttpClient();
                             c.Timeout = TimeSpan.FromSeconds(30);
                             var r = await c.GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead);
                             totalBytes = r.Content.Headers.ContentLength;

--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -375,16 +375,12 @@ namespace Knossos.NET.ViewModels
 
                 if (imageUrl != string.Empty)
                 {
-                    using (HttpClient client = new HttpClient())
-                    {
-                        client.Timeout = TimeSpan.FromSeconds(30);
-                        HttpResponseMessage response = await client.GetAsync(imageUrl);
-                        byte[] content = await response.Content.ReadAsByteArrayAsync();
-                        Stream stream = new MemoryStream(content);
-                        var item = new ScreenshotItem(new Bitmap(stream), true);
-                        item.url = url;
-                        Screenshots.Add(item);
-                    }
+                    HttpResponseMessage response = await KnUtils.GetHttpClient().GetAsync(imageUrl);
+                    byte[] content = await response.Content.ReadAsByteArrayAsync();
+                    Stream stream = new MemoryStream(content);
+                    var item = new ScreenshotItem(new Bitmap(stream), true);
+                    item.url = url;
+                    Screenshots.Add(item);
                 }
                 else
                 {


### PR DESCRIPTION
The http client factory is the recomended method to get HttpClients instead of just instantiate a new instance of HttpClient and having to dispose it after using it.