### PR TITLE
fix version list not updating after deleting from nebula and editor scrolling

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -216,6 +216,8 @@ namespace Knossos.NET.Models
                                 if(isInstalled.modData != null)
                                 {
                                     isInstalled.modData.inNebula = true;
+                                    if (isInstalled.modData.devMode)
+                                        DeveloperModsViewModel.Instance!.UpdateVersionManager(isInstalled.modData.id);
                                 }
                             }
                         }
@@ -235,6 +237,8 @@ namespace Knossos.NET.Models
                                 {
                                     Dispatcher.UIThread.Invoke(() => MainWindowViewModel.Instance?.MarkAsUpdateAvalible(mod.id), DispatcherPriority.Background);
                                 }
+                                if(isInstalled.First().devMode)
+                                    DeveloperModsViewModel.Instance!.UpdateVersionManager(isInstalled.First().id);
                             }
                             else
                             {

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -499,6 +499,7 @@ namespace Knossos.NET.ViewModels
                             if (result == "ok")
                             {
                                 editor.ActiveVersion.inNebula = false;
+                                HackUpdateModList();
                                 await MessageBox.Show(MainWindow.instance!, "The mod " + editor.ActiveVersion + " was deleted from Nebula.", "Mod deleted", MessageBox.MessageBoxButtons.OK);
                             }
                             else

--- a/Knossos.NET/Views/Templates/DevBuildPkgMgrView.axaml
+++ b/Knossos.NET/Views/Templates/DevBuildPkgMgrView.axaml
@@ -12,7 +12,8 @@
 		<vm:DevBuildPkgMgrViewModel/>
 	</Design.DataContext>
 
-	<StackPanel>
+	<ScrollViewer>
+	<StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
 		<Label FontWeight="Bold" FontSize="20" Margin="5">Packages</Label>
 		<WrapPanel>
 			<Button Margin="8,0,0,5" Content="+Package">
@@ -78,5 +79,5 @@
 			</ListBox.ItemTemplate>
 		</ListBox>
 	</StackPanel>
-
+	</ScrollViewer>
 </UserControl>

--- a/Knossos.NET/Views/Templates/DevModEditorView.axaml
+++ b/Knossos.NET/Views/Templates/DevModEditorView.axaml
@@ -11,11 +11,10 @@
 	<Design.DataContext>
 		<vm:DevModEditorViewModel/>
 	</Design.DataContext>
-	
-	<ScrollViewer>
 
-		<Grid ColumnDefinitions="Auto,*">
-			<StackPanel Width="250" Grid.Column="0">
+	<Grid ColumnDefinitions="Auto,*">
+		<ScrollViewer Width="250" Grid.Column="0">
+			<StackPanel Width="250" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
 				<TextBlock HorizontalAlignment="Center" Text="{Binding Name}" FontSize="14" FontWeight="Bold" TextWrapping="Wrap" Margin="0"></TextBlock>
 				<Image HorizontalAlignment="Center" Margin="10" Source="{Binding ModImage}" Width="150" Height="225"></Image>
 				<TextBlock HorizontalAlignment="Center" Text="Active Version" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0"></TextBlock>
@@ -40,36 +39,34 @@
 					<Button Command="{Binding OpenTool}" HorizontalAlignment="Center" Margin="2" Width="150" HorizontalContentAlignment="Center" FontWeight="Black">Open</Button>
 				</StackPanel>
 			</StackPanel>
-		
-			<TabControl SelectedIndex="{Binding TabIndex}" Grid.Column="1">
+		</ScrollViewer>
+		<TabControl SelectedIndex="{Binding TabIndex}" Grid.Column="1">
 			
-				<TabItem Header="Versions">
-					<v:DevModVersionsView Content="{Binding VersionsView}"/>
-				</TabItem>
+			<TabItem Header="Versions">
+				<v:DevModVersionsView Content="{Binding VersionsView}"/>
+			</TabItem>
 
-				<TabItem Header="Details">
-					<v:DevModDetailsView Content="{Binding DetailsView}"/>
-				</TabItem>
+			<TabItem Header="Details">
+				<v:DevModDetailsView Content="{Binding DetailsView}"/>
+			</TabItem>
 			
-				<TabItem Header="Packages" >
-					<StackPanel>
-						<v:DevModPkgMgrView IsVisible="{Binding !IsEngineBuild}" Content="{Binding PkgMgrView}"/>
-						<v:DevBuildPkgMgrView IsVisible="{Binding IsEngineBuild}" Content="{Binding PkgMgrView}"/>
-					</StackPanel>
-				</TabItem>
+			<TabItem Header="Packages" >
+				<Grid>
+					<v:DevModPkgMgrView IsVisible="{Binding !IsEngineBuild}" Content="{Binding PkgMgrView}"/>
+					<v:DevBuildPkgMgrView IsVisible="{Binding IsEngineBuild}" Content="{Binding PkgMgrView}"/>
+				</Grid>
+			</TabItem>
 
-				<TabItem Header="FSO Settings" IsVisible="{Binding !IsEngineBuild}">
-					<v:DevModFsoSettingsView Content="{Binding FsoSettingsView}"/>
-				</TabItem>
+			<TabItem Header="FSO Settings" IsVisible="{Binding !IsEngineBuild}">
+				<v:DevModFsoSettingsView Content="{Binding FsoSettingsView}"/>
+			</TabItem>
 			
-				<TabItem Header="Members">
-					<v:DevModMembersMgrView Content="{Binding MembersView}"/>
-				</TabItem>
+			<TabItem Header="Members">
+				<v:DevModMembersMgrView Content="{Binding MembersView}"/>
+			</TabItem>
 			
-			</TabControl>
+		</TabControl>
 
-		</Grid>
-		
-	</ScrollViewer>
-	
+	</Grid>
+
 </UserControl>

--- a/Knossos.NET/Views/Templates/DevModMembersMgrView.cs.axaml
+++ b/Knossos.NET/Views/Templates/DevModMembersMgrView.cs.axaml
@@ -13,7 +13,7 @@
 	</Design.DataContext>
 
 	<ScrollViewer Background="#422626">
-		<StackPanel IsEnabled="{Binding ButtonsEnabled}">
+		<StackPanel IsEnabled="{Binding ButtonsEnabled}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
 			<WrapPanel IsVisible="{Binding !Loading}" Margin="20">
 				<Button Command="{Binding NewMember}" Content="Add Member"/>
 				<Button Command="{Binding Save}" Margin="20,0,0,0" Content="Save Changes"/>

--- a/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
+++ b/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
@@ -12,7 +12,8 @@
 		<vm:DevModPkgMgrViewModel/>
 	</Design.DataContext>
 
-	<StackPanel>
+	<ScrollViewer HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+	<StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
 		<Label FontWeight="Bold" FontSize="20" Margin="5">Packages and Dependencies</Label>
 		<WrapPanel>
 			<Button Margin="8,0,0,5" Content="+Package">
@@ -39,7 +40,7 @@
 			<ListBox.ItemTemplate>
 				<DataTemplate>
 					<!--Package Item-->
-					<StackPanel>
+					<StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
 						<WrapPanel>
 							<CheckBox ToolTip.Tip="If package is enabled or disabled. Disabled packages are not used when playing." IsChecked="{Binding IsEnabled}" VerticalContentAlignment="Center" HorizontalContentAlignment="Center"></CheckBox>
 							<Label MinWidth="250" FontWeight="Bold" FontSize="18" Content="{Binding Package.name}" VerticalContentAlignment="Center" HorizontalContentAlignment="Left"></Label>
@@ -126,5 +127,5 @@
 		<Label Margin="5,0,0,0" FontSize="14">-Only add additional FSO or mod dependencies to optional packages IF that package needs a different version than the rest of the mod.</Label>
 		<Label Margin="5,0,0,0" FontSize="14">-Do not repeat the same dependency across multiple packages, this is not needed.</Label>
 	</StackPanel>
-	
+	</ScrollViewer>
 </UserControl>

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -12,7 +12,7 @@
 		<vm:DevModVersionsViewModel/>
 	</Design.DataContext>
 
-	<Grid RowDefinitions="Auto,*, Auto, Auto">
+	<Grid RowDefinitions="Auto,*, Auto, Auto" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
 		<WrapPanel IsEnabled="{Binding ButtonsEnabled}" Grid.Row="0" Margin="10" HorizontalAlignment="Center">
 			<Button Background="DarkCyan" FontWeight="Bold" Content="New Version" x:Name="CreateVersion">
 				<Button.Flyout>


### PR DESCRIPTION
-Fixes the version list not removing the "uploaded to nebula" text after just deleting a version from nebula
-Fixes the scrolling, hot it is per menu item rather than scrolling the entire editor.