### PR TITLE
tweak disk space check to use exact directory if possible

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -596,7 +596,10 @@ namespace Knossos.NET
         {
             try
             {
-                var directoryPath = new FileInfo(path).Directory?.FullName;
+                var fi = new FileInfo(path);
+                var isDirectory = (fi.Attributes & FileAttributes.Directory) == FileAttributes.Directory;
+
+                var directoryPath = isDirectory ? fi.FullName : fi.Directory?.FullName;
                 if (directoryPath != null)
                 {
                     var drive = new DriveInfo(directoryPath);


### PR DESCRIPTION
FileInfo(x).Directory returns the parent directory of x. If x is already a directory then it moves up a level, possibly changing mount points on *nix systems and giving incorrect values. So use full path of x if it's a directory and parent of x otherwise.