### PR TITLE
Some Formatting Adjustments To Download List

### DIFF
--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -3245,6 +3245,7 @@ namespace Knossos.NET.ViewModels
                                         }
                                     }
                                     fileTask.Info = " Checksum OK!";
+                                    await Dispatcher.UIThread.InvokeAsync(() => TaskList.Remove(fileTask));
                                 }
                             }
                             else

--- a/Knossos.NET/Views/Templates/TaskItemView.axaml
+++ b/Knossos.NET/Views/Templates/TaskItemView.axaml
@@ -43,7 +43,7 @@
 										<Label Height="22" FontSize="12" Margin="5,0,0,0" VerticalAlignment="Bottom" Content="{Binding Info}"/>
 									</WrapPanel>
 									<StackPanel IsVisible="{Binding !IsTextTask}">
-										<Label Height="22" FontSize="14" VerticalAlignment="Bottom" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="5,0,0,0" Content="Complete!"/>
+										<Label Height="22" FontSize="14" VerticalAlignment="Bottom" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="125,0,0,0" Content="Complete!"/>
 									</StackPanel>
 								</WrapPanel>
 							</WrapPanel>

--- a/Knossos.NET/Views/Templates/TaskItemView.axaml
+++ b/Knossos.NET/Views/Templates/TaskItemView.axaml
@@ -13,41 +13,56 @@
 	</Design.DataContext>
 	<Border BorderBrush="BlueViolet">
 		<WrapPanel ToolTip.Tip="{Binding Tooltip}">
-			<Button Command="{Binding CancelTaskCommand}" IsVisible="{Binding CancelButtonVisible}" Margin="5,0,0,0" Height="25" FontSize="8" Background="Red" Foreground="Black" FontWeight="Bold">X</Button>
 			<WrapPanel VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="5">
+				<Button Command="{Binding CancelTaskCommand}" IsVisible="{Binding CancelButtonVisible}" Margin="5,0,0,0" Height="25" Width="27" FontSize="14" Background="Red" Foreground="Black" HorizontalAlignment="Left" VerticalAlignment="Top" FontWeight="Bold">X</Button>
 				<!--Task Tree-->
 				<TreeView Margin="10,0,0,0" IsVisible="{Binding TaskRoot.Count}" ItemsSource="{Binding TaskRoot}">
 					<TreeView.DataTemplates>
 						<TreeDataTemplate DataType="vm:TaskItemViewModel" ItemsSource="{Binding TaskList}">
 							<WrapPanel>
-								<Label Height="25" Width="400" HorizontalContentAlignment="Left" FontSize="14" Margin="5,0,0,0" Content="{Binding Name}" Foreground="{Binding TextColor}"/>
-								<WrapPanel IsVisible="{Binding !IsCompleted}">
-									<Button Margin="5,0,0,0" Content="{Binding PauseButtonText}" Background="Black" IsEnabled="{Binding !IsCancelled}" FontWeight="Bold" Height="25" FontSize="8" Command="{Binding PauseDownloadCommand}" IsVisible="{Binding IsFileDownloadTask}"/>
-									<Button Margin="5,0,0,0" Background="Black" IsEnabled="{Binding !IsCancelled}" FontWeight="Bold" Height="25" FontSize="8" Command="{Binding RestartDownloadCommand}" IsVisible="{Binding IsFileDownloadTask}">Restart</Button>
+								<!--Two versions to better handle spacing-->
+								<!--Download Version-->
+								<WrapPanel IsEnabled="{Binding IsFileDownloadTask}" IsVisible="{Binding IsFileDownloadTask}">
+									<Label Height="22" Width="300" HorizontalContentAlignment="Left" FontSize="14" Margin="5,0,0,0" Content="{Binding Name}" Foreground="{Binding TextColor}"/>
+									<WrapPanel IsVisible="{Binding !IsCompleted}">
+										<Button Margin="5,0,0,0" Width="57" Content="{Binding PauseButtonText}" Background="Black" IsVisible="{Binding !IsCancelled }" HorizontalAlignment="Center" FontWeight="Bold" Height="22" FontSize="10" Command="{Binding PauseDownloadCommand}"/>
+										<Button Margin="5,0,0,0" Width="53" Background="Black" IsVisible="{Binding !IsCancelled}" HorizontalAlignment="Center" FontWeight="Bold" Height="22" FontSize="10" Command="{Binding RestartDownloadCommand}">Restart</Button>
+										<ProgressBar Width="250" IsVisible="{Binding ProgressBarMax}" Maximum="{Binding ProgressBarMax}" Minimum="{Binding ProgressBarMin}" Value="{Binding ProgressCurrent}" Margin="5,0,0,0" Height="20" ShowProgressText="{Binding ShowProgressText}"></ProgressBar>
+										<Label Height="22" FontSize="10" Margin="5,0,0,0" VerticalAlignment="Bottom" Content="{Binding Info}"/>
+										<Label IsVisible="{Binding IsFileDownloadTask}" Height="22" FontSize="10" Margin="5,0,0,0" VerticalAlignment="Bottom" Content="{Binding CurrentMirror}"/>
+									</WrapPanel>
+									<StackPanel IsVisible="{Binding !IsTextTask}">
+										<Label Height="22" FontSize="14" VerticalAlignment="Bottom" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="5,0,0,0" Content="Complete!"/>
+									</StackPanel>
 								</WrapPanel>
-								<ProgressBar Width="250" IsVisible="{Binding ProgressBarMax}" Maximum="{Binding ProgressBarMax}" Minimum="{Binding ProgressBarMin}" Value="{Binding ProgressCurrent}" Margin="5,0,0,0" Height="20" ShowProgressText="{Binding ShowProgressText}"></ProgressBar>
-								<Label Height="25" FontSize="14" Margin="5,0,0,0" Content="{Binding Info}"/>
-								<Label IsVisible="{Binding IsFileDownloadTask}" Height="25" FontSize="14" Margin="5,0,0,0" Content="{Binding CurrentMirror}"/>
-								<StackPanel IsVisible="{Binding !IsTextTask}">
-									<Label Height="25" FontSize="14" VerticalAlignment="Center" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="10,0,0,0" Content="Task Complete!"/>
-								</StackPanel>
+								<!--Decompression Version-->
+								<WrapPanel IsVisible="{Binding !IsFileDownloadTask}" IsEnabled="{Binding !IsFileDownloadTask}">
+									<Label Height="22" Width="300" HorizontalContentAlignment="Left" FontSize="14" Margin="5,0,0,0" Content="{Binding Name}" Foreground="{Binding TextColor}"/>
+									<WrapPanel IsVisible="{Binding !IsCompleted}">
+										<ProgressBar Width="250" IsVisible="{Binding ProgressBarMax}" Maximum="{Binding ProgressBarMax}" Minimum="{Binding ProgressBarMin}" Value="{Binding ProgressCurrent}" Margin="125,0,0,0" Height="20" ShowProgressText="{Binding ShowProgressText}"></ProgressBar>
+										<Label Height="22" FontSize="10" Margin="5,0,0,0" VerticalAlignment="Bottom" Content="{Binding Info}"/>
+									</WrapPanel>
+									<StackPanel IsVisible="{Binding !IsTextTask}">
+										<Label Height="22" FontSize="14" VerticalAlignment="Bottom" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="5,0,0,0" Content="Complete!"/>
+									</StackPanel>
+								</WrapPanel>
 							</WrapPanel>
 						</TreeDataTemplate>
 					</TreeView.DataTemplates>
 				</TreeView>
 				<!--Single Task-->
 				<WrapPanel IsVisible="{Binding !TaskRoot.Count}">
-					<TextBlock Height="25" FontSize="16" Margin="5,0,0,0" TextWrapping="Wrap" Text="{Binding Name}" Foreground="{Binding TextColor}"/>
+					<TextBlock Height="22" FontSize="16" Margin="5,0,0,0" TextWrapping="Wrap" Text="{Binding Name}" Foreground="{Binding TextColor}"/>
 					<WrapPanel IsVisible="{Binding ProgressBarMax}">
 						<WrapPanel IsVisible="{Binding !IsCompleted}">
-							<Button Margin="5,0,0,0" Content="{Binding PauseButtonText}" Background="Black" IsEnabled="{Binding !IsCancelled}" FontWeight="Bold" Height="25" FontSize="8" Command="{Binding PauseDownloadCommand}" IsVisible="{Binding IsFileDownloadTask}"/>
-							<Button Margin="5,0,0,0" Background="Black" IsEnabled="{Binding !IsCancelled}" FontWeight="Bold" Height="25" FontSize="8" Command="{Binding RestartDownloadCommand}" IsVisible="{Binding IsFileDownloadTask}">Restart</Button>
+							<Button Margin="5,0,0,0" Content="{Binding PauseButtonText}" Background="Black" IsEnabled="{Binding !IsCancelled}" FontWeight="Bold" Height="22" FontSize="12" Command="{Binding PauseDownloadCommand}" IsVisible="{Binding IsFileDownloadTask}"/>
+							<Button Margin="5,0,0,0" Background="Black" IsEnabled="{Binding !IsCancelled}" FontWeight="Bold" Height="22" FontSize="10" Command="{Binding RestartDownloadCommand}" IsVisible="{Binding IsFileDownloadTask}">Restart</Button>
+							<ProgressBar Width="400" Maximum="{Binding ProgressBarMax}" Minimum="{Binding ProgressBarMin}" Value="{Binding ProgressCurrent}" Margin="5,0,0,0" Height="20" ShowProgressText="True"></ProgressBar>
+							<Label Height="22" FontSize="14" Margin="5,0,0,0" Content="{Binding Info}"/>
+							<Label IsVisible="{Binding IsFileDownloadTask}" Height="20" FontSize="12" Margin="5,0,0,0" Content="{Binding CurrentMirror}"/>
 						</WrapPanel>
-						<ProgressBar Width="400" Maximum="{Binding ProgressBarMax}" Minimum="{Binding ProgressBarMin}" Value="{Binding ProgressCurrent}" Margin="5,0,0,0" Height="20" ShowProgressText="True"></ProgressBar>
-						<Label Height="25" FontSize="14" Margin="5,0,0,0" Content="{Binding Info}"/>
-						<Label IsVisible="{Binding IsFileDownloadTask}" Height="20" FontSize="12" Margin="5,0,0,0" Content="{Binding CurrentMirror}"/>
 						<StackPanel IsVisible="{Binding !IsTextTask}">
-							<Label Height="25" FontSize="14" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="10,0,0,0" Content="Task Complete!"/>
+							<Label Height="22" FontSize="14" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="5,0,0,0" Content="Complete!"/>
 						</StackPanel>
 					</WrapPanel>
 				</WrapPanel>

--- a/Knossos.NET/Views/Templates/TaskItemView.axaml
+++ b/Knossos.NET/Views/Templates/TaskItemView.axaml
@@ -40,7 +40,7 @@
 									<Label Height="22" Width="300" HorizontalContentAlignment="Left" FontSize="14" Margin="5,0,0,0" Content="{Binding Name}" Foreground="{Binding TextColor}"/>
 									<WrapPanel IsVisible="{Binding !IsCompleted}">
 										<ProgressBar Width="250" IsVisible="{Binding ProgressBarMax}" Maximum="{Binding ProgressBarMax}" Minimum="{Binding ProgressBarMin}" Value="{Binding ProgressCurrent}" Margin="125,0,0,0" Height="20" ShowProgressText="{Binding ShowProgressText}"></ProgressBar>
-										<Label Height="22" FontSize="10" Margin="5,0,0,0" VerticalAlignment="Bottom" Content="{Binding Info}"/>
+										<Label Height="22" FontSize="12" Margin="5,0,0,0" VerticalAlignment="Bottom" Content="{Binding Info}"/>
 									</WrapPanel>
 									<StackPanel IsVisible="{Binding !IsTextTask}">
 										<Label Height="22" FontSize="14" VerticalAlignment="Bottom" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="5,0,0,0" Content="Complete!"/>
@@ -59,7 +59,7 @@
 							<Button Margin="5,0,0,0" Background="Black" IsEnabled="{Binding !IsCancelled}" FontWeight="Bold" Height="22" FontSize="10" Command="{Binding RestartDownloadCommand}" IsVisible="{Binding IsFileDownloadTask}">Restart</Button>
 							<ProgressBar Width="400" Maximum="{Binding ProgressBarMax}" Minimum="{Binding ProgressBarMin}" Value="{Binding ProgressCurrent}" Margin="5,0,0,0" Height="20" ShowProgressText="True"></ProgressBar>
 							<Label Height="22" FontSize="14" Margin="5,0,0,0" Content="{Binding Info}"/>
-							<Label IsVisible="{Binding IsFileDownloadTask}" Height="20" FontSize="12" Margin="5,0,0,0" Content="{Binding CurrentMirror}"/>
+							<Label IsVisible="{Binding IsFileDownloadTask}" Height="20" FontSize="14" Margin="5,0,0,0" Content="{Binding CurrentMirror}"/>
 						</WrapPanel>
 						<StackPanel IsVisible="{Binding !IsTextTask}">
 							<Label Height="22" FontSize="14" IsVisible="{Binding IsCompleted}" Foreground="Green" Margin="5,0,0,0" Content="Complete!"/>


### PR DESCRIPTION
I noticed that the formatting and spacing in the download list were a little rough, so I made some changes.

Before:
![Screen Shot 2023-11-14 at 10 40 53 AM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/d7f733ba-1146-46e3-9e3d-1696658e785b)


After:
![Screen Shot 2023-11-14 at 10 39 04 AM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/81d3a663-cd61-4792-b324-5a239f80d243)

