### PR TITLE
Fix custom exec names on macOS

### DIFF
--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -695,6 +695,42 @@ namespace Knossos.NET.Models
             //inverted
             return SemanticVersion.Compare(build2.version, build1.version);
         }
+
+        /// <summary>
+        /// Used to fix up the executable name for macOS app bundles. Takes as arguments
+        /// the full path to the directory containing the current exe and the name of what
+        /// is currently considered the exe.
+        /// </summary>
+        /// <param name="pathName"></param>
+        /// <param name="fileName"></param>
+        /// <returns>string</returns>
+        public static string GetRealExeName(string pathName, string fileName)
+        {
+            try {
+                if (KnUtils.IsMacOS)
+                {
+                    var exe = new FileInfo(Path.Combine(pathName, fileName));
+                    if (exe != null && ((exe.Attributes & FileAttributes.Directory) == FileAttributes.Directory))
+                    {
+                        var files = Directory.GetFiles(Path.Combine(exe.FullName, "Contents/MacOS"));
+                        foreach(string file in files)
+                        {
+                            var fi = new FileInfo(file);
+                            if (fi != null && (fi.Name.ToLower().Contains("fs2_open") || fi.Name.ToLower().Contains("fred2_open") || fi.Name.ToLower().Contains("qtfred")))
+                            {
+                                return exe.Name + "/Contents/MacOS/" + fi.Name;
+                            }
+                        }
+                    }
+                }
+            }
+            catch(Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "AddUserBuildViewModel.GetExeName()", ex);
+            }
+
+            return fileName;
+        }
     }
 
     public class FsoFile

--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -761,25 +761,28 @@ namespace Knossos.NET.Models
         private int DetermineScore(string modpath)
         {
             int score = 0;
+            string filePath = string.Empty;
+            if (modpath != string.Empty)
+                filePath = Path.Combine(modpath, filename);
             /* First the cases that are an instant 0 */
             if (arch == FsoExecArch.other || env == FsoExecEnvironment.Unknown || type == FsoExecType.Unknown)
             {
                 if (modpath != string.Empty)
-                    Log.Add(Log.LogSeverity.Warning, "FsoFile.DetermineScore", "File: " + modpath + filename + " has an unknown cpu arch, build or enviroment type in json.");
+                    Log.Add(Log.LogSeverity.Warning, "FsoFile.DetermineScore", "File: " + filePath + " has an unknown cpu arch, build or enviroment type in json.");
                 return 0;
             }
-
-            if (modpath != string.Empty && !File.Exists(modpath + filename))
+// get exe name here for exists check
+            if (modpath != string.Empty && !File.Exists(filePath))
             {
                 if (modpath != string.Empty)
-                    Log.Add(Log.LogSeverity.Warning, "FsoFile.DetermineScore", "File: " + modpath + filename + " does not exist!");
+                    Log.Add(Log.LogSeverity.Warning, "FsoFile.DetermineScore", "File: " + filePath + " does not exist!");
                 return 0;
             }
 
             if (env == FsoExecEnvironment.Windows && !KnUtils.IsWindows || env == FsoExecEnvironment.Linux && !KnUtils.IsLinux || env == FsoExecEnvironment.MacOSX && !KnUtils.IsMacOS)
             {
                 if (modpath != string.Empty)
-                    Log.Add(Log.LogSeverity.Warning, "FsoFile.DetermineScore", "File: " + modpath + filename + " is not valid for this OS. Detected: " + env);
+                    Log.Add(Log.LogSeverity.Warning, "FsoFile.DetermineScore", "File: " + filePath + " is not valid for this OS. Detected: " + env);
                 return 0;
             }
 

--- a/Knossos.NET/ViewModels/Templates/DevBuildPkgMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevBuildPkgMgrViewModel.cs
@@ -273,7 +273,8 @@ namespace Knossos.NET.ViewModels
 
                     if (result != null && result.Count > 0)
                     {
-                        var newFile = result[0].Path.LocalPath.ToString();
+                        var fullPath = result[0].Path.LocalPath.ToString();
+                        var newFile = Path.Combine(Path.GetDirectoryName(fullPath)!, FsoBuild.GetRealExeName(Path.GetDirectoryName(fullPath)!, Path.GetFileName(fullPath)));
                         var newExec = new ModExecutable();
                         newExec.file = Path.GetRelativePath(Path.Combine(PkgMgr.editor!.ActiveVersion.fullPath, Package.folder != null ? Package.folder : "" ), newFile).Replace(@"\",@"/");
                         Executables.Add(new PackageExecItem(newExec, this));

--- a/Knossos.NET/ViewModels/Windows/AddUserBuildViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/AddUserBuildViewModel.cs
@@ -81,6 +81,10 @@ namespace Knossos.NET.ViewModels
                     {
                         execs=Directory.GetFiles(folderPath, "*.exe");
                     }
+                    else if (KnUtils.IsMacOS)
+                    {
+                        execs=Directory.GetDirectories(folderPath, "*.app");
+                    }
                     else
                     {
                         execs=Directory.GetFiles(folderPath, "*.AppImage");
@@ -408,14 +412,14 @@ namespace Knossos.NET.ViewModels
                     if(Release != string.Empty)
                     {
                         var newFile = new ModExecutable();
-                        newFile.file = Release;
+                        newFile.file = FsoBuild.GetRealExeName(folderPath, Release);
                         newFile.properties= properties;
                         package.executables.Add(newFile);
                     }
                     if (DebugFile != string.Empty)
                     {
                         var newFile = new ModExecutable();
-                        newFile.file = DebugFile;
+                        newFile.file = FsoBuild.GetRealExeName(folderPath, DebugFile);
                         newFile.label = "FastDebug";
                         newFile.properties = properties;
                         package.executables.Add(newFile);
@@ -423,7 +427,7 @@ namespace Knossos.NET.ViewModels
                     if (Fred2 != string.Empty)
                     {
                         var newFile = new ModExecutable();
-                        newFile.file = Fred2;
+                        newFile.file = FsoBuild.GetRealExeName(folderPath, Fred2);
                         newFile.label = "FRED2";
                         newFile.properties = properties;
                         package.executables.Add(newFile);
@@ -431,7 +435,7 @@ namespace Knossos.NET.ViewModels
                     if (Fred2Debug != string.Empty)
                     {
                         var newFile = new ModExecutable();
-                        newFile.file = Fred2Debug;
+                        newFile.file = FsoBuild.GetRealExeName(folderPath, Fred2Debug);
                         newFile.label = "Fred FastDebug";
                         newFile.properties = properties;
                         package.executables.Add(newFile);
@@ -439,7 +443,7 @@ namespace Knossos.NET.ViewModels
                     if (QtFred != string.Empty)
                     {
                         var newFile = new ModExecutable();
-                        newFile.file = QtFred;
+                        newFile.file = FsoBuild.GetRealExeName(folderPath, QtFred);
                         newFile.label = "QTFred";
                         newFile.properties = properties;
                         package.executables.Add(newFile);
@@ -447,7 +451,7 @@ namespace Knossos.NET.ViewModels
                     if (QtFredDebug != string.Empty)
                     {
                         var newFile = new ModExecutable();
-                        newFile.file = QtFredDebug;
+                        newFile.file = FsoBuild.GetRealExeName(folderPath, QtFredDebug);
                         newFile.label = "QTFred FastDebug";
                         newFile.properties = properties;
                         package.executables.Add(newFile);
@@ -519,7 +523,7 @@ namespace Knossos.NET.ViewModels
                     Dispatcher.UIThread.Invoke(()=> MaxFiles = allFiles.Length );
                     foreach (string newPath in Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories))
                     {
-                        if (!newPath.ToLower().Contains(".pdb") && !newPath.ToLower().Contains(".lib") && !newPath.ToLower().Contains(".exp"))
+                        if (!newPath.ToLower().Contains(".pdb") && !newPath.ToLower().Contains(".lib") && !newPath.ToLower().Contains(".exp") && !newPath.ToLower().EndsWith(".a"))
                         {
                             System.IO.File.Copy(newPath, newPath.Replace(sourcePath, targetPath), true);
                         }

--- a/Knossos.NET/Views/Windows/AddUserBuildView.axaml
+++ b/Knossos.NET/Views/Windows/AddUserBuildView.axaml
@@ -62,7 +62,7 @@
 			<StackPanel IsVisible="{Binding Stage2}" Margin="0,30,0,0">
 				<Label>3) Click the button when ready, the folder will be copied to:</Label>
 				<TextBlock TextWrapping="Wrap" Text="{Binding BuildNewPath}"></TextBlock>
-				<Label>Any (.lib, .pdb and .exp) will be ignored, and a mod.json file will be generated.</Label>
+				<Label>Any (.lib, .a, .pdb and .exp) will be ignored, and a mod.json file will be generated.</Label>
 				<Button VerticalAlignment="Center" Command="{Binding AddCommand}">Add new build</Button>
 			</StackPanel>
 		</StackPanel>


### PR DESCRIPTION
Sets the proper executable name when generating engine json and using app bundles on macOS. This allows custom builds to be generated properly on mac and fixes dev mode engine packages as well.

Also fixes broken path in `DeterminScore()` when passed modpath doesn't include a trailing directory separator, and makes sure to ignore library files (`*.a`) on Linux/mac when copying custom builds.