### PR TITLE
Add SevenZipcmdline decompression, Fix autoupdate, add utility method to decompress files

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -13,6 +13,11 @@ using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using System.Net;
 using System.Net.Http;
+using SharpCompress.Archives;
+using SharpCompress.Common;
+using SharpCompress.Readers;
+using Knossos.NET.Classes;
+using Knossos.NET.Models;
 
 namespace Knossos.NET
 {
@@ -624,6 +629,139 @@ namespace Knossos.NET
         public static HttpClient GetHttpClient()
         {
             return httpClientFactory.CreateClient("generic");
+        }
+
+        public async static Task<bool> DecompressFile(string compressedFilePath, string destFolderPath, CancellationTokenSource? cancellationTokenSource, bool extractFullPath = true, Action<int>? progressCallback = null, Decompressor? decompressor = null)
+        {
+            if(!File.Exists(compressedFilePath))
+            {
+                Log.Add(Log.LogSeverity.Error, "KnUtil.DecompressFile()", "File " + compressedFilePath + " does not exist!");
+                return false;
+            }
+            if(decompressor == null)
+            {
+                decompressor = Knossos.globalSettings.decompressor;
+            }
+
+            return await Task.Run(async() => {
+                if(cancellationTokenSource == null)
+                    cancellationTokenSource = new CancellationTokenSource();
+
+                progressCallback?.Invoke(0);
+
+                bool result = false;
+
+                switch(decompressor)
+                {
+                    case Decompressor.Auto: 
+                        result = DecompressFileSharpCompress(compressedFilePath, destFolderPath, cancellationTokenSource, extractFullPath, progressCallback);
+                        if(!result)
+                        {
+                            result = await DecompressFileSevenZip(compressedFilePath, destFolderPath, cancellationTokenSource, extractFullPath, progressCallback).ConfigureAwait(false);
+                        }
+                        break;
+                    case Decompressor.SharpCompress:
+                        result = DecompressFileSharpCompress(compressedFilePath, destFolderPath, cancellationTokenSource, extractFullPath, progressCallback);
+                        break;
+                    case Decompressor.SevenZip:
+                        result = await DecompressFileSevenZip(compressedFilePath, destFolderPath, cancellationTokenSource, extractFullPath, progressCallback).ConfigureAwait(false);
+                        break;
+                }
+
+                if (!result)
+                    cancellationTokenSource?.Cancel();
+
+                return result;
+            });
+        }
+
+        private async static Task<bool> DecompressFileSevenZip(string compressedFilePath, string destFolderPath, CancellationTokenSource cancellationTokenSource, bool extractFullPath = true, Action<int>? progressCallback = null)
+        {
+            try
+            {
+                using (var sevenZip = new SevenZipConsoleWrapper(progressCallback, cancellationTokenSource))
+                {
+                    return await sevenZip.DecompressFile(compressedFilePath, destFolderPath, extractFullPath);
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                Log.Add(Log.LogSeverity.Warning, "KnUtil.DecompressFileSevenZip()", "Decompression of file " + compressedFilePath + " was cancelled.");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "KnUtil.DecompressFileSevenZip()", ex);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Decompress a Zip, 7z, or tar.gz file using SharpCompress lib
+        /// </summary>
+        /// <param name="compressedFilePath"></param>
+        /// <param name="destFolderPath"></param>
+        /// <param name="cancellationTokenSource"></param>
+        /// <param name="extractFullPath"></param>
+        /// <param name="progressCallback"></param>
+        /// <returns> true if decompression was successfull, false otherwise</returns>
+        private static bool DecompressFileSharpCompress(string compressedFilePath, string destFolderPath, CancellationTokenSource cancellationTokenSource, bool extractFullPath = true, Action<int>? progressCallback = null)
+        {
+            try
+            {
+                using (var fileStream = new ProgressStream(File.Open(compressedFilePath, FileMode.Open, FileAccess.Read, FileShare.Read), progressCallback))
+                {
+                    //tar.gz
+                    if (compressedFilePath!.ToLower().Contains(".tar") || compressedFilePath.ToLower().Contains(".gz"))
+                    {
+                        using (var reader = ReaderFactory.Open(fileStream))
+                        {
+                            while (reader.MoveToNextEntry())
+                            {
+                                if (!reader.Entry.IsDirectory)
+                                {
+                                    reader.WriteEntryToDirectory(destFolderPath, new ExtractionOptions() { ExtractFullPath = extractFullPath, Overwrite = true, WriteSymbolicLink = (source, target) => { File.CreateSymbolicLink(source, target); } });
+                                }
+                                if (cancellationTokenSource!.IsCancellationRequested)
+                                {
+                                    throw new TaskCanceledException();
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        //zip, 7z
+                        using (var archive = ArchiveFactory.Open(fileStream))
+                        {
+                            var reader = archive.ExtractAllEntries();
+                            while (reader.MoveToNextEntry())
+                            {
+                                if (!reader.Entry.IsDirectory)
+                                {
+                                    reader.WriteEntryToDirectory(destFolderPath, new ExtractionOptions() { ExtractFullPath = extractFullPath, Overwrite = true });
+                                }
+                                if (cancellationTokenSource!.IsCancellationRequested)
+                                {
+                                    throw new TaskCanceledException();
+                                }
+                            }
+                        }
+                    }
+                    fileStream.Close();
+                    return true;
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                Log.Add(Log.LogSeverity.Warning, "KnUtil.DecompressFileSharpCompress()", "Decompression of file " + compressedFilePath + " was cancelled.");
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "KnUtil.DecompressFileSharpCompress()", ex);
+                return false;
+            }
         }
     }
 }

--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -631,6 +631,21 @@ namespace Knossos.NET
             return httpClientFactory.CreateClient("generic");
         }
 
+        /// <summary>
+        /// Decompress a Zip, 7z, or tar.gz file to a folder
+        /// If not Decompressor method is specified the one saved in the global settings will be used
+        /// Decompression Method:
+        /// Auto(0) = First it tries with sharpcompress, and if it fails it then uses the SevepZip console utility
+        /// Sharpcompress(1) = Decompress only using Sharpcompress
+        /// SevenZip(2) = Decompress only using SevenZip cmdline utility
+        /// </summary>
+        /// <param name="compressedFilePath"></param>
+        /// <param name="destFolderPath"></param>
+        /// <param name="cancellationTokenSource"></param>
+        /// <param name="extractFullPath"></param>
+        /// <param name="progressCallback"></param>
+        /// <param name="decompressor"></param>
+        /// <returns> true if decompression was successfull, false otherwise</returns>
         public async static Task<bool> DecompressFile(string compressedFilePath, string destFolderPath, CancellationTokenSource? cancellationTokenSource, bool extractFullPath = true, Action<int>? progressCallback = null, Decompressor? decompressor = null)
         {
             if(!File.Exists(compressedFilePath))
@@ -675,6 +690,15 @@ namespace Knossos.NET
             });
         }
 
+        /// <summary>
+        /// Decompress a Zip, 7z, or tar.gz file using SevenZip cmdline utility
+        /// </summary>
+        /// <param name="compressedFilePath"></param>
+        /// <param name="destFolderPath"></param>
+        /// <param name="cancellationTokenSource"></param>
+        /// <param name="extractFullPath"></param>
+        /// <param name="progressCallback"></param>
+        /// <returns> true if decompression was successfull, false otherwise</returns>
         private async static Task<bool> DecompressFileSevenZip(string compressedFilePath, string destFolderPath, CancellationTokenSource cancellationTokenSource, bool extractFullPath = true, Action<int>? progressCallback = null)
         {
             try

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -370,7 +370,12 @@ namespace Knossos.NET
                                         else
                                         {
 
-                                            var result = await KnUtils.DecompressFile(KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "update" + extension, appDirPath!, null, false, null).ConfigureAwait(false);
+                                            var result = false;
+
+                                            await Dispatcher.UIThread.Invoke(async () =>
+                                            {
+                                                result  = await TaskViewModel.Instance!.AddFileDecompressionTask(KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "update" + extension, appDirPath!, false);
+                                            }).ConfigureAwait(false);
 
                                             if (!result)
                                             {

--- a/Knossos.NET/Classes/ProgressStream.cs
+++ b/Knossos.NET/Classes/ProgressStream.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+
+
+namespace Knossos.NET.Classes
+{
+    /// <summary>
+    /// Small Class that allows to track the progress of how much % of file stream has been read
+    /// </summary>
+    public class ProgressStream : Stream
+    {
+        private Stream stream;
+        private Action<int>? progressCallback;
+
+
+        public ProgressStream(Stream stream, Action<int>? progressCallback)
+        {
+            this.stream = stream;
+            this.progressCallback = progressCallback;
+        }
+
+        public override bool CanRead => stream.CanRead;
+
+        public override bool CanSeek => stream.CanSeek;
+
+        public override bool CanWrite => stream.CanWrite;
+
+        public override long Length => stream.Length;
+
+        public override long Position { get => stream.Position; set => stream.Position = value; }
+
+        public override void Flush()
+        {
+            stream.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int n = stream.Read(buffer, offset, count);
+            progressCallback?.Invoke((int)((100 * stream.Position) / stream.Length));
+            return n;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            stream.Seek(offset, origin);
+            return Position;
+        }
+
+        public override void SetLength(long value)
+        {
+            stream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            stream.Write(buffer, offset, count);
+        }
+
+        public override void Close()
+        {
+            stream.Close();
+            base.Close();
+        }
+    }
+}

--- a/Knossos.NET/Classes/SevenZipConsoleWrapper.cs
+++ b/Knossos.NET/Classes/SevenZipConsoleWrapper.cs
@@ -21,12 +21,12 @@ namespace Knossos.NET
         private bool disposed = false;
         public string versionString = string.Empty;
         private string pathToConsoleExecutable;
-        private Action<string>? progressCallback;
+        private Action<int>? progressCallback;
         private Process? process;
         private bool completedSuccessfully = false;
         private CancellationTokenSource? cancelSource;
 
-        public SevenZipConsoleWrapper(Action<string>? progressCallback = null, CancellationTokenSource? cancelSource = null) 
+        public SevenZipConsoleWrapper(Action<int>? progressCallback = null, CancellationTokenSource? cancelSource = null) 
         {
             this.pathToConsoleExecutable = UnpackExec();
             this.progressCallback = progressCallback;
@@ -40,6 +40,52 @@ namespace Knossos.NET
             {
                 Log.Add(Log.LogSeverity.Error, "SevenZipConsoleWrapper.Constructor", "File does not exist: " + pathToConsoleExecutable);
             }
+        }
+
+        /// <summary>
+        /// Decompress a .zip, .7z or .tar.gz file to a folder using the 7zip cmdline tool
+        /// </summary>
+        /// <param name="sourceFile"></param>
+        /// <param name="destFolder"></param>
+        /// <param name="extractFullPath"></param>
+        /// <returns>true if the descompression was successfull, false otherwise</returns>
+        /// <exception cref="ObjectDisposedException"></exception>
+        public async Task<bool> DecompressFile(string sourceFile, string destFolder, bool extractFullPath = true)
+        {
+            if (disposed)
+                throw new ObjectDisposedException("This object was already disposed.");
+
+            bool isTarGz = false;
+
+            if (sourceFile.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+                isTarGz = true;
+
+            string cmdline = "\"" + sourceFile + "\" -aoa -bsp1 -y";
+
+            if (extractFullPath)
+                cmdline = "x " + cmdline;
+            else
+                cmdline = "e " + cmdline;
+
+            var result = await Run(cmdline, destFolder);
+
+            if (isTarGz && result)
+            {
+                sourceFile = Path.Combine(destFolder, Path.GetFileName(sourceFile).Replace(".tar.gz", ".tar"));
+                if (extractFullPath)
+                    cmdline = "x ";
+                else
+                    cmdline = "e ";
+                cmdline += "\"" + sourceFile + "\" -aoa -bsp1 -y";
+                result = await Run(cmdline, destFolder);
+                try
+                {
+                    File.Delete(sourceFile);
+                }
+                catch { }
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -57,7 +103,7 @@ namespace Knossos.NET
             string cmdline = "a -t7z -m0=lzma2 -md=64M -mx=9 -ms=on -bsp1 -y ";
             if (doNotStoreTimestamp)
                 cmdline += "-mtm- ";
-            return await Run(cmdline + destFile, sourceFolder);
+            return await Run(cmdline + "\"" + destFile + "\"", sourceFolder);
         }
 
         /// <summary>
@@ -81,7 +127,7 @@ namespace Knossos.NET
                 cmdline = "a -mx=8 -bsp1 -y ";
                 if (doNotStoreTimestamp)
                     cmdline += "-mtm- ";
-                return await Run(cmdline + destFile + ".tar.gz" + " " + destFile + ".tar", sourceFolder);
+                return await Run(cmdline + "\"" + destFile + ".tar.gz\"" + " " + destFile + ".tar", sourceFolder);
             }
             return r;
         }
@@ -123,7 +169,10 @@ namespace Knossos.NET
         {
             try
             {
-                process?.Kill();
+                if (process != null && process.ExitCode != 0)
+                {
+                    process.Kill();
+                }
             }
             catch (Exception ex)
             {
@@ -275,11 +324,12 @@ namespace Knossos.NET
                         {
                             percentage = match.Groups[1].Value;
                         }
-                        progressCallback?.Invoke(percentage);
+                        progressCallback?.Invoke(int.Parse(percentage));
                     }  
                 }catch { }
                 if(e.Data.Contains("Everything is Ok"))
                 {
+                    progressCallback?.Invoke(100);
                     completedSuccessfully = true;
                 }
             }
@@ -308,7 +358,10 @@ namespace Knossos.NET
             {
                 try
                 {
-                    process.Kill();
+                    if (process.ExitCode != 0)
+                    {
+                        process.Kill();
+                    }
                 }
                 catch { }
                 process.Dispose();

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -28,6 +28,17 @@ namespace Knossos.NET.Models
     }
 
     /// <summary>
+    /// Decompressor Method setting for KnUtils
+    /// Auto = First try with sharpcompress and if it fails try with sevenzip
+    /// </summary>
+    public enum Decompressor
+    {
+        Auto,
+        SharpCompress,
+        SevenZip
+    }
+
+    /// <summary>
     /// Stores and load the global Knossos.NET configuration
     /// </summary>
     public class GlobalSettings
@@ -65,6 +76,8 @@ namespace Knossos.NET.Models
         public bool checkUpdate { get; set; } = true;
         [JsonPropertyName("delete_uploaded_files")]
         public bool deleteUploadedFiles { get; set; } = true;
+        [JsonPropertyName("decompressor")]
+        public Decompressor decompressor { get; set; } = Decompressor.Auto;
 
         /* FSO Settings that use the fs2_open.ini are json ignored */
 
@@ -536,7 +549,7 @@ namespace Knossos.NET.Models
                         checkUpdate = tempSettings.checkUpdate;
                         ttsVoiceName = tempSettings.ttsVoiceName;
                         deleteUploadedFiles = tempSettings.deleteUploadedFiles;
-
+                        decompressor = tempSettings.decompressor;
                         ReadFS2IniValues();
                         Log.Add(Log.LogSeverity.Information, "GlobalSettings.Load()", "Global seetings has been loaded");
                     }

--- a/Knossos.NET/ViewModels/TaskViewModel.cs
+++ b/Knossos.NET/ViewModels/TaskViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
 using System;
+using System.IO;
 
 namespace Knossos.NET.ViewModels
 {
@@ -96,6 +97,36 @@ namespace Knossos.NET.ViewModels
                 TaskList.Add(newTask);
             });
             return await newTask.DownloadFile(url, dest, msg, showStopButton, tooltip).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Extracts a file to a folder showing a progress bar
+        /// This task does not wait in queue
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="destFolder"></param>
+        /// <returns>true if the extraction was completed, false otherwise</returns>
+        public async Task<bool> AddFileDecompressionTask(string filePath, string destFolder, bool extractFullPath = true)
+        {
+            var newTask = new TaskItemViewModel();
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                TaskList.Add(newTask);
+            });
+
+            if(!File.Exists(filePath))
+            {
+                Log.Add(Log.LogSeverity.Error, "TaskViewModel.AddFileDecompressionTask()", "File: " + filePath + " dosent exist!");
+                return false;
+            }
+
+            if (!Directory.Exists(destFolder))
+            {
+                Log.Add(Log.LogSeverity.Error, "TaskViewModel.AddFileDecompressionTask()", "Dest folder: " + destFolder + " dosent exist!");
+                return false;
+            }
+
+            return await newTask.DecompressNebulaFile(filePath, Path.GetFileName(filePath), destFolder, null, extractFullPath).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -2607,7 +2607,7 @@ namespace Knossos.NET.ViewModels
             }
         }
 
-        public async Task<bool> DecompressNebulaFile(string filepath, string? filename, string dest, CancellationTokenSource? cancelSource = null)
+        public async Task<bool> DecompressNebulaFile(string filepath, string? filename, string dest, CancellationTokenSource? cancelSource = null, bool extractFullPath = true)
         {
             try
             {
@@ -2629,7 +2629,7 @@ namespace Knossos.NET.ViewModels
                         cancellationTokenSource = new CancellationTokenSource();
                     }
 
-                    return await KnUtils.DecompressFile(filepath, dest, cancellationTokenSource, true, deCompressionCallback);
+                    return await KnUtils.DecompressFile(filepath, dest, cancellationTokenSource, extractFullPath, deCompressionCallback);
                 }
                 else
                 {

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -10,11 +10,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
-using SharpCompress.Archives;
-using SharpCompress.Readers;
-using SharpCompress.Common;
 using System.Threading;
-using System.Net;
 using Knossos.NET.Classes;
 using VP.NET;
 using System.Text;
@@ -2620,9 +2616,10 @@ namespace Knossos.NET.ViewModels
                     TaskIsSet = true;
                     CancelButtonVisible = false;
                     Name = "Decompressing " + filename;
-                    ShowProgressText = false;
+                    ShowProgressText = true;
                     ProgressBarMin = 0;
                     ProgressCurrent = 0;
+                    ProgressBarMax = 100;
                     if (cancelSource != null)
                     {
                         cancellationTokenSource = cancelSource;
@@ -2631,105 +2628,8 @@ namespace Knossos.NET.ViewModels
                     {
                         cancellationTokenSource = new CancellationTokenSource();
                     }
-                    //tar.gz
-                    if (filename!.ToLower().Contains(".tar") || filename.ToLower().Contains(".gz"))
-                    {
-                        await Task.Run(() =>
-                        {
-                            using var fileStream = File.OpenRead(filepath);
-                            using (var reader = ReaderFactory.Open(fileStream))
-                            {
-                                try
-                                {
-                                    ProgressCurrent = 0;
-                                    ProgressBarMax = 1;
-                                    while (reader.MoveToNextEntry())
-                                    {
 
-                                        if (!reader.Entry.IsDirectory)
-                                        {
-                                            reader.WriteEntryToDirectory(dest, new ExtractionOptions() { ExtractFullPath = true, Overwrite = true, WriteSymbolicLink = (source, target) => { File.CreateSymbolicLink(source, target); } });
-                                        }
-                                        if (cancellationTokenSource!.IsCancellationRequested)
-                                        {
-                                            throw new TaskCanceledException();
-                                        }
-                                    }
-                                    IsCompleted = true;
-                                    Info = string.Empty;
-                                    ProgressCurrent = ProgressBarMax;
-                                    fileStream.Close();
-                                    return true;
-                                }
-                                catch (TaskCanceledException)
-                                {
-                                    Info = "Task Cancelled";
-                                    IsCancelled = true;
-                                    fileStream.Close();
-                                    return false;
-                                }
-                                catch (Exception ex)
-                                {
-                                    Info = "Task Failed";
-                                    IsCompleted = false;
-                                    IsCancelled = true;
-                                    CancelButtonVisible = false;
-                                    cancellationTokenSource?.Cancel();
-                                    fileStream.Close();
-                                    Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.DecompressTask()", ex);
-                                    return false;
-                                }
-                            }
-                        });
-                    }
-                    else
-                    {
-                        //zip, 7z
-                        await Task.Run(() => {
-                            using (var archive = ArchiveFactory.Open(filepath))
-                            {
-                                try
-                                {
-                                    var reader = archive.ExtractAllEntries();
-                                    ProgressBarMax = archive.Entries.Count();
-                                    while (reader.MoveToNextEntry())
-                                    {
-                                        Info = "Files: " + ProgressCurrent + "/" + ProgressBarMax;
-                                        if (!reader.Entry.IsDirectory)
-                                        {
-                                            reader.WriteEntryToDirectory(dest, new ExtractionOptions() { ExtractFullPath = true, Overwrite = true });
-                                        }
-                                        ProgressCurrent++;
-                                        if (cancellationTokenSource!.IsCancellationRequested)
-                                        {
-                                            throw new TaskCanceledException();
-                                        }
-                                    }
-                                    IsCompleted = true;
-                                    Info = string.Empty;
-                                    ProgressCurrent = ProgressBarMax;
-                                    return true;
-                                }
-                                catch (TaskCanceledException)
-                                {
-                                    Info = "Task Cancelled";
-                                    IsCancelled = true;
-                                    return false;
-                                }
-                                catch (Exception ex)
-                                {
-                                    Info = "Task Failed";
-                                    IsCompleted = false;
-                                    IsCancelled = true;
-                                    CancelButtonVisible = false;
-                                    cancellationTokenSource?.Cancel();
-                                    Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.DecompressTask()", ex);
-                                    return false;
-                                }
-                            }
-                        });
-                    }
-                    return true;
+                    return await KnUtils.DecompressFile(filepath, dest, cancellationTokenSource, true, deCompressionCallback);
                 }
                 else
                 {
@@ -4293,12 +4193,12 @@ namespace Knossos.NET.ViewModels
             });
         }
 
-        private async void sevenZipCallback(string percentage)
+        private async void sevenZipCallback(int percentage)
         {
             await Dispatcher.UIThread.InvokeAsync(() => {
                 try
                 {
-                    ProgressCurrent = int.Parse(percentage);
+                    ProgressCurrent = percentage;
                 }
                 catch { }
             });
@@ -4360,6 +4260,13 @@ namespace Knossos.NET.ViewModels
                     Info = ProgressCurrent.ToString() + " / " + ProgressBarMax.ToString() + "  -  " + filename;
                 }
                 catch { }
+            });
+        }
+
+        private void deCompressionCallback(int progress)
+        {
+            Dispatcher.UIThread.InvokeAsync(() => {
+                ProgressCurrent = progress;
             });
         }
 


### PR DESCRIPTION
Im going to make some more tests before merging

The bad news is that while doing this i discovered that RC6 autoupdate is broken in the worse way possible, it will not display the update. This is strange before i remember testing it. If the user has the "autoupdate" option enabled it will pickup the update and do it more or less correctly. But other than that it will give an "call from invalid thread" error that gets printed to log but nothing more.
RC6 cant display the update msg box, or close itself. This was caused by my changes to make macos more responsive.
Since i was working on that part of the code i took the opportunity to fix that too.

This pr adds decompression function to the SevenZip console wrapper, reworked the decompression methods, now an utility function inside KnUtils, it also adds a proper progress tracking to Sharpcompress decompression process.

There is a hidden setting to choose the decompressor, the settings json will have a "decompressor" option, with possible values being = 0, 1 or 2.
0 = Auto
Auto means knet will first try to decompress using sharpcompress and if decompression fails, it will then try with the sevenzip wrapper.
1 = only sharpcompress
2 = only sevenzip

