### PR TITLE
Change mod pkg checknotes to object

### DIFF
--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -815,7 +815,7 @@ namespace Knossos.NET.Models
         public ModFilelist[]? filelist { get; set; } = new ModFilelist[0];
         public List<ModExecutable>? executables { get; set; } = new List<ModExecutable>();// optional
         [JsonPropertyName("check_notes")]
-        public string? checkNotes { get; set; }
+        public object? checkNotes { get; set; }
 
         /* Knet Only */
         [JsonIgnore]


### PR DESCRIPTION
We are not using this value currently, but it seems that old knossos can write both "" and [] as default values to it and [] is not valid for a string type, so it is changed to a generic object so the json deserializer can handle it.