### PR TITLE
Settings Tab Overhaul

### DIFF
--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -37,8 +37,8 @@
 							<Button Margin="5,0,0,0" Grid.Column="2" Classes="Secondary" Command="{Binding BrowseFolderCommand}">Browse</Button>
 						</Grid>
 						<!-- Lib Info -->
-						<Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto, Auto" Margin="5">
-							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Statistics</TextBlock>
+						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="5">
+							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Stats</TextBlock>
 							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="10,2,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold" ToolTip.Tip="How many standalone games and modifications (collectively known as mods) are installed in your Knossos library.">Mods:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
@@ -95,7 +95,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Bandwidth limit -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Bandwidth Limit</TextBlock>
 							<ComboBox SelectedIndex="{Binding MaxDownloadSpeedIndex}" ToolTip.Tip="Bandwidth limiter (Per Individual Download)" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Unlimited</ComboBoxItem>
@@ -113,7 +113,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Mirror Blacklist -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Mirror Blacklist</TextBlock>
 							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
 								<CheckBox Margin="0,0,0,0" IsChecked="{Binding BlDlNebula}">dl.fsnebula.org</CheckBox>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -121,7 +121,7 @@
 						<!-- Log File -->
 						<WrapPanel Margin="5,10,0,0">
                             <Label Margin="0,5,0,0" Width="210">Enable Logging</Label> 
-							<CheckBox IsChecked="{Binding EnableLogFile}"></CheckBox>
+							<CheckBox Margin="1,0,0,0" IsChecked="{Binding EnableLogFile}"></CheckBox>
 						</WrapPanel>
 						<WrapPanel Margin="5,10,0,0">
                             <Label Margin="0,5,0,0" Width="200">Logging Level</Label> 
@@ -384,7 +384,7 @@
 
 						<WrapPanel Margin="0,5,0,0">	
 							<Label Margin="5,5,0,0" IsVisible="{Binding IsAVX}" Width="200">Force SSE2</Label> 
-							<CheckBox Margin="10,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
+							<CheckBox Margin="12,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
 						</WrapPanel>
 						<!-- GLOBAL CMDLINE -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -17,7 +17,7 @@
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
 					<Button Command="{Binding QuickSetupCommand}" FontSize="22" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
-					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="480,0,0,0" Classes="Cancel">Reset</Button>
+					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="500,0,0,0" Classes="Cancel">Reset</Button>
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
 					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="10,0,0,0">Save</Button>
 				</WrapPanel>
@@ -39,7 +39,7 @@
 						<!-- Lib Info -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="6,10,0,0">
 							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Stats</TextBlock>
-							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="10,2,0,0">
+							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="8,2,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold" ToolTip.Tip="How many standalone games and modifications (collectively known as mods) are installed in your Knossos library.">Mods:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
 								<Label Margin="40,5,0,0" FontWeight="Bold">Builds:</Label>
@@ -111,11 +111,11 @@
 						</Grid>
 						<!-- Mirror Blacklist -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Mirror Blacklist</TextBlock>
-							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
-								<CheckBox Margin="0,0,0,0" IsChecked="{Binding BlDlNebula}">dl.fsnebula.org</CheckBox>
-								<CheckBox Margin="25,0,0,0" IsChecked="{Binding BlCfNebula}">cf.fsnebula.org</CheckBox>
-								<CheckBox Margin="25,0,0,0" IsChecked="{Binding BlAigaion}">aigaion.feralhosting.com</CheckBox>
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Mirrors</TextBlock>
+							<WrapPanel Grid.Column="1" Margin="8,0,0,0">
+								<CheckBox Margin="0,0,0,0" IsChecked="{Binding !BlDlNebula}">dl.fsnebula.org</CheckBox>
+								<CheckBox Margin="25,0,0,0" IsChecked="{Binding !BlCfNebula}">cf.fsnebula.org</CheckBox>
+								<CheckBox Margin="25,0,0,0" IsChecked="{Binding !BlAigaion}">aigaion.feralhosting.com</CheckBox>
 							</WrapPanel>
 						</Grid>
 						<!-- Log File -->
@@ -229,7 +229,7 @@
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
 							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}" Width="200"></CheckBox>
 						</WrapPanel>
-            			<Button Margin="4,4,0,5" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Raising FPS Tips" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
+            			<Button Margin="4,4,0,5" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="I need more FPS!" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 					</StackPanel>
 				</Border>
 

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -49,7 +49,7 @@
 						<WrapPanel Margin="5,10,0,0">	
 							<Label Margin="0,5,0,0" Width="200">Freespace 2 Retail</Label>
 							<CheckBox Margin="10,0,0,0" IsVisible="{Binding Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
-							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Margin="10,0,0,0">Retail Freespace 2 Installer</Button>
+							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Margin="10,0,0,0">Installer</Button>
 						</WrapPanel>
 						<WrapPanel Margin="5,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
@@ -75,17 +75,17 @@
 							<CheckBox Margin="5,0,0,0" IsChecked="{Binding DeleteUploadedFiles}" ToolTip.Tip="During the upload of a mod version, generates files are saved on a '{modfolder}\kn_upload' folder, if this option is enabled these unnecessary files files will be deleted after a successfull upload. You con choose to disable this option if you need to take a closer look or debug a problem."></CheckBox>
 						</WrapPanel>
 						<!-- Remove Dependencies-->
-						<WrapPanel Margin="5,5,0,0">
-							<Button Command="{Binding CleanupLibraryCommand}" Background="Black" Margin="210,0,0,0">Remove Unused Dependencies</Button>
+						<WrapPanel Margin="5,10,0,0">
+							<Button Command="{Binding CleanupLibraryCommand}">Remove Unused Dependencies</Button>
 						</WrapPanel>
 						<!-- Image Cache -->
-						<WrapPanel Margin="5,5,0,0">
+						<WrapPanel Margin="5,10,0,0">
 							<Label VerticalAlignment="Center" Width="200" Content="Image Cache Size"/>
 							<Label Margin="10,0,0,0" VerticalAlignment="Center" Foreground="Yellow" Content="{Binding ImgCacheSize}"/>
 							<Button Command="{Binding ClearImageCache}" Grid.Column="2" Classes="Secondary">Clear Cache</Button>
 						</WrapPanel>
 						<!-- SubTasks -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Concurrent Subtasks</TextBlock>
 							<ComboBox SelectedIndex="{Binding MaxConcurrentSubtasks}" ToolTip.Tip="All tasks are done in order, but some tasks like install tasks creates multiple subtasks to download files, etc. This setting controls how many of them can run simultaneously." Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="1">1</ComboBoxItem>
@@ -95,7 +95,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Bandwidth limit -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Bandwidth Limit</TextBlock>
 							<ComboBox SelectedIndex="{Binding MaxDownloadSpeedIndex}" ToolTip.Tip="Bandwidth limiter (Per Individual Download)" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Unlimited</ComboBoxItem>
@@ -113,7 +113,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Mirror Blacklist -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Mirror Blacklist</TextBlock>
 							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
 								<CheckBox Margin="0,0,0,0" IsChecked="{Binding BlDlNebula}">dl.fsnebula.org</CheckBox>
@@ -122,10 +122,12 @@
 							</WrapPanel>
 						</Grid>
 						<!-- Log File -->
-						<WrapPanel Margin="5">
-							<CheckBox Grid.Column="0" IsChecked="{Binding EnableLogFile}" Width="200">Enable Log File</CheckBox>
+						<WrapPanel Margin="5,10,0,0">
+                            <Label Margin="0,5,0,0" Width="210">Enable Logging</Label> 
+							<CheckBox IsChecked="{Binding EnableLogFile}"></CheckBox>
 						</WrapPanel>
 						<WrapPanel Margin="5">
+                            <Label Margin="0,5,0,0" Width="210">Logging Level</Label> 
 							<ComboBox SelectedIndex="{Binding LogLevel}" IsEnabled="{Binding EnableLogFile}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Information</ComboBoxItem>
 								<ComboBoxItem Tag="1">Warning</ComboBoxItem>
@@ -365,7 +367,7 @@
 							<NumericUpDown Value="{Binding MultiPort}" Grid.Column="1" Width="150"></NumericUpDown>
 						</Grid>
 						<!-- Sys Info -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,5,0,0">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="10,5,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Build Types </TextBlock>
 							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -17,7 +17,7 @@
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
 					<Button Command="{Binding QuickSetupCommand}" FontSize="22" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
-					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="450,0,0,0">Save</Button>
+					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="480,0,0,0">Save</Button>
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
 					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="10,0,0,0" Classes="Cancel">Reset</Button>
 				</WrapPanel>
@@ -27,7 +27,7 @@
 		<ScrollViewer Grid.Row="1">
 			<StackPanel>
 				<!--KNOSSOS SETTINGS-->
-				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Knossos Settings</Label>
+				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Knossos</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Base Path -->
@@ -60,24 +60,10 @@
 						<Button Command="{Binding CleanupLibraryCommand}" Background="Black" Margin="15,0,0,0">Remove Unused Dependencies</Button>
 						</WrapPanel>
 						<!--AutoUpdates -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto,Auto" Margin="210,3,0,0" >
+						<Grid ColumnDefinitions="Auto,Auto,Auto,Auto" Margin="210,5,0,0" >
 							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="1" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for available updates at the start.">Check for updates at startup</CheckBox>
 							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="2" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input.">Auto Update</CheckBox>
 							<CheckBox Margin="5,0,0,0" Grid.Column="3" IsChecked="{Binding DeleteUploadedFiles}" ToolTip.Tip="During the upload of a mod version, generates files are saved on a '{modfolder}\kn_upload' folder, if this option is enabled these unnecessary files files will be deleted after a successfull upload. You con choose to disable this option if you need to take a closer look or debug a problem.">Delete Uploaded Mod Files</CheckBox>
-						</Grid>
-						<!-- Sys Info -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5,20,0,0">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" FontWeight="Heavy" Width="200">System </TextBlock>
-							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
-								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
-								<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
-								<Label Margin="30,5,0,0" FontWeight="Bold">CPU Arch:</Label>
-								<TextBlock Margin="5,8,0,0" Text="{Binding CpuArch}"></TextBlock>
-								<CheckBox Margin="20,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
-								<Label Margin="0,5,0,0" IsVisible="{Binding IsAVX}">Force SSE2</Label> 
-								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX}">AVX</CheckBox>
-								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX2}">AVX2</CheckBox>
-							</WrapPanel>
 						</Grid>
 						<!-- Image Cache -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="0,5,0,0">
@@ -123,18 +109,20 @@
 							</WrapPanel>
 						</Grid>
 						<!-- Log File -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<WrapPanel Margin="5">
 							<CheckBox Grid.Column="0" IsChecked="{Binding EnableLogFile}" Width="200">Enable Log File</CheckBox>
+						</WrapPanel>
+						<WrapPanel Margin="5">
 							<ComboBox SelectedIndex="{Binding LogLevel}" IsEnabled="{Binding EnableLogFile}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Information</ComboBoxItem>
 								<ComboBoxItem Tag="1">Warning</ComboBoxItem>
 								<ComboBoxItem Tag="2">Error</ComboBoxItem>
 							</ComboBox>
-						</Grid>
+						</WrapPanel>
 					</StackPanel>
 				</Border>
 				<!--VIDEO SETTINGS-->
-				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Video Settings</Label>
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">Video</Label>
 				<Border BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Resolution -->
@@ -156,7 +144,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Window -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label VerticalAlignment="Center" Grid.Column="0" Width="200">Window Mode</Label>
 							<ComboBox SelectedIndex="{Binding WindowMode}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Windowed</ComboBoxItem>
@@ -165,7 +153,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Shadows -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label VerticalAlignment="Center" Grid.Column="0" Width="200">Shadows</Label>
 							<ComboBox ToolTip.Tip="High performance impact, especially at Ultra" Tag="-shadow_quality" SelectedIndex="{Binding ShadowQualitySelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
@@ -176,7 +164,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- AA Filter -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Post-processing Anti-Aliasing</Label>
 							<ComboBox Tag="-aa_preset" SelectedIndex="{Binding AaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
@@ -190,7 +178,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- SMAA Filter -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 						<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample Anti-Aliasing</Label>
 						<ComboBox ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 							<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
@@ -199,36 +187,42 @@
 						</ComboBox>
 						</Grid>
 						<!-- Enable deferred lighting -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<Label Margin="5,0,0,0" Width="200">Enable Deferred Lighting</Label> 
-							<CheckBox Tag="-no_deferred" Grid.Column="0" IsChecked="{Binding EnableDeferredLighting}" Width="200"></CheckBox>
-						</Grid>
+						<WrapPanel>
+							<Label Margin="5,5,0,0" Width="210">Deferred Lighting</Label> 
+							<CheckBox Tag="-no_deferred" IsChecked="{Binding EnableDeferredLighting}"></CheckBox>
+						</WrapPanel>
 						<!-- Enable soft particles -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-						<CheckBox Tag="-soft_particles" Grid.Column="0" IsChecked="{Binding EnableSoftParticles}" Width="200">Enable Soft Particles</CheckBox>
-						</Grid>
-						<!-- VSYNC -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-no_vsync" Grid.Column="0" IsChecked="{Binding Vsync}" Width="200">Enable VSync</CheckBox>
-						</Grid>
+						<WrapPanel>
+							<Label Margin="5,5,0,0" Width="210">Soft Particles</Label> 
+							<CheckBox Tag="-soft_particles" IsChecked="{Binding EnableSoftParticles}"></CheckBox>
+						</WrapPanel>
 						<!-- Disable Post Processing -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-no_post_process" Grid.Column="0" IsChecked="{Binding PostProcess}" Width="200">Enable Post Processing</CheckBox>
-						</Grid>
+						<WrapPanel>
+							<Label Margin="5,5,0,0" Width="210">Post Processing</Label> 
+							<CheckBox Tag="-no_post_process" IsChecked="{Binding PostProcess}"></CheckBox>
+						</WrapPanel>
+
+						<!-- VSYNC -->
+						<WrapPanel>
+							<Label Margin="5,5,0,0" Width="210">VSync</Label> 
+							<CheckBox Tag="-no_vsync" IsChecked="{Binding !Vsync}"></CheckBox>
+						</WrapPanel>
 						<!-- FPS Cap -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-no_fps_capping" Grid.Column="0" IsChecked="{Binding NoFpsCapping}" Width="200">Disable 120 FPS Limit</CheckBox>
-						</Grid>
+						<WrapPanel>
+							<Label Margin="5,5,0,0" Width="210">Limit to 120 FPS</Label> 
+							<CheckBox Tag="-no_fps_capping" IsChecked="{Binding !NoFpsCapping}"></CheckBox>
+						</WrapPanel>
 						<!-- Show FPS -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-fps" Grid.Column="0" IsChecked="{Binding ShowFps}" Width="200">Display FPS</CheckBox>
-						</Grid>
-            			<Button Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Slow in-game performance?" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
+						<WrapPanel>
+							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
+							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}" Width="200">Display FPS</CheckBox>
+						</WrapPanel>
+            			<Button Margin="3,4,0,5" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Slow in-game performance?" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 					</StackPanel>
 				</Border>
 
 				<!--Audio SETTINGS-->
-				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Audio Settings</Label>
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">Audio</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Playback -->
@@ -293,7 +287,7 @@
 				</Border>
 
 				<!--INPUT SETTINGS-->
-				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Input Settings</Label>
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">Input</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
             <?ignore
@@ -338,16 +332,10 @@
 					</StackPanel>
 				</Border>
 		
-				<!--MOD SETTINGS-->
-				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">FSO Global Settings</Label>
+				<!--FSO ENGINE SETTINGS-->
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">FSO Engine Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<!-- GLOBAL CMDLINE -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<Label ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Global Cmdline</Label>
-							<TextBox Text="{Binding GlobalCmd}" ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="1" Width="500"></TextBox>
-							<Button Command="{Binding GlobalCmdHelp}" Classes="Secondary" Grid.Column="2" Margin="10,0,0,0">?</Button>
-						</Grid>
 						<!-- FS2 Lang -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="3,0,0,0" Width="200">FS2 Language</TextBlock>
@@ -362,6 +350,26 @@
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label ToolTip.Tip="Network port used by multiplayer. Default is 7808." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Multiplayer Port</Label>
 							<NumericUpDown Value="{Binding MultiPort}" Grid.Column="1" Width="150"></NumericUpDown>
+						</Grid>
+						<!-- Sys Info -->
+						<Grid ColumnDefinitions="Auto,Auto" Margin="5,20,0,0">
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" FontWeight="Heavy" Width="200">System </TextBlock>
+							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
+								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
+								<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
+								<Label Margin="30,5,0,0" FontWeight="Bold">CPU Arch:</Label>
+								<TextBlock Margin="5,8,0,0" Text="{Binding CpuArch}"></TextBlock>
+								<CheckBox Margin="20,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
+								<Label Margin="0,5,0,0" IsVisible="{Binding IsAVX}">Force SSE2</Label> 
+								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX}">AVX</CheckBox>
+								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX2}">AVX2</CheckBox>
+							</WrapPanel>
+						</Grid>
+						<!-- GLOBAL CMDLINE -->
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
+							<Label ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Global Command Line</Label>
+							<TextBox Text="{Binding GlobalCmd}" ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="1" Width="500"></TextBox>
+							<Button Command="{Binding GlobalCmdHelp}" Classes="Secondary" Grid.Column="2" Margin="10,0,0,0">?</Button>
 						</Grid>
 					</StackPanel>
 				</Border>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -47,9 +47,9 @@
 							</WrapPanel>
 						</Grid>
 						<WrapPanel Margin="5,10,0,0">	
-							<Label Margin="5,0,0,0">Freespace 2 Retail</Label>
-							<CheckBox Margin="210,0,0,0" IsVisible="{Binding Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
-							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" Background="Black" Margin="210,0,0,0">Retail Freespace 2 Installer</Button>
+							<Label Width="200">Freespace 2 Retail</Label>
+							<CheckBox Margin="10,0,0,0" IsVisible="{Binding !Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
+							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" Background="Black" Margin="10,0,0,0">Retail Freespace 2 Installer</Button>
 						</WrapPanel>
 						<WrapPanel Margin="5,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
@@ -63,15 +63,15 @@
 						</WrapPanel>
 						<!-- AutoUpdates -->
                         <WrapPanel Margin="5,10,0,0">
-                            <Label Margin="5,5,0,0" Width="210">Check for updates at startup</Label> 
+                            <Label Margin="0,5,0,0" Width="210">Check for updates at startup</Label> 
 							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for available updates at the start."></CheckBox>
 						</WrapPanel>
                         <WrapPanel Margin="5,10,0,0">
-                            <Label Margin="5,5,0,0" Width="210">Auto Update</Label> 
-							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input.">Auto Update</CheckBox>
+                            <Label Margin="0,5,0,0" Width="210">Auto Update</Label> 
+							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input."></CheckBox>
 						</WrapPanel>
                         <WrapPanel Margin="5,10,0,0">
-                            <Label Margin="5,5,0,0" Width="210">Delete Uploaded Mod Files</Label> 
+                            <Label Margin="0,5,0,0" Width="210">Delete Uploaded Mod Files</Label> 
 							<CheckBox Margin="5,0,0,0" IsChecked="{Binding DeleteUploadedFiles}" ToolTip.Tip="During the upload of a mod version, generates files are saved on a '{modfolder}\kn_upload' folder, if this option is enabled these unnecessary files files will be deleted after a successfull upload. You con choose to disable this option if you need to take a closer look or debug a problem."></CheckBox>
 						</WrapPanel>
 						<!-- Remove Dependencies-->

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -228,7 +228,7 @@
 						<!-- Show FPS -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
-							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}" Width="200">Display FPS</CheckBox>
+							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}" Width="200"></CheckBox>
 						</WrapPanel>
             			<Button Margin="4,4,0,5" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Raising FPS Tips" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 					</StackPanel>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -21,7 +21,7 @@
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
 					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="10,0,0,0" Classes="Cancel">Reset</Button>
 				</WrapPanel>
-				<TextBlock Margin="10,15,0,3" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please close this tab before playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
+				<TextBlock Margin="10,15,3,3" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please close this tab before playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
 			</StackPanel>
 		</Border>
 		<ScrollViewer Grid.Row="1">
@@ -32,45 +32,58 @@
 					<StackPanel Margin="5">
 						<!-- Base Path -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" FontWeight="Heavy" Width="200">Library </TextBlock>
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Library Folder </TextBlock>
 							<TextBox Text="{Binding BasePath}" Margin="10,0,0,0" Grid.Column="1" IsReadOnly="True" Width="500"></TextBox>
 							<Button Margin="5,0,0,0" Grid.Column="2" Classes="Secondary" Command="{Binding BrowseFolderCommand}">Browse</Button>
 						</Grid>
 						<!-- Lib Info -->
 						<Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto, Auto" Margin="5">
-							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200"></TextBlock>
+							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Statistics</TextBlock>
 							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="10,2,0,0">
-								<Label Margin="0,5,0,0" FontWeight="Bold">Mods:</Label>
+								<Label Margin="0,5,0,0" FontWeight="Bold" ToolTip.Tip="How many standalone games and modifications (collectively known as mods) are installed in your Knossos library.">Mods:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
 								<Label Margin="40,5,0,0" FontWeight="Bold">Builds:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfBuilds}"></TextBlock>
-								<CheckBox Margin="40,0,0,0" IsEnabled="False" IsChecked="{Binding Fs2RootPack}">Retail Freespace 2 Installed</CheckBox>
-								<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Background="Black" Margin="10,0,0,0">Installer</Button>
 							</WrapPanel>
 						</Grid>
-						<WrapPanel Grid.Column="1" Margin="220,5,0,0">
-						<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="120">Mod Compression</TextBlock>
-						<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space. 'Manual' means you will have to compress or decompress the files manually from mod settings. 'Always' means Knossos will compress all mods during install and 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum. This only works if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
-							<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
-							<ComboBoxItem Tag="1">Manual</ComboBoxItem>
-							<ComboBoxItem Tag="2">Always</ComboBoxItem>
-							<ComboBoxItem Tag="3">Mod Support</ComboBoxItem>
-						</ComboBox>
-						<NumericUpDown IsEnabled="{Binding ModCompression}" Margin="10,0,0,0" Width="120" Grid.Column="2" Minimum="1" Maximum="8" Value="{Binding CompressionMaxParallelism}" ToolTip.Tip="Max number of parallel compression tasks"></NumericUpDown>
-						<Button Command="{Binding CleanupLibraryCommand}" Background="Black" Margin="15,0,0,0">Remove Unused Dependencies</Button>
+						<WrapPanel Margin="5,10,0,0">	
+							<Label Margin="5,0,0,0">Freespace 2 Retail</Label>
+							<CheckBox Margin="210,0,0,0" IsVisible="{Binding Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
+							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" Background="Black" Margin="210,0,0,0">Retail Freespace 2 Installer</Button>
 						</WrapPanel>
-						<!--AutoUpdates -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto,Auto" Margin="210,5,0,0" >
-							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="1" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for available updates at the start.">Check for updates at startup</CheckBox>
-							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="2" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input.">Auto Update</CheckBox>
-							<CheckBox Margin="5,0,0,0" Grid.Column="3" IsChecked="{Binding DeleteUploadedFiles}" ToolTip.Tip="During the upload of a mod version, generates files are saved on a '{modfolder}\kn_upload' folder, if this option is enabled these unnecessary files files will be deleted after a successfull upload. You con choose to disable this option if you need to take a closer look or debug a problem.">Delete Uploaded Mod Files</CheckBox>
-						</Grid>
+						<WrapPanel Margin="5,10,0,0">
+							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
+							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space. 'Manual' means you will have to compress or decompress the files manually from mod settings. 'Always' means Knossos will compress all mods during install and 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum. This only works if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
+								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
+								<ComboBoxItem Tag="1">Manual</ComboBoxItem>
+								<ComboBoxItem Tag="2">Always</ComboBoxItem>
+								<ComboBoxItem Tag="3">Mod Support</ComboBoxItem>
+							</ComboBox>
+							<NumericUpDown IsEnabled="{Binding ModCompression}" Margin="10,0,0,0" Width="120" Grid.Column="2" Minimum="1" Maximum="8" Value="{Binding CompressionMaxParallelism}" ToolTip.Tip="Max number of parallel compression tasks"></NumericUpDown>
+						</WrapPanel>
+						<!-- AutoUpdates -->
+                        <WrapPanel Margin="5,10,0,0">
+                            <Label Margin="5,5,0,0" Width="210">Check for updates at startup</Label> 
+							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for available updates at the start."></CheckBox>
+						</WrapPanel>
+                        <WrapPanel Margin="5,10,0,0">
+                            <Label Margin="5,5,0,0" Width="210">Auto Update</Label> 
+							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input.">Auto Update</CheckBox>
+						</WrapPanel>
+                        <WrapPanel Margin="5,10,0,0">
+                            <Label Margin="5,5,0,0" Width="210">Delete Uploaded Mod Files</Label> 
+							<CheckBox Margin="5,0,0,0" IsChecked="{Binding DeleteUploadedFiles}" ToolTip.Tip="During the upload of a mod version, generates files are saved on a '{modfolder}\kn_upload' folder, if this option is enabled these unnecessary files files will be deleted after a successfull upload. You con choose to disable this option if you need to take a closer look or debug a problem."></CheckBox>
+						</WrapPanel>
+						<!-- Remove Dependencies-->
+						<WrapPanel Margin="5,5,0,0">
+							<Button Command="{Binding CleanupLibraryCommand}" Background="Black" Margin="210,0,0,0">Remove Unused Dependencies</Button>
+						</WrapPanel>
 						<!-- Image Cache -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="0,5,0,0">
-							<Label Grid.Column="0" VerticalAlignment="Center" Width="212" Content="Image Cache Size"/>
-							<Label Grid.Column="1" VerticalAlignment="Center" Foreground="Yellow" Content="{Binding ImgCacheSize}"/>
+						<WrapPanel Margin="5,5,0,0">
+							<Label VerticalAlignment="Center" Width="200" Content="Image Cache Size"/>
+							<Label Margin="10,0,0,0" VerticalAlignment="Center" Foreground="Yellow" Content="{Binding ImgCacheSize}"/>
 							<Button Command="{Binding ClearImageCache}" Grid.Column="2" Classes="Secondary">Clear Cache</Button>
-						</Grid>
+						</WrapPanel>
 						<!-- SubTasks -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Concurrent Subtasks</TextBlock>
@@ -123,7 +136,7 @@
 				</Border>
 				<!--VIDEO SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">Video</Label>
-				<Border BorderBrush="Black" BorderThickness="5" CornerRadius="2">
+				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Resolution -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
@@ -145,7 +158,7 @@
 						</Grid>
 						<!-- Window -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<Label VerticalAlignment="Center" Grid.Column="0" Width="200">Window Mode</Label>
+							<Label VerticalAlignment="Center" Grid.Column="0" Width="200">Windowed Mode</Label>
 							<ComboBox SelectedIndex="{Binding WindowMode}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Windowed</ComboBoxItem>
 								<ComboBoxItem Tag="1">Borderless</ComboBoxItem>
@@ -217,7 +230,7 @@
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
 							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}" Width="200">Display FPS</CheckBox>
 						</WrapPanel>
-            			<Button Margin="3,4,0,5" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Slow in-game performance?" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
+            			<Button Margin="4,4,0,5" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Raising FPS Tips" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 					</StackPanel>
 				</Border>
 
@@ -334,7 +347,7 @@
 		
 				<!--FSO ENGINE SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">FSO Engine Settings</Label>
-				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
+				<Border Margin="0,5,0,5" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- FS2 Lang -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
@@ -352,8 +365,8 @@
 							<NumericUpDown Value="{Binding MultiPort}" Grid.Column="1" Width="150"></NumericUpDown>
 						</Grid>
 						<!-- Sys Info -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5,20,0,0">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" FontWeight="Heavy" Width="200">System </TextBlock>
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,5,0,0">
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Build Types </TextBlock>
 							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
@@ -369,7 +382,7 @@
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Global Command Line</Label>
 							<TextBox Text="{Binding GlobalCmd}" ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="1" Width="500"></TextBox>
-							<Button Command="{Binding GlobalCmdHelp}" Classes="Secondary" Grid.Column="2" Margin="10,0,0,0">?</Button>
+							<Button Command="{Binding GlobalCmdHelp}" Classes="Secondary" Grid.Column="2" Margin="10,0,0,0">Command Line Wiki Page</Button>
 						</Grid>
 					</StackPanel>
 				</Border>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -15,64 +15,72 @@
 	<Grid RowDefinitions="Auto,*">
 		<Border Margin="0,5,0,5" Grid.Row="0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 			<StackPanel>
-				<Grid Margin="5" ColumnDefinitions="*,*,Auto" >
-					<Button Grid.Row="0" Command="{Binding SaveCommand}" Grid.Column="2" Classes="Accept">SAVE</Button>
-					<Button Grid.Row="0" Command="{Binding ReloadFlagData}" Classes="Option" Grid.Column="1" Margin="5,0,0,0">Reload Data</Button>
-					<Button Grid.Row="0" Command="{Binding ResetCommand}" Grid.Column="0" Classes="Cancel">RESET</Button>
-				</Grid>
-				<TextBlock TextWrapping="Wrap" FontSize="13" VerticalAlignment="Center" HorizontalAlignment="Center">It is not recommended that you leave this tab open while playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
+				<WrapPanel Margin="0,10,0,0">
+					<Button Command="{Binding QuickSetupCommand}" FontSize="22" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
+					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="340,0,0,0">Save</Button>
+					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
+					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="10,0,0,0" Classes="Cancel">Reset</Button>
+				</WrapPanel>
+				<TextBlock Margin="10,15,0,0" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please exit this tab open before playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
 			</StackPanel>
 		</Border>
 		<ScrollViewer Grid.Row="1">
 			<StackPanel>
 				<!--KNOSSOS SETTINGS-->
+				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Knossos Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold" FontSize="18">Knossos Settings</Label>
 						<!-- Base Path -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="185">Library Path</TextBlock>
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" FontWeight="Heavy" Width="200">Library </TextBlock>
 							<TextBox Text="{Binding BasePath}" Margin="10,0,0,0" Grid.Column="1" IsReadOnly="True" Width="500"></TextBox>
 							<Button Grid.Column="2" Classes="Secondary" Command="{Binding BrowseFolderCommand}">Browse</Button>
 						</Grid>
 						<!-- Lib Info -->
 						<Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto, Auto" Margin="5">
-							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Library Info</TextBlock>
-							<WrapPanel Grid.Column="1" Grid.Row="0" Margin="10,0,0,0">
+							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200"></TextBlock>
+							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="10,2,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold">Mods:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
 								<Label Margin="40,5,0,0" FontWeight="Bold">Builds:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfBuilds}"></TextBlock>
 								<CheckBox Margin="40,0,0,0" IsEnabled="False" IsChecked="{Binding Fs2RootPack}">FS2 Root Pack</CheckBox>
-
-							</WrapPanel>
-							<WrapPanel Grid.Column="1" Grid.Row="1">
-								<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Margin="10,0,0,0">FS2 Retail Installer</Button>
-								<Button Command="{Binding QuickSetupCommand}" Classes="Secondary" Margin="5,0,0,0">Quick Setup Guide</Button>
-								<Button Command="{Binding CleanupLibraryCommand}" Classes="Tertiary" Margin="5,0,0,0">Remove Unused Dependencies</Button>
+								<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Background="Black" Margin="10,0,0,0">FS2 Retail Installer</Button>
 							</WrapPanel>
 						</Grid>
-						<!-- Sys Info -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">System Info</TextBlock>
-							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
-								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
-								<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
-								<Label Margin="50,5,0,0" FontWeight="Bold">CPU Arch:</Label>
-								<TextBlock Margin="5,8,0,0" Text="{Binding CpuArch}"></TextBlock>
-								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX}">AVX</CheckBox>
-								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX2}">AVX2</CheckBox>
-							</WrapPanel>
-						</Grid>
-						<!-- Force SSE2 and AutoUpdates -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto,Auto" Margin="5" >
-							<CheckBox IsVisible="{Binding IsAVX}" Grid.Column="0" ToolTip.Tip="If available, Knossos will force to run SSE2 FSO builds instead of AVX ones." IsChecked="{Binding ForceSSE2}" Width="200">Force SSE2 Builds</CheckBox>
+						<WrapPanel Grid.Column="1" Margin="220,5,0,0">
+						<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="120">Mod Compression</TextBlock>
+						<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space. 'Manual' means you will have to compress or decompress the files manually from mod settings. 'Always' means Knossos will compress all mods during install and 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum. This only works if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
+							<ComboBoxItem Tag="1">Manual</ComboBoxItem>
+							<ComboBoxItem Tag="2">Always</ComboBoxItem>
+							<ComboBoxItem Tag="3">Mod Support</ComboBoxItem>
+						</ComboBox>
+						<NumericUpDown IsEnabled="{Binding ModCompression}" Margin="10,0,0,0" Width="120" Grid.Column="2" Minimum="1" Maximum="8" Value="{Binding CompressionMaxParallelism}" ToolTip.Tip="Max number of parallel compression tasks"></NumericUpDown>
+						<Button Command="{Binding CleanupLibraryCommand}" Background="Black" Margin="15,0,0,0">Remove Unused Dependencies</Button>
+						</WrapPanel>
+						<!--AutoUpdates -->
+						<Grid ColumnDefinitions="Auto,Auto,Auto,Auto" Margin="210,3,0,0" >
 							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="1" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for available updates at the start.">Check for updates at startup</CheckBox>
 							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" Grid.Column="2" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input.">Auto Update</CheckBox>
 							<CheckBox Margin="5,0,0,0" Grid.Column="3" IsChecked="{Binding DeleteUploadedFiles}" ToolTip.Tip="During the upload of a mod version, generates files are saved on a '{modfolder}\kn_upload' folder, if this option is enabled these unnecessary files files will be deleted after a successfull upload. You con choose to disable this option if you need to take a closer look or debug a problem.">Delete Uploaded Mod Files</CheckBox>
 						</Grid>
+						<!-- Sys Info -->
+						<Grid ColumnDefinitions="Auto,Auto" Margin="5,20,0,0">
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" FontWeight="Heavy" Width="200">System </TextBlock>
+							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
+								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
+								<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
+								<Label Margin="30,5,0,0" FontWeight="Bold">CPU Arch:</Label>
+								<TextBlock Margin="5,8,0,0" Text="{Binding CpuArch}"></TextBlock>
+								<CheckBox Margin="20,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
+								<Label Margin="0,5,0,0" IsVisible="{Binding IsAVX}">Force SSE2</Label> 
+								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX}">AVX</CheckBox>
+								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX2}">AVX2</CheckBox>
+							</WrapPanel>
+						</Grid>
 						<!-- Image Cache -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="0,5,0,0">
 							<Label Grid.Column="0" VerticalAlignment="Center" Width="212" Content="Image Cache Size"/>
 							<Label Grid.Column="1" VerticalAlignment="Center" Foreground="Yellow" Content="{Binding ImgCacheSize}"/>
 							<Button Command="{Binding ClearImageCache}" Grid.Column="2" Classes="Secondary">Clear Cache</Button>
@@ -86,17 +94,6 @@
 								<ComboBoxItem Tag="3">3</ComboBoxItem>
 								<ComboBoxItem Tag="4">4</ComboBoxItem>
 							</ComboBox>
-						</Grid>
-						<!-- Compression -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
-							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space. 'Manual' means you will have to compress or decompress the files manually from mod settings. 'Always' means Knossos will compress all mods during install and 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum. This only works if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
-								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
-								<ComboBoxItem Tag="1">Manual</ComboBoxItem>
-								<ComboBoxItem Tag="2">Always</ComboBoxItem>
-								<ComboBoxItem Tag="3">Mod Support</ComboBoxItem>
-							</ComboBox>
-							<NumericUpDown IsEnabled="{Binding ModCompression}" Margin="10,0,0,0" Width="120" Grid.Column="2" Minimum="1" Maximum="8" Value="{Binding CompressionMaxParallelism}" ToolTip.Tip="Max number of parallel compression tasks"></NumericUpDown>
 						</Grid>
 						<!-- Bandwidth limit -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
@@ -137,9 +134,9 @@
 					</StackPanel>
 				</Border>
 				<!--VIDEO SETTINGS-->
+				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Video Settings</Label>
 				<Border BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold" FontSize="18">Video Settings</Label>
 						<!-- Resolution -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Display Resolution</TextBlock>
@@ -230,9 +227,9 @@
 				</Border>
 
 				<!--Audio SETTINGS-->
+				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Audio Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold" FontSize="18">Audio Settings</Label>
 						<!-- Playback -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Playback Devices</TextBlock>
@@ -289,15 +286,15 @@
 						</Grid>
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Speech Volume</TextBlock>
-							<Slider Grid.Column="1" Width="500" Value="{Binding TtsVolume}" Maximum="100" Minimum="0"></Slider>
+							<Slider Grid.Column="1" Width="500" Margin="10,0,0,0" Value="{Binding TtsVolume}" Maximum="100" Minimum="0"></Slider>
 						</Grid>
 					</StackPanel>
 				</Border>
 
 				<!--INPUT SETTINGS-->
+				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Input Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold" FontSize="18">Input Settings</Label>
             <?ignore
 							<!--Mouse and Joystick settings are saved in the pilot file, these values only edit the new in-game options which are not used-->
 							<Grid ColumnDefinitions="Auto,Auto" Margin="5">

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -30,16 +30,6 @@
 				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Knossos</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<!-- FS2 Lang -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="3,0,0,0" Width="200">In-game Language</TextBlock>
-							<ComboBox SelectedIndex="{Binding Fs2LangSelectedIndex}" Grid.Column="1" Width="200" Margin="7,0,0,0">
-								<ComboBoxItem>English</ComboBoxItem>
-								<ComboBoxItem>German</ComboBoxItem>
-								<ComboBoxItem>French</ComboBoxItem>
-								<ComboBoxItem>Polish</ComboBoxItem>
-							</ComboBox>
-						</Grid>
 						<!-- Base Path -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Library Folder </TextBlock>
@@ -135,7 +125,7 @@
 						</WrapPanel>
 						<WrapPanel Margin="5,10,0,0">
                             <Label Margin="0,5,0,0" Width="200">Logging Level</Label> 
-							<ComboBox SelectedIndex="{Binding LogLevel}" IsEnabled="{Binding EnableLogFile}" Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<ComboBox SelectedIndex="{Binding LogLevel}" IsEnabled="{Binding EnableLogFile}" Grid.Column="1" Width="150" Margin="11,0,0,0">
 								<ComboBoxItem Tag="0">Information</ComboBoxItem>
 								<ComboBoxItem Tag="1">Warning</ComboBoxItem>
 								<ComboBoxItem Tag="2">Error</ComboBoxItem>
@@ -148,15 +138,16 @@
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Resolution -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Display Resolution</TextBlock>
+						<WrapPanel Margin="5,0,0,0">
+							<TextBlock VerticalAlignment="Center" Width="200">Display Resolution</TextBlock>
 							<ComboBox SelectedIndex="{Binding BitsSelectedIndex}" IsVisible="{Binding FlagDataLoaded}" Grid.Column="2" Width="100" Margin="10,0,0,0">
 								<ComboBoxItem Tag="32">32 Bit</ComboBoxItem>
 								<ComboBoxItem Tag="16" IsEnabled="{Binding Enable16BitColor}">16 bit</ComboBoxItem>
 							</ComboBox>
 							<TextBlock Text="First download a FSO build to enable this setting." IsVisible="{Binding !FlagDataLoaded}" VerticalAlignment="Center" Foreground="Red" FontWeight="Bold" Grid.Column="1" Width="500" Margin="10,0,0,0"></TextBlock>
 							<ComboBox SelectedIndex="{Binding ResolutionSelectedIndex}" ItemsSource="{Binding ResolutionItems}" IsVisible="{Binding FlagDataLoaded}" Grid.Column="1" Width="300" Margin="10,0,0,0"></ComboBox>
-						</Grid>
+							<Button Margin="130,0,0,0" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Tips to Optimize Game Performance" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Right"></Button>
+						</WrapPanel>
 						<!-- Resolution -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Texture Filtering</TextBlock>
@@ -238,7 +229,6 @@
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
 							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}"></CheckBox>
-							<Button Margin="20,0,0,0" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="I need more FPS!" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 						</WrapPanel>
 					</StackPanel>
 				</Border>
@@ -364,19 +354,26 @@
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">FSO Engine Settings</Label>
 				<Border Margin="0,5,0,5" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<!-- Sys Info -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,5,0,0">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Detected Build Settings </TextBlock>
-							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
-								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
-								<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
-								<Label Margin="30,5,0,0" FontWeight="Bold">CPU Arch:</Label>
-								<TextBlock Margin="5,8,0,0" Text="{Binding CpuArch}"></TextBlock>
-								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX}">AVX</CheckBox>
-								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX2}">AVX2</CheckBox>
-							</WrapPanel>
+						<!-- FS2 Lang -->
+						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="3,0,0,0" Width="200">In-game Language</TextBlock>
+							<ComboBox SelectedIndex="{Binding Fs2LangSelectedIndex}" Grid.Column="1" Width="200" Margin="8,0,0,0">
+								<ComboBoxItem>English</ComboBoxItem>
+								<ComboBoxItem>German</ComboBoxItem>
+								<ComboBoxItem>French</ComboBoxItem>
+								<ComboBoxItem>Polish</ComboBoxItem>
+							</ComboBox>
 						</Grid>
-
+						<!-- Sys Info -->
+						<WrapPanel Margin="9,0,0,0">
+							<TextBlock VerticalAlignment="Center" Width="201">Detected Build Settings </TextBlock>
+							<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
+							<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
+							<Label Margin="30,5,0,0" FontWeight="Bold">CPU Arch:</Label>
+							<TextBlock Margin="5,8,0,0" Text="{Binding CpuArch}"></TextBlock>
+							<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX}">AVX</CheckBox>
+							<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX2}">AVX2</CheckBox>
+						</WrapPanel>	
 						<WrapPanel Margin="0,5,0,0">	
 							<Label Margin="5,5,0,0" IsVisible="{Binding IsAVX}" Width="200">Force SSE2</Label> 
 							<CheckBox Margin="12,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -17,7 +17,7 @@
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
 					<Button Command="{Binding QuickSetupCommand}" FontSize="22" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
-					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="500,0,0,0" Classes="Cancel">Reset</Button>
+					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="510,0,0,0" Classes="Cancel">Reset</Button>
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
 					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="10,0,0,0">Save</Button>
 				</WrapPanel>
@@ -237,7 +237,7 @@
 						<!-- Show FPS -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
-							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}" Width="200"></CheckBox>
+							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}"></CheckBox>
 							<Button Margin="20,0,0,0" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="I need more FPS!" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 						</WrapPanel>
 					</StackPanel>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -31,28 +31,28 @@
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Base Path -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="10,10,0,0">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Library Folder </TextBlock>
 							<TextBox Text="{Binding BasePath}" Margin="10,0,0,0" Grid.Column="1" IsReadOnly="True" Width="500"></TextBox>
 							<Button Margin="5,0,0,0" Grid.Column="2" Classes="Secondary" Command="{Binding BrowseFolderCommand}">Browse</Button>
 						</Grid>
 						<!-- Lib Info -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="5,10,0,0">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="6,10,0,0">
 							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Stats</TextBlock>
 							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="10,2,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold" ToolTip.Tip="How many standalone games and modifications (collectively known as mods) are installed in your Knossos library.">Mods:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
 								<Label Margin="40,5,0,0" FontWeight="Bold">Builds:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfBuilds}"></TextBlock>
-								<Button Margin="5,0,0,0" Command="{Binding CleanupLibraryCommand}">Remove Unused Dependencies</Button>
+								<Button Margin="40,0,0,0" Command="{Binding CleanupLibraryCommand}">Remove Unused Dependencies</Button>
 							</WrapPanel>
 						</Grid>
-						<WrapPanel Margin="10,10,0,0">	
+						<WrapPanel Margin="6,10,0,0">	
 							<Label Margin="0,5,0,0" Width="200">Retail Freespace 2</Label>
 							<CheckBox Margin="10,0,0,0" IsVisible="{Binding Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
 							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Margin="10,0,0,0">Installer</Button>
 						</WrapPanel>
-						<WrapPanel Margin="10,10,0,0">
+						<WrapPanel Margin="8,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
 							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space. 'Manual' means you will have to compress or decompress the files manually from mod settings. 'Always' means Knossos will compress all mods during install and 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum. This only works if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
@@ -77,12 +77,12 @@
 						</WrapPanel>
 						<!-- Image Cache -->
 						<WrapPanel Margin="5,10,0,0">
-							<Label VerticalAlignment="Center" Width="200" Content="Image Cache Size"/>
+							<Label VerticalAlignment="Center" Width="200" Content="Image Cache"/>
 							<Label Margin="10,0,0,0" VerticalAlignment="Center" Foreground="Yellow" Content="{Binding ImgCacheSize}"/>
 							<Button Command="{Binding ClearImageCache}" Margin="5,0,0,0" Classes="Secondary">Clear</Button>
 						</WrapPanel>
 						<!-- SubTasks -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,10,0,0">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Concurrent Subtasks</TextBlock>
 							<ComboBox SelectedIndex="{Binding MaxConcurrentSubtasks}" ToolTip.Tip="All tasks are done in order, but some tasks like install tasks creates multiple subtasks to download files, etc. This setting controls how many of them can run simultaneously." Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="1">1</ComboBoxItem>
@@ -92,7 +92,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Bandwidth limit -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,10,0,0">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Bandwidth Limit</TextBlock>
 							<ComboBox SelectedIndex="{Binding MaxDownloadSpeedIndex}" ToolTip.Tip="Bandwidth limiter (Per Individual Download)" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Unlimited</ComboBoxItem>
@@ -110,7 +110,7 @@
 							</ComboBox>
 						</Grid>
 						<!-- Mirror Blacklist -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,10,0,0">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Mirror Blacklist</TextBlock>
 							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
 								<CheckBox Margin="0,0,0,0" IsChecked="{Binding BlDlNebula}">dl.fsnebula.org</CheckBox>
@@ -261,21 +261,24 @@
 						</Grid>
 						<!-- Enable EFX -->
                         <WrapPanel>
-                            <Label Margin="5,5,0,0" Width="200">Enable EFX</Label> 
-							<CheckBox Tag="efx" Grid.Column="0" IsChecked="{Binding EnableEFX}" ToolTip.Tip="Enables in-mission sound effects to play with an extra sound environment filter set by the mission designer. By default, this filter adds a reverb effect."></CheckBox>
+                            <Label Margin="4,5,0,0" Width="200">Enable EFX</Label> 
+							<CheckBox Tag="efx" Margin="11,0,0,0" IsChecked="{Binding EnableEFX}" ToolTip.Tip="Enables in-mission sound effects to play with an extra sound environment filter set by the mission designer. By default, this filter adds a reverb effect."></CheckBox>
 						</WrapPanel>
 						<!-- Disable Audio -->
                         <WrapPanel>
-                            <Label Margin="5,5,0,0" Width="200">Disable Audio</Label> 
-							<CheckBox Tag="-nosound" Grid.Column="0" IsChecked="{Binding DisableAudio}"></CheckBox>
+                            <Label Margin="4,5,0,0" Width="200">Disable Audio</Label> 
+							<CheckBox Tag="-nosound" Margin="11,0,0,0" IsChecked="{Binding DisableAudio}"></CheckBox>
 						</WrapPanel>
 						<!-- Disable Music -->
                         <WrapPanel>
-                            <Label Margin="5,5,0,0" Width="200">Disable Music</Label> 
-							<CheckBox Tag="-nomusic" Grid.Column="0" IsChecked="{Binding DisableMusic}"></CheckBox>
+                            <Label Margin="4,5,0,0" Width="200">Disable Music</Label> 
+							<CheckBox Tag="-nomusic" Margin="11,0,0,0" IsChecked="{Binding DisableMusic}"></CheckBox>
 						</WrapPanel>
 						<!-- TTS -->
-						<CheckBox IsChecked="{Binding EnableTTS}" Margin="5">Enable Text to speech</CheckBox>
+                        <WrapPanel>
+                            <Label Margin="4,5,0,0" Width="200">Enable Text to Speech</Label> 
+							<CheckBox IsChecked="{Binding EnableTTS}" Margin="11,0,0,0"></CheckBox>
+						</WrapPanel>
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Voice</TextBlock>
 							<TextBlock Text="First download a FSO build to enable this setting." IsVisible="{Binding !FlagDataLoaded}" VerticalAlignment="Center" Foreground="Red" FontWeight="Bold" Grid.Column="1" Width="500" Margin="10,0,0,0"></TextBlock>
@@ -368,18 +371,21 @@
 						</Grid>
 						<!-- Sys Info -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="10,5,0,0">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Build Types </TextBlock>
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Detected Build Settings </TextBlock>
 							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding DetectedOS}"></TextBlock>
 								<Label Margin="30,5,0,0" FontWeight="Bold">CPU Arch:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding CpuArch}"></TextBlock>
-								<CheckBox Margin="20,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
-								<Label Margin="0,5,0,0" IsVisible="{Binding IsAVX}">Force SSE2</Label> 
 								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX}">AVX</CheckBox>
 								<CheckBox Margin="50,0,0,0" IsEnabled="False" IsChecked="{Binding IsAVX2}">AVX2</CheckBox>
 							</WrapPanel>
 						</Grid>
+
+						<WrapPanel Margin="0,5,0,0">	
+							<Label Margin="5,5,0,0" IsVisible="{Binding IsAVX}" Width="200">Force SSE2</Label> 
+							<CheckBox Margin="20,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
+						</WrapPanel>
 						<!-- GLOBAL CMDLINE -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Global Command Line</Label>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -47,9 +47,9 @@
 							</WrapPanel>
 						</Grid>
 						<WrapPanel Margin="5,10,0,0">	
-							<Label Width="200">Freespace 2 Retail</Label>
-							<CheckBox Margin="10,0,0,0" IsVisible="{Binding !Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
-							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" Background="Black" Margin="10,0,0,0">Retail Freespace 2 Installer</Button>
+							<Label Margin="0,5,0,0" Width="200">Freespace 2 Retail</Label>
+							<CheckBox Margin="10,0,0,0" IsVisible="{Binding Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
+							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Margin="10,0,0,0">Retail Freespace 2 Installer</Button>
 						</WrapPanel>
 						<WrapPanel Margin="5,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -17,24 +17,24 @@
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
 					<Button Command="{Binding QuickSetupCommand}" FontSize="22" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
-					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="340,0,0,0">Save</Button>
+					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="450,0,0,0">Save</Button>
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
 					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="10,0,0,0" Classes="Cancel">Reset</Button>
 				</WrapPanel>
-				<TextBlock Margin="10,15,0,0" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please exit this tab open before playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
+				<TextBlock Margin="10,15,0,3" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please close this tab before playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
 			</StackPanel>
 		</Border>
 		<ScrollViewer Grid.Row="1">
 			<StackPanel>
 				<!--KNOSSOS SETTINGS-->
-				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Knossos Settings</Label>
+				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Knossos Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Base Path -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" FontWeight="Heavy" Width="200">Library </TextBlock>
 							<TextBox Text="{Binding BasePath}" Margin="10,0,0,0" Grid.Column="1" IsReadOnly="True" Width="500"></TextBox>
-							<Button Grid.Column="2" Classes="Secondary" Command="{Binding BrowseFolderCommand}">Browse</Button>
+							<Button Margin="5,0,0,0" Grid.Column="2" Classes="Secondary" Command="{Binding BrowseFolderCommand}">Browse</Button>
 						</Grid>
 						<!-- Lib Info -->
 						<Grid ColumnDefinitions="Auto,Auto" RowDefinitions="Auto, Auto" Margin="5">
@@ -44,8 +44,8 @@
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
 								<Label Margin="40,5,0,0" FontWeight="Bold">Builds:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfBuilds}"></TextBlock>
-								<CheckBox Margin="40,0,0,0" IsEnabled="False" IsChecked="{Binding Fs2RootPack}">FS2 Root Pack</CheckBox>
-								<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Background="Black" Margin="10,0,0,0">FS2 Retail Installer</Button>
+								<CheckBox Margin="40,0,0,0" IsEnabled="False" IsChecked="{Binding Fs2RootPack}">Retail Freespace 2 Installed</CheckBox>
+								<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Background="Black" Margin="10,0,0,0">Installer</Button>
 							</WrapPanel>
 						</Grid>
 						<WrapPanel Grid.Column="1" Margin="220,5,0,0">
@@ -134,7 +134,7 @@
 					</StackPanel>
 				</Border>
 				<!--VIDEO SETTINGS-->
-				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Video Settings</Label>
+				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Video Settings</Label>
 				<Border BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Resolution -->
@@ -189,23 +189,24 @@
 								<ComboBoxItem Tag="7">SMAA Ultra</ComboBoxItem>
 							</ComboBox>
 						</Grid>
-            <!-- SMAA Filter -->
-            <Grid ColumnDefinitions="Auto,Auto" Margin="5">
-              <Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample Anti-Aliasing</Label>
-              <ComboBox ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
-                <ComboBoxItem Tag="0">Disabled</ComboBoxItem>
-                <ComboBoxItem Tag="4">High</ComboBoxItem>
-                <ComboBoxItem Tag="8">Ultra</ComboBoxItem>
-              </ComboBox>
-            </Grid>
+						<!-- SMAA Filter -->
+						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample Anti-Aliasing</Label>
+						<ComboBox ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
+							<ComboBoxItem Tag="4">High</ComboBoxItem>
+							<ComboBoxItem Tag="8">Ultra</ComboBoxItem>
+						</ComboBox>
+						</Grid>
 						<!-- Enable deferred lighting -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-no_deferred" Grid.Column="0" IsChecked="{Binding EnableDeferredLighting}" Width="200">Enable Deferred Lighting</CheckBox>
+							<Label Margin="5,0,0,0" Width="200">Enable Deferred Lighting</Label> 
+							<CheckBox Tag="-no_deferred" Grid.Column="0" IsChecked="{Binding EnableDeferredLighting}" Width="200"></CheckBox>
 						</Grid>
-            <!-- Enable soft particles -->
-            <Grid ColumnDefinitions="Auto,Auto" Margin="5">
-              <CheckBox Tag="-soft_particles" Grid.Column="0" IsChecked="{Binding EnableSoftParticles}" Width="200">Enable Soft Particles</CheckBox>
-            </Grid>
+						<!-- Enable soft particles -->
+						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<CheckBox Tag="-soft_particles" Grid.Column="0" IsChecked="{Binding EnableSoftParticles}" Width="200">Enable Soft Particles</CheckBox>
+						</Grid>
 						<!-- VSYNC -->
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<CheckBox Tag="-no_vsync" Grid.Column="0" IsChecked="{Binding Vsync}" Width="200">Enable VSync</CheckBox>
@@ -222,12 +223,12 @@
 						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
 							<CheckBox Tag="-fps" Grid.Column="0" IsChecked="{Binding ShowFps}" Width="200">Display FPS</CheckBox>
 						</Grid>
-            <Button Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Slow in-game performance?" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
+            			<Button Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="Slow in-game performance?" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 					</StackPanel>
 				</Border>
 
 				<!--Audio SETTINGS-->
-				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Audio Settings</Label>
+				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Audio Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Playback -->
@@ -265,7 +266,7 @@
 							<CheckBox Tag="-nomusic" Grid.Column="0" IsChecked="{Binding DisableMusic}" Width="200">Disable Music</CheckBox>
 						</Grid>
 						<!-- TTS -->
-						<CheckBox IsChecked="{Binding EnableTTS}" Margin="5">Enable TTS (Text to speech)</CheckBox>
+						<CheckBox IsChecked="{Binding EnableTTS}" Margin="5">Enable Text to speech</CheckBox>
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Voice</TextBlock>
 							<TextBlock Text="First download a FSO build to enable this setting." IsVisible="{Binding !FlagDataLoaded}" VerticalAlignment="Center" Foreground="Red" FontWeight="Bold" Grid.Column="1" Width="500" Margin="10,0,0,0"></TextBlock>
@@ -292,7 +293,7 @@
 				</Border>
 
 				<!--INPUT SETTINGS-->
-				<Label Margin="5,5,0,0" FontWeight="Bold" FontSize="18">Input Settings</Label>
+				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Input Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
             <?ignore
@@ -338,9 +339,9 @@
 				</Border>
 		
 				<!--MOD SETTINGS-->
+				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">FSO Global Settings</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<Label FontWeight="Bold" FontSize="18">FSO Global Settings</Label>
 						<!-- GLOBAL CMDLINE -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Global Cmdline</Label>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -17,11 +17,11 @@
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
 					<Button Command="{Binding QuickSetupCommand}" FontSize="22" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
-					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="480,0,0,0">Save</Button>
+					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="480,0,0,0" Classes="Cancel">Reset</Button>
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
-					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="10,0,0,0" Classes="Cancel">Reset</Button>
+					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="10,0,0,0">Save</Button>
 				</WrapPanel>
-				<TextBlock Margin="10,15,3,3" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please close this tab before playing, as Knossos constantly scans here for changes to the .ini file.</TextBlock>
+				<TextBlock Margin="10,15,3,3" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please navigate to another tab before playing, as this tab constantly scans for option file changes.</TextBlock>
 			</StackPanel>
 		</Border>
 		<ScrollViewer Grid.Row="1">
@@ -85,7 +85,7 @@
 							<Button Command="{Binding ClearImageCache}" Grid.Column="2" Classes="Secondary">Clear Cache</Button>
 						</WrapPanel>
 						<!-- SubTasks -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Concurrent Subtasks</TextBlock>
 							<ComboBox SelectedIndex="{Binding MaxConcurrentSubtasks}" ToolTip.Tip="All tasks are done in order, but some tasks like install tasks creates multiple subtasks to download files, etc. This setting controls how many of them can run simultaneously." Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="1">1</ComboBoxItem>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -30,6 +30,16 @@
 				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Knossos</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
+						<!-- FS2 Lang -->
+						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
+							<TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="3,0,0,0" Width="200">In-game Language</TextBlock>
+							<ComboBox SelectedIndex="{Binding Fs2LangSelectedIndex}" Grid.Column="1" Width="200" Margin="7,0,0,0">
+								<ComboBoxItem>English</ComboBoxItem>
+								<ComboBoxItem>German</ComboBoxItem>
+								<ComboBoxItem>French</ComboBoxItem>
+								<ComboBoxItem>Polish</ComboBoxItem>
+							</ComboBox>
+						</Grid>
 						<!-- Base Path -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Library Folder </TextBlock>
@@ -78,7 +88,7 @@
 						<!-- Image Cache -->
 						<WrapPanel Margin="5,10,0,0">
 							<Label VerticalAlignment="Center" Width="200" Content="Image Cache"/>
-							<Label Margin="10,0,0,0" VerticalAlignment="Center" Foreground="Yellow" Content="{Binding ImgCacheSize}"/>
+							<Label Margin="10,0,0,0" VerticalAlignment="Center" Content="{Binding ImgCacheSize}"/>
 							<Button Command="{Binding ClearImageCache}" Margin="5,0,0,0" Classes="Secondary">Clear</Button>
 						</WrapPanel>
 						<!-- SubTasks -->
@@ -228,8 +238,8 @@
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
 							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}" Width="200"></CheckBox>
+							<Button Margin="20,0,0,0" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="I need more FPS!" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 						</WrapPanel>
-            			<Button Margin="4,4,0,5" Command="{Binding OpenPerformanceHelp}" Classes="Secondary" Content="I need more FPS!" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Left"></Button>
 					</StackPanel>
 				</Border>
 
@@ -354,21 +364,6 @@
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">FSO Engine Settings</Label>
 				<Border Margin="0,5,0,5" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
-						<!-- FS2 Lang -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="3,0,0,0" Width="200">FS2 Language</TextBlock>
-							<ComboBox SelectedIndex="{Binding Fs2LangSelectedIndex}" Grid.Column="1" Width="200" Margin="7,0,0,0">
-								<ComboBoxItem>English</ComboBoxItem>
-								<ComboBoxItem>German</ComboBoxItem>
-								<ComboBoxItem>French</ComboBoxItem>
-								<ComboBoxItem>Polish</ComboBoxItem>
-							</ComboBox>
-						</Grid>
-						<!-- Multi Port -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<Label ToolTip.Tip="Network port used by multiplayer. Default is 7808." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Multiplayer Port</Label>
-							<NumericUpDown Value="{Binding MultiPort}" Grid.Column="1" Width="150"></NumericUpDown>
-						</Grid>
 						<!-- Sys Info -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,5,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Detected Build Settings </TextBlock>
@@ -391,6 +386,11 @@
 							<Label ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Global Command Line</Label>
 							<TextBox Text="{Binding GlobalCmd}" ToolTip.Tip="This cmdline will be added to all mods and will override any mod settings using the same flags." Grid.Column="1" Width="500"></TextBox>
 							<Button Command="{Binding GlobalCmdHelp}" Classes="Secondary" Grid.Column="2" Margin="10,0,0,0">Command Line Wiki Page</Button>
+						</Grid>
+						<!-- Multi Port -->
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
+							<Label ToolTip.Tip="Network port used by multiplayer. Default is 7808." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Multiplayer Port</Label>
+							<NumericUpDown Value="{Binding MultiPort}" Grid.Column="1" Width="150"></NumericUpDown>
 						</Grid>
 					</StackPanel>
 				</Border>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -31,27 +31,28 @@
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Base Path -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="10,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Library Folder </TextBlock>
 							<TextBox Text="{Binding BasePath}" Margin="10,0,0,0" Grid.Column="1" IsReadOnly="True" Width="500"></TextBox>
 							<Button Margin="5,0,0,0" Grid.Column="2" Classes="Secondary" Command="{Binding BrowseFolderCommand}">Browse</Button>
 						</Grid>
 						<!-- Lib Info -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="5">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="5,10,0,0">
 							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Stats</TextBlock>
 							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="10,2,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold" ToolTip.Tip="How many standalone games and modifications (collectively known as mods) are installed in your Knossos library.">Mods:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
 								<Label Margin="40,5,0,0" FontWeight="Bold">Builds:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfBuilds}"></TextBlock>
+								<Button Margin="5,0,0,0" Command="{Binding CleanupLibraryCommand}">Remove Unused Dependencies</Button>
 							</WrapPanel>
 						</Grid>
-						<WrapPanel Margin="5,10,0,0">	
-							<Label Margin="0,5,0,0" Width="200">Freespace 2 Retail</Label>
+						<WrapPanel Margin="10,10,0,0">	
+							<Label Margin="0,5,0,0" Width="200">Retail Freespace 2</Label>
 							<CheckBox Margin="10,0,0,0" IsVisible="{Binding Fs2RootPack}" IsEnabled="False" IsChecked="{Binding Fs2RootPack}"></CheckBox>
 							<Button Classes="Secondary" Command="{Binding InstallFS2Command}" IsVisible="{Binding !Fs2RootPack}" Margin="10,0,0,0">Installer</Button>
 						</WrapPanel>
-						<WrapPanel Margin="5,10,0,0">
+						<WrapPanel Margin="10,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
 							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space. 'Manual' means you will have to compress or decompress the files manually from mod settings. 'Always' means Knossos will compress all mods during install and 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum. This only works if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
@@ -63,26 +64,22 @@
 						</WrapPanel>
 						<!-- AutoUpdates -->
                         <WrapPanel Margin="5,10,0,0">
-                            <Label Margin="0,5,0,0" Width="210">Check for updates at startup</Label> 
+                            <Label Margin="0,5,0,0" Width="205">Check for updates at startup</Label> 
 							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for available updates at the start."></CheckBox>
 						</WrapPanel>
                         <WrapPanel Margin="5,10,0,0">
-                            <Label Margin="0,5,0,0" Width="210">Auto Update</Label> 
+                            <Label Margin="0,5,0,0" Width="205">Auto Update</Label> 
 							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input."></CheckBox>
 						</WrapPanel>
                         <WrapPanel Margin="5,10,0,0">
-                            <Label Margin="0,5,0,0" Width="210">Delete Uploaded Mod Files</Label> 
+                            <Label Margin="0,5,0,0" Width="205">Delete Uploaded Mod Files</Label> 
 							<CheckBox Margin="5,0,0,0" IsChecked="{Binding DeleteUploadedFiles}" ToolTip.Tip="During the upload of a mod version, generates files are saved on a '{modfolder}\kn_upload' folder, if this option is enabled these unnecessary files files will be deleted after a successfull upload. You con choose to disable this option if you need to take a closer look or debug a problem."></CheckBox>
-						</WrapPanel>
-						<!-- Remove Dependencies-->
-						<WrapPanel Margin="5,10,0,0">
-							<Button Command="{Binding CleanupLibraryCommand}">Remove Unused Dependencies</Button>
 						</WrapPanel>
 						<!-- Image Cache -->
 						<WrapPanel Margin="5,10,0,0">
 							<Label VerticalAlignment="Center" Width="200" Content="Image Cache Size"/>
 							<Label Margin="10,0,0,0" VerticalAlignment="Center" Foreground="Yellow" Content="{Binding ImgCacheSize}"/>
-							<Button Command="{Binding ClearImageCache}" Grid.Column="2" Classes="Secondary">Clear Cache</Button>
+							<Button Command="{Binding ClearImageCache}" Margin="5,0,0,0" Classes="Secondary">Clear</Button>
 						</WrapPanel>
 						<!-- SubTasks -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,10,0,0">
@@ -126,8 +123,8 @@
                             <Label Margin="0,5,0,0" Width="210">Enable Logging</Label> 
 							<CheckBox IsChecked="{Binding EnableLogFile}"></CheckBox>
 						</WrapPanel>
-						<WrapPanel Margin="5">
-                            <Label Margin="0,5,0,0" Width="210">Logging Level</Label> 
+						<WrapPanel Margin="5,10,0,0">
+                            <Label Margin="0,5,0,0" Width="200">Logging Level</Label> 
 							<ComboBox SelectedIndex="{Binding LogLevel}" IsEnabled="{Binding EnableLogFile}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Information</ComboBoxItem>
 								<ComboBoxItem Tag="1">Warning</ComboBoxItem>
@@ -263,17 +260,20 @@
 							</ComboBox>
 						</Grid>
 						<!-- Enable EFX -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="efx" Grid.Column="0" IsChecked="{Binding EnableEFX}" Width="200" ToolTip.Tip="Enables in-mission sound effects to play with an extra sound environment filter set by the mission designer. By default, this filter adds a reverb effect.">Enable EFX</CheckBox>
-						</Grid>
+                        <WrapPanel>
+                            <Label Margin="5,5,0,0" Width="200">Enable EFX</Label> 
+							<CheckBox Tag="efx" Grid.Column="0" IsChecked="{Binding EnableEFX}" ToolTip.Tip="Enables in-mission sound effects to play with an extra sound environment filter set by the mission designer. By default, this filter adds a reverb effect."></CheckBox>
+						</WrapPanel>
 						<!-- Disable Audio -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-nosound" Grid.Column="0" IsChecked="{Binding DisableAudio}" Width="200">Disable Audio</CheckBox>
-						</Grid>
+                        <WrapPanel>
+                            <Label Margin="5,5,0,0" Width="200">Disable Audio</Label> 
+							<CheckBox Tag="-nosound" Grid.Column="0" IsChecked="{Binding DisableAudio}"></CheckBox>
+						</WrapPanel>
 						<!-- Disable Music -->
-						<Grid ColumnDefinitions="Auto,Auto" Margin="5">
-							<CheckBox Tag="-nomusic" Grid.Column="0" IsChecked="{Binding DisableMusic}" Width="200">Disable Music</CheckBox>
-						</Grid>
+                        <WrapPanel>
+                            <Label Margin="5,5,0,0" Width="200">Disable Music</Label> 
+							<CheckBox Tag="-nomusic" Grid.Column="0" IsChecked="{Binding DisableMusic}"></CheckBox>
+						</WrapPanel>
 						<!-- TTS -->
 						<CheckBox IsChecked="{Binding EnableTTS}" Margin="5">Enable Text to speech</CheckBox>
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -370,7 +370,7 @@
 							<NumericUpDown Value="{Binding MultiPort}" Grid.Column="1" Width="150"></NumericUpDown>
 						</Grid>
 						<!-- Sys Info -->
-						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="10,5,0,0">
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5,5,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Detected Build Settings </TextBlock>
 							<WrapPanel Grid.Column="1" Margin="10,0,0,0">
 								<Label Margin="0,5,0,0" FontWeight="Bold">OS:</Label>
@@ -384,7 +384,7 @@
 
 						<WrapPanel Margin="0,5,0,0">	
 							<Label Margin="5,5,0,0" IsVisible="{Binding IsAVX}" Width="200">Force SSE2</Label> 
-							<CheckBox Margin="20,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
+							<CheckBox Margin="10,0,0,0" IsVisible="{Binding IsAVX}" ToolTip.Tip="When enabled, Knossos will force to run SSE2 FSO builds instead of AVX ones, if SSE2 builds are available." IsChecked="{Binding ForceSSE2}"></CheckBox>
 						</WrapPanel>
 						<!-- GLOBAL CMDLINE -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">

--- a/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
+++ b/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
@@ -12,8 +12,8 @@
 		CanResize="False">
 	
 	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
-		<TextBlock Margin="10" TextWrapping="Wrap">If in-game performance is slow, ensure that "Extra Multi Sample Anti-Aliasing" and "Shadows" are disabled.</TextBlock>
-		<TextBlock TextWrapping="Wrap" Margin="10">If still slow, then disable "Deferred Lighting" and "Post-processing Anti-Aliasing".</TextBlock>
-		<TextBlock TextWrapping="Wrap" Margin="10">Always remember to click the "Save" button, too!</TextBlock>
+		<TextBlock Margin="10,20,20,0" TextWrapping="Wrap">If in-game performance is slow, try disabling "Extra Multi Sample Anti-Aliasing" or "Shadows".</TextBlock>
+		<TextBlock Margin="10,5,20,0" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and "Post-processing Anti-Aliasing".</TextBlock>
+		<TextBlock Margin="10,5,20,20" TextWrapping="Wrap">And always remember to click the "Save" button!</TextBlock>
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
+++ b/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
@@ -13,7 +13,7 @@
 	
 	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
 		<TextBlock Margin="10,20,20,0" TextWrapping="Wrap">If in-game performance is slow, try disabling "Extra Multi Sample Anti-Aliasing" or "Shadows".</TextBlock>
-		<TextBlock Margin="10,5,20,0" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and "Post-processing Anti-Aliasing".</TextBlock>
-		<TextBlock Margin="10,5,20,20" TextWrapping="Wrap">And always remember to click the "Save" button!</TextBlock>
+		<TextBlock Margin="10,10,20,0" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and "Post-processing Anti-Aliasing".</TextBlock>
+		<TextBlock Margin="10,10,20,20" TextWrapping="Wrap">And always remember to click the "Save" button!</TextBlock>
 	</StackPanel>
 </Window>


### PR DESCRIPTION
This fixes up the setting screen.  I need confirmation from @Shivansps though on whether the UI will still set values correctly if some items that rely on `-tag` are changed to their negation, like No-vsync being changed to just Vsync.

I tried to organize these setting the best I could, but I'm open to feeback.

Mostly up to date screenshots (I may have done a couple small adjustments since I took them)

![Screen Shot 2023-11-21 at 12 04 41 AM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/94a0249a-f192-4b14-80e0-163d58fafbf6)

![Screen Shot 2023-11-21 at 12 04 50 AM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/25c48ddb-e212-4c4d-83f3-e881c0978dff)

![Screen Shot 2023-11-21 at 12 04 59 AM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/777fc127-1412-4470-9b2f-d463ca045dd5)

![Screen Shot 2023-11-21 at 12 05 11 AM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/1bc2208d-3fff-40d0-affd-1c266b527e1a)

![Screen Shot 2023-11-21 at 12 05 19 AM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/64a99389-a6d0-43ff-ad3d-58e84a27c3da)
 