### PR TITLE
Update Quick Setup Guide button text

### DIFF
--- a/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
+++ b/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
@@ -12,8 +12,8 @@
 		CanResize="False">
 	
 	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
-		<TextBlock Margin="10,20,20,0" TextWrapping="Wrap">If in-game performance is slow, try disabling "Extra Multi Sample Anti-Aliasing" or "Shadows".</TextBlock>
-		<TextBlock Margin="10,10,20,0" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and "Post-processing Anti-Aliasing".</TextBlock>
+		<TextBlock Margin="10,20,20,10" TextWrapping="Wrap">If in-game performance is slow, close the game and then try disabling "Extra Multi Sample Anti-Aliasing" and "Shadows".</TextBlock>
+		<TextBlock Margin="10,10,20,10" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and then "Post-processing Anti-Aliasing".</TextBlock>
 		<TextBlock Margin="10,10,20,20" TextWrapping="Wrap">And always remember to click the "Save" button!</TextBlock>
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -28,7 +28,7 @@
 		<StackPanel IsVisible="{Binding Page1}" Grid.Row="0">
 			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Welcome To Knossos.NET</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" >This quick setup guide will help you through the basics of configuring the Knossos launcher for the first time. If you already know how to configure the launcher you can close this window.</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" >Note, you can reopen this guide at any time. To do so, go to the "Settings" tab, look under the "Knossos Settings" section and press the "Quick Setup Guide" button.</TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" >Note, you can reopen this guide at any time, just go to the "Settings" tab and click the "Quick Setup Guide" button.</TextBlock>
       <TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" >If at any point you ever need assistance with Knossos plese ask on the Knossos Discord channel linked below.</TextBlock>
       <Button Margin="20, 10" Command="{Binding OpenDiscordQuickSetup}">Discord Help for Knossos</Button>
 		</StackPanel>


### PR DESCRIPTION
Now that the Quick Setup Guide button is not Under the 'Knossos' Section but the header, the text in the Quick Setup Guide has been updated accordingly.