### PR TITLE
Add DevEnv mod version support

### DIFF
--- a/Knossos.NET/ViewModels/TaskViewModel.cs
+++ b/Knossos.NET/ViewModels/TaskViewModel.cs
@@ -330,6 +330,7 @@ namespace Knossos.NET.ViewModels
                     taskQueue.Enqueue(newTask);
                 });
                 await newTask.CreateModVersion(oldMod, newVersion, cancelSource).ConfigureAwait(false);
+                await Task.Delay(1000).ConfigureAwait(false);
                 Dispatcher.UIThread.Invoke(() =>
                 {
                     hackCallback?.Invoke();

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -60,10 +60,7 @@ namespace Knossos.NET.ViewModels
             get 
             {
                 if (editor != null)
-                    if ( !IsDevEnvVersion || Mods.Count() <= 1 || Mods.Count() <= ( selectedIndex - 1 ) )
-                        return editor.ActiveVersion.version;
-                    else
-                        return Mods[SelectedIndex - 1].version;
+                    return editor.ActiveVersion.version;
                 else
                     return "1.0.0-Default";
             }
@@ -77,7 +74,12 @@ namespace Knossos.NET.ViewModels
                 if (newVersion != string.Empty)
                     return newVersion;
                 else
-                    return CurrentVersion;
+                {
+                    if (!IsDevEnvVersion || Mods.Count() <= 1 || Mods.Count() <= (selectedIndex - 1))
+                        return CurrentVersion;
+                    else
+                        return Mods[SelectedIndex - 1].version;
+                }
             }
             set
             {

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -185,7 +185,7 @@ namespace Knossos.NET.ViewModels
             }
             if (Mods.FirstOrDefault(m => m.version == NewVersion) != null)
             {
-                await MessageBox.Show(MainWindow.instance!, "'" + NewVersion + "' already exist.", "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance!, "'" + NewVersion + "' already exists.", "Validation error", MessageBox.MessageBoxButtons.OK);
                 return;
             }
             var parentDir = new DirectoryInfo(editor.ActiveVersion.fullPath).Parent;
@@ -197,7 +197,7 @@ namespace Knossos.NET.ViewModels
             var newDir = parentDir.FullName + Path.DirectorySeparatorChar + editor.ActiveVersion.id + "-" + NewVersion;
             if (Directory.Exists(newDir))
             {
-                await MessageBox.Show(MainWindow.instance!, "The directory '"+ newDir + "' already exist.", "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance!, "The directory '"+ newDir + "' already exists.", "Validation error", MessageBox.MessageBoxButtons.OK);
                 return;
             }
 
@@ -593,8 +593,8 @@ namespace Knossos.NET.ViewModels
             if (editor == null)
                 return;
             string devVersion = "999.0.0-DevEnv";
-            string explanation = "A DevEnv version is a mod version intended to be used for continuous local development process and it cant be uploaded to Nebula.\nThis version will always be the default active version every time you start Knet, and" +
-                " provides a static folder you can always work on.\nWhen you want to release a new version you can create a new version from the DevEnv one and release it.";
+            string explanation = "A DevEnv version is a mod version intended to be used for continuous local development process, and it can't be uploaded to Nebula.\nThis version will always be the default active version every time you start Knet, and" +
+                            " provides a static folder you can always work on.\nWhen you want to release a new version you can create a new version from the DevEnv one and release it.";
 
             if(await MessageBox.Show(MainWindow.instance!, explanation, "Creating Dev Environment version", MessageBox.MessageBoxButtons.ContinueCancel) != MessageBox.MessageBoxResult.Continue)
             {
@@ -602,7 +602,7 @@ namespace Knossos.NET.ViewModels
             }
             if (Mods.FirstOrDefault(m => m.version == devVersion) != null)
             {
-                await MessageBox.Show(MainWindow.instance!, "'" + devVersion + "' already exist.", "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance!, "'" + devVersion + "' already exists.", "Validation error", MessageBox.MessageBoxButtons.OK);
                 return;
             }
             var parentDir = new DirectoryInfo(editor.ActiveVersion.fullPath).Parent;
@@ -614,7 +614,7 @@ namespace Knossos.NET.ViewModels
             var newDir = parentDir.FullName + Path.DirectorySeparatorChar + editor.ActiveVersion.id + "-" + devVersion;
             if (Directory.Exists(newDir))
             {
-                await MessageBox.Show(MainWindow.instance!, "The directory '" + newDir + "' already exist.", "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance!, "The directory '" + newDir + "' already exists.", "Validation error", MessageBox.MessageBoxButtons.OK);
                 return;
             }
 

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -28,6 +28,7 @@
 					</Flyout>
 				</Button.Flyout>
 			</Button>
+			<Button Command="{Binding CreateDevEnv}" IsVisible="{Binding !ModHasDevEnvVersion}" Classes="Quaternary" Margin="20,0,0,0">Create DevEnv Version</Button>
 			<Button Command="{Binding LoadVersionsFromNebula}" Classes="Option" Margin="20,0,0,0">Install or Modify</Button>
 			<Button Command="{Binding DeleteAll}" Classes="Cancel" Margin="20,0,0,0">Delete Mod</Button>
 		</WrapPanel>
@@ -45,9 +46,9 @@
 		</ListBox>
 		<Label Grid.Row="2" HorizontalAlignment="Center">Actions for Active Version</Label>
 		<WrapPanel Grid.Row="3" Margin="10" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-			<Button Command="{Binding UploadMod}" Classes="Accept" Margin="0,5,5,5">Upload to Nebula</Button>
-			<Button Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="20,5,5,5"/>
-			<Button Command="{Binding DeleteNebula}" Classes="Cancel" Margin="20,5,5,5">Delete from Nebula</Button>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept" Margin="0,5,5,5">Upload to Nebula</Button>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="20,5,5,5"/>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="20,5,5,5">Delete from Nebula</Button>
 			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="20,5,5,5">Delete Locally</Button>
 		</WrapPanel>
 	</Grid>


### PR DESCRIPTION
Add support for a single continuous mod development version.

This version is called "999.0.0-DevEnv" the idea is that mod developers can always work on this one version, that due to the version number will be always the one enabled by default. 

Uploading of this version to Nebula is not allowed, and instead in order to release a mod developer will have to create a new version from this one.