### PR TITLE
More Dev tab subscreen adjustments

### DIFF
--- a/Knossos.NET/Views/DeveloperModsView.axaml
+++ b/Knossos.NET/Views/DeveloperModsView.axaml
@@ -29,7 +29,7 @@
 									</DataTemplate>
 								</ListBox.ItemTemplate>
 							</ListBox>
-							<Button Command="{Binding CreateMod}" Grid.Row="1" Classes="Quaternary"  HorizontalAlignment="Center">Create New Mod</Button>
+							<Button Command="{Binding CreateMod}" Grid.Row="1" Classes="Quaternary" Margin="0,20,0,10" HorizontalAlignment="Center">Create New Mod</Button>
 						</Grid>
 					</SplitView.Pane>
 

--- a/Knossos.NET/Views/DeveloperModsView.axaml
+++ b/Knossos.NET/Views/DeveloperModsView.axaml
@@ -14,7 +14,7 @@
 
 	<TabControl SelectedIndex="{Binding TabIndex}">
 	  <TabItem Header="Mods">
-				<SplitView Margin="0,0,0,5" IsPaneOpen="True" DisplayMode="Inline" OpenPaneLength="400">
+				<SplitView Margin="0,0,0,5" IsPaneOpen="True" DisplayMode="Inline" OpenPaneLength="350">
 					<SplitView.Pane>
 						<Grid RowDefinitions="*,Auto">
 							<ListBox Grid.Row="0" ItemsSource="{Binding Mods}" SelectedIndex="{Binding SelectedIndex}">

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -56,19 +56,18 @@
 				</StackPanel>
 			</WrapPanel>
 			<!--Tile Image-->
-			<WrapPanel HorizontalAlignment="Left" Margin="10,0,0,10">
-				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Title Image</Label>
-				<StackPanel MinWidth="225" Margin="5">
-					<Border Width="152" Height="227" Margin="5" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
+			<WrapPanel HorizontalAlignment="Left" Margin="20,0,0,0">
+				<Label HorizontalContentAlignment="Right" FontWeight="Bold" FontSize="18">Title Image</Label>
+				<StackPanel MinWidth="225">
+					<Border Width="152" Height="227" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="150" Height="225" Source="{Binding TileImage}"></Image>
 					</Border>
-					<Label HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large.</Label>
+					<Label Margin="5,3,0,0" HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large.</Label>
 				</StackPanel>
-				<StackPanel VerticalAlignment="Center">
-					<Button Command="{Binding ChangeTileImage}" Width="100" Classes="Option" Margin="5">Browse</Button>
-					<Button Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
-				</StackPanel>
-				
+			</WrapPanel>
+			<WrapPanel Margin="20,0,0,0" HorizontalAlignment="Center">
+				<Button Command="{Binding ChangeTileImage}" Width="100" Classes="Option" Margin="5">Browse</Button>
+				<Button Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 			</WrapPanel>
 			<!--Banner Image-->
 			<WrapPanel HorizontalAlignment="Left">
@@ -85,10 +84,10 @@
 				</StackPanel>
 			</WrapPanel>
 			<!--Screenshoots-->
-			<WrapPanel HorizontalAlignment="Left">
+			<WrapPanel Margin="0,15,0,0" HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Screenshots</Label>
 				<StackPanel>
-					<Button Command="{Binding NewScreenShot}" Classes="Option" Margin="5">Add</Button>
+					<Button Command="{Binding NewScreenShot}" Classes="Option" Margin="10">Add</Button>
 					<ListBox ItemsSource="{Binding Screenshots}" Margin="5,0,0,0">
 						<ListBox.ItemTemplate>
 							<DataTemplate>

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -13,31 +13,31 @@
 	</Design.DataContext>
 
 	<ScrollViewer>
-		<StackPanel Margin="50,5,0,0">
+		<StackPanel Margin="10,5,0,0">
 			<!--NAME-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" Margin="5" FontWeight="Bold" HorizontalContentAlignment="Right" FontSize="18">Name</Label>
-				<TextBox MinWidth="300" Text="{Binding ModName}" Margin="5"></TextBox>
+				<TextBox MinWidth="280" Text="{Binding ModName}" Margin="5"></TextBox>
 			</WrapPanel>
 			<!--ID-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">ID</Label>
-				<Label MinWidth="300" Content="{Binding ModId}" Margin="5"></Label>
+				<Label MinWidth="280" Content="{Binding ModId}" Margin="5"></Label>
 			</WrapPanel>
 			<!--Type-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Type</Label>
-				<Label MinWidth="300" Content="{Binding ModType}" Margin="5"></Label>
+				<Label MinWidth="280" Content="{Binding ModType}" Margin="5"></Label>
 			</WrapPanel>
 			<!--Parent-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Parent</Label>
-				<Label MinWidth="300" Content="{Binding ModParent}" Margin="5"></Label>
+				<Label MinWidth="280" Content="{Binding ModParent}" Margin="5"></Label>
 			</WrapPanel>
 			<!--Description-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Description</Label>
-				<StackPanel MinWidth="310" MaxWidth="600">
+				<StackPanel MinWidth="280" MaxWidth="600">
 					<TextBox TextWrapping="Wrap" Height="200" Text="{Binding ModDescription}" Margin="5"></TextBox>
 					<Button Command="{Binding OpenDescriptionEditor}" Classes="Primary" Margin="5">Open Editor</Button>
 				</StackPanel>
@@ -45,12 +45,12 @@
 			<!--FORUM-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Release Thread</Label>
-				<TextBox MinWidth="300" Text="{Binding ModForumLink}" Margin="5"></TextBox>
+				<TextBox MinWidth="280" Text="{Binding ModForumLink}" Margin="5"></TextBox>
 			</WrapPanel>
 			<!--Videos-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Youtube Videos</Label>
-				<StackPanel MinWidth="310">
+				<StackPanel MinWidth="280">
 					<TextBox Height="125" Text="{Binding ModVideos}" Margin="5"></TextBox>
 					<Label Margin="5" Foreground="Yellow" FontSize="12">One link per line</Label>
 				</StackPanel>

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -65,7 +65,7 @@
 					<Label Margin="5,3,0,0" HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large.</Label>
 				</StackPanel>
 			</WrapPanel>
-			<WrapPanel Margin="20,0,0,0" HorizontalAlignment="Center">
+			<WrapPanel Margin="130,0,0,0">
 				<Button Command="{Binding ChangeTileImage}" Width="100" Classes="Option" Margin="5">Browse</Button>
 				<Button Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 			</WrapPanel>
@@ -77,7 +77,7 @@
 						<Image Width="535" Height="150" Source="{Binding BannerImage}"></Image>
 					</Border>
 					<Label HorizontalAlignment="Center" Margin="5" Foreground="Yellow" FontSize="12">This image should be 1070x300 pixels large.</Label>
-					<WrapPanel HorizontalAlignment="Center">
+					<WrapPanel Margin="130,0,0,0">
 						<Button Command="{Binding ChangeBannerImage}" Width="100" Classes="Option" Margin="5">Browse</Button>
 						<Button Command="{Binding RemoveBannerImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 					</WrapPanel>

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -62,7 +62,7 @@
 					<Border Width="152" Height="227" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="150" Height="225" Source="{Binding TileImage}"></Image>
 					</Border>
-					<Label Margin="5,3,0,0" HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large.</Label>
+					<Label Margin="5,5,0,0" HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large.</Label>
 				</StackPanel>
 			</WrapPanel>
 			<WrapPanel Margin="130,0,0,0">
@@ -76,7 +76,7 @@
 					<Border Margin="45,5,5,5" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="535" Height="150" Source="{Binding BannerImage}"></Image>
 					</Border>
-					<Label HorizontalAlignment="Center" Margin="5" Foreground="Yellow" FontSize="12">This image should be 1070x300 pixels large.</Label>
+					<Label Margin="125,5,0,0" Foreground="Yellow" FontSize="12">This image should be 1070x300 pixels large.</Label>
 					<WrapPanel Margin="130,0,0,0">
 						<Button Command="{Binding ChangeBannerImage}" Width="100" Classes="Option" Margin="5">Browse</Button>
 						<Button Command="{Binding RemoveBannerImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>

--- a/Knossos.NET/Views/Templates/DevModEditorView.axaml
+++ b/Knossos.NET/Views/Templates/DevModEditorView.axaml
@@ -13,9 +13,9 @@
 	</Design.DataContext>
 
 	<Grid ColumnDefinitions="Auto,*">
-		<ScrollViewer Width="250" Grid.Column="0">
-			<StackPanel Width="250" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-				<TextBlock HorizontalAlignment="Center" Text="{Binding Name}" FontSize="16" FontWeight="Bold" TextWrapping="Wrap" Margin="0"></TextBlock>
+		<ScrollViewer Width="210" Grid.Column="0">
+			<StackPanel Width="210" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+				<TextBlock HorizontalAlignment="Center" Text="{Binding Name}" FontSize="14" FontWeight="Bold" TextWrapping="Wrap" Margin="0"></TextBlock>
 				<Image HorizontalAlignment="Center" Margin="10" Source="{Binding ModImage}" Width="150" Height="225"></Image>
 				<TextBlock HorizontalAlignment="Center" Text="Active Version" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0"></TextBlock>
 				<TextBlock HorizontalAlignment="Center" Text="{Binding Version}" FontSize="14" TextWrapping="Wrap" Margin="0"></TextBlock>

--- a/Knossos.NET/Views/Templates/DevModEditorView.axaml
+++ b/Knossos.NET/Views/Templates/DevModEditorView.axaml
@@ -30,13 +30,13 @@
 				</StackPanel>
 				<!--Engine Builds-->
 				<StackPanel Margin="10" HorizontalAlignment="Center" IsVisible="{Binding IsEngineBuild}">
-					<Button Command="{Binding OpenModFolder}" Classes="Option" Margin="2" Width="150" >Open Folder</Button>
+					<Button Command="{Binding OpenModFolder}" Classes="Accept" Margin="2" Width="150">Open Folder</Button>
 				</StackPanel>
 				<!--Tools-->
 				<StackPanel IsVisible="true" Margin="20,10,20,10" HorizontalAlignment="Center">
 					<TextBlock HorizontalAlignment="Center" Text="Tools" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0,0,0,3"></TextBlock>
-					<ComboBox ItemsSource="{Binding ToolItems}" Width="180" SelectedIndex="{Binding ToolIndex}"></ComboBox>
-					<Button Command="{Binding OpenTool}" HorizontalAlignment="Center" Margin="2" Width="150">Open</Button>
+					<ComboBox ItemsSource="{Binding ToolItems}" Width="155" SelectedIndex="{Binding ToolIndex}"></ComboBox>
+					<Button Classes="Primary" Command="{Binding OpenTool}" HorizontalAlignment="Center" Margin="2" Width="150">Open</Button>
 				</StackPanel>
 			</StackPanel>
 		</ScrollViewer>

--- a/Knossos.NET/Views/Templates/DevModEditorView.axaml
+++ b/Knossos.NET/Views/Templates/DevModEditorView.axaml
@@ -13,8 +13,8 @@
 	</Design.DataContext>
 
 	<Grid ColumnDefinitions="Auto,*">
-		<ScrollViewer Width="210" Grid.Column="0">
-			<StackPanel Width="210" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+		<ScrollViewer Width="190" Grid.Column="0">
+			<StackPanel Width="190" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
 				<TextBlock HorizontalAlignment="Center" Text="{Binding Name}" FontSize="14" FontWeight="Bold" TextWrapping="Wrap" Margin="0"></TextBlock>
 				<Image HorizontalAlignment="Center" Margin="10" Source="{Binding ModImage}" Width="150" Height="225"></Image>
 				<TextBlock HorizontalAlignment="Center" Text="Active Version" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0"></TextBlock>
@@ -35,7 +35,7 @@
 				<!--Tools-->
 				<StackPanel IsVisible="true" Margin="20,10,20,10" HorizontalAlignment="Center">
 					<TextBlock HorizontalAlignment="Center" Text="Tools" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0,0,0,3"></TextBlock>
-					<ComboBox ItemsSource="{Binding ToolItems}" Width="220" SelectedIndex="{Binding ToolIndex}"></ComboBox>
+					<ComboBox ItemsSource="{Binding ToolItems}" Width="180" SelectedIndex="{Binding ToolIndex}"></ComboBox>
 					<Button Command="{Binding OpenTool}" HorizontalAlignment="Center" Margin="2" Width="150">Open</Button>
 				</StackPanel>
 			</StackPanel>

--- a/Knossos.NET/Views/Templates/DevModEditorView.axaml
+++ b/Knossos.NET/Views/Templates/DevModEditorView.axaml
@@ -35,8 +35,8 @@
 				<!--Tools-->
 				<StackPanel IsVisible="true" Margin="20,10,20,10" HorizontalAlignment="Center">
 					<TextBlock HorizontalAlignment="Center" Text="Tools" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0,0,0,3"></TextBlock>
-					<ComboBox ItemsSource="{Binding ToolItems}" Width="155" SelectedIndex="{Binding ToolIndex}"></ComboBox>
-					<Button Classes="Primary" Command="{Binding OpenTool}" HorizontalAlignment="Center" Margin="2" Width="150">Open</Button>
+					<ComboBox ItemsSource="{Binding ToolItems}" Width="154" SelectedIndex="{Binding ToolIndex}"></ComboBox>
+					<Button Classes="Primary" Command="{Binding OpenTool}" HorizontalAlignment="Center" Margin="2,4,0,0" Width="150">Open</Button>
 				</StackPanel>
 			</StackPanel>
 		</ScrollViewer>

--- a/Knossos.NET/Views/Templates/DevModFsoSettingsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModFsoSettingsView.axaml
@@ -20,7 +20,7 @@
 			<v:FsoBuildPickerView Content="{Binding FsoPicker}"/>
 			<Label Foreground="Yellow">*This is only used locally, the FSO build setting on this tab is not uploaded to nebula.</Label>
 			<Label Foreground="Yellow" Margin="6,0,0,0">Use a package dependency to set the fso build version for players.</Label>
-			<Label Margin="0,50,0,0" FontWeight="Black" FontSize="20">Mod CmdLine</Label>
+			<Label Margin="0,30,0,0" FontWeight="Black" FontSize="20">Mod CmdLine</Label>
 			<TextBox Text="{Binding CmdLine}" IsVisible="{Binding !ConfigureBuildOpen}" Margin="5,20,0,0" FontSize="14"/>			
 			<Button IsVisible="{Binding !ConfigureBuildOpen}" Command="{Binding ConfigureBuild}" Margin="5" FontSize="18" Classes="Secondary">Open Flag Configuration</Button>
 			<v:FsoFlagsView Content="{Binding FsoFlags}"/>

--- a/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
+++ b/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
@@ -44,23 +44,27 @@
 						<WrapPanel>
 							<CheckBox ToolTip.Tip="If package is enabled or disabled. Disabled packages are not used when playing." IsChecked="{Binding IsEnabled}" VerticalContentAlignment="Center" HorizontalContentAlignment="Center"></CheckBox>
 							<Label MinWidth="250" FontWeight="Bold" FontSize="18" Content="{Binding Package.name}" VerticalContentAlignment="Center" HorizontalContentAlignment="Left"></Label>
-							<Button Command="{Binding OpenModPackageFolder}" Margin="10,0,0,0">Open Folder</Button>
-							<Button Command="{Binding AddModDependency}" Margin="10,0,0,0">+Dependency</Button>
-							<Button Margin="10,0,0,0" Content="Notes">
+						</WrapPanel>
+						<WrapPanel Margin="10,0,0,7">
+							<Button Command="{Binding OpenModPackageFolder}" >Open Folder</Button>
+							<Button Command="{Binding AddModDependency}" Margin="8,0,0,0">+Dependency</Button>
+							<Button Margin="8,0,0,0" Content="Notes">
 								<Button.Flyout>
 									<Flyout>
 										<TextBox Text="{Binding PackageNotes}" Width="250" MinHeight="100" TextWrapping="Wrap"></TextBox>
 									</Flyout>
 								</Button.Flyout>
 							</Button>
+						</WrapPanel>
+						<WrapPanel>
 							<ComboBox Margin="10,0,0,0" SelectedIndex="{Binding PackageStatusIndex}" MinWidth="130" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Background="White" Foreground="Black">
 								<ComboBoxItem ToolTip.Tip="Always installed with the mod, in fact these are the base files of the mod">Required</ComboBoxItem>
 								<ComboBoxItem ToolTip.Tip="Automatically selected for installation, but the user can skip them">Recommended</ComboBoxItem>
 								<ComboBoxItem ToolTip.Tip="Not automatically selected, but user can add them during the install process">Optional</ComboBoxItem>
 							</ComboBox>
 							<CheckBox IsChecked="{Binding PackVP}" Margin="10,0,0,0" ToolTip.Tip="Whether Knossos should pack the files in a VP on upload.&#x0a;Warning: VPs have a 2GB total size limit.">Make VP</CheckBox>
-							<Label FontSize="16" Margin="5" ToolTip.Tip="Current package folder size" Foreground="Yellow" Content="{Binding DiskSpace}"/>
-							<Button Command="{Binding DeleteModPkg}" Margin="20,0,0,0" Classes="Cancel">Delete</Button>
+							<Label FontSize="16" Margin="5,6,5,5" ToolTip.Tip="Current package folder size" Foreground="Yellow" Content="{Binding DiskSpace}"/>
+							<Button HorizontalAlignment="Right" Command="{Binding DeleteModPkg}" Margin="10,0,0,10" Classes="Cancel">Delete</Button>
 						</WrapPanel>
 						<!--Pkg Dependency List-->
 						<ItemsControl ItemsSource="{Binding DependencyItems}" Margin="0,5,0,0">
@@ -70,12 +74,12 @@
 									<Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto">
 										<Label Margin="30,0,0,0" Grid.Column="0" FontSize="18" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">&#x21B3;</Label>
 										<ComboBox SelectedIndex="{Binding ModSelectedIndex}" ItemsSource="{Binding ModItems}" Grid.Column="1" HorizontalAlignment="Stretch" Margin="5,2,2,2" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black"></ComboBox>
-										<ComboBox SelectedIndex="{Binding VersionTypeIndex}" Grid.Column="2" MinWidth="75" Margin="2" FontWeight="Bold" FontSize="16" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black">
+										<ComboBox SelectedIndex="{Binding VersionTypeIndex}" Grid.Column="2" MinWidth="60" Margin="2" FontWeight="Bold" FontSize="16" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black">
 											<ComboBoxItem ToolTip.Tip="Only the selected version">==</ComboBoxItem>
 											<ComboBoxItem ToolTip.Tip="Higher or equal than the selected version">>=</ComboBoxItem>
 											<ComboBoxItem ToolTip.Tip="Same minor version, revision equal or better:&#x0a;Dependency: ~1.5.2&#x0a;1.5.1 ->Not Valid&#x0a;1.5.6 -> Valid&#x0a;1.6.0 -> Not valid">~</ComboBoxItem>
 										</ComboBox>
-										<ComboBox SelectedIndex="{Binding VersionSelectedIndex}" ItemsSource="{Binding VersionItems}" Grid.Column="3" MinWidth="150" Margin="2" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black"></ComboBox>
+										<ComboBox SelectedIndex="{Binding VersionSelectedIndex}" ItemsSource="{Binding VersionItems}" Grid.Column="3" MinWidth="75" Margin="2" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black"></ComboBox>
 										<!--Packages-->
 										<Button IsVisible="{Binding DisplayPackages}" Grid.Column="4" Margin="5,0,2,0" Content="Packages">
 											<Button.Flyout>

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -45,11 +45,13 @@
 			</ListBox.ItemTemplate>
 		</ListBox>
 		<Label Grid.Row="2" HorizontalAlignment="Center">Actions for Active Version</Label>
-		<WrapPanel Grid.Row="3" Margin="5" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+		<WrapPanel Grid.Row="3" Margin="30" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
 			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept" Margin="0,5,5,5">Upload to Nebula</Button>
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="10,5,5,5"/>
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="10,5,5,5">Delete from Nebula</Button>
-			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="10,5,5,5">Delete Locally</Button>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="20,5,5,5"/>
+		</WrapPanel>
+		<WrapPanel Grid.Row="3" Margin="22,80" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="0,5,5,5">Delete from Nebula</Button>
+			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="18,5,5,5">Delete Locally</Button>
 		</WrapPanel>
 	</Grid>
 	

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -49,7 +49,7 @@
 			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept" Margin="0,5,5,5">Upload to Nebula</Button>
 			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="20,5,5,5"/>
 		</WrapPanel>
-		<WrapPanel Grid.Row="3" Margin="22,80" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+		<WrapPanel Grid.Row="3" Margin="15,65" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
 			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="0,5,5,5">Delete from Nebula</Button>
 			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="18,5,5,5">Delete Locally</Button>
 		</WrapPanel>

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -12,6 +12,7 @@
 		<vm:DevModVersionsViewModel/>
 	</Design.DataContext>
 
+	<StackPanel>
 	<Grid RowDefinitions="Auto,*, Auto, Auto" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
 		<WrapPanel IsEnabled="{Binding ButtonsEnabled}" Grid.Row="0" Margin="10" HorizontalAlignment="Center">
 			<Button Classes="Primary" Content="New Version" x:Name="CreateVersion">
@@ -32,7 +33,7 @@
 			<Button Command="{Binding LoadVersionsFromNebula}" Classes="Option" Margin="20,0,0,0">Install or Modify</Button>
 			<Button Command="{Binding DeleteAll}" Classes="Cancel" Margin="20,0,0,0">Delete Mod</Button>
 		</WrapPanel>
-		<ListBox Background="{StaticResource BackgroundColorSecondary}" IsEnabled="{Binding ButtonsEnabled}" Margin="10,0,10,10" Grid.Row="1" ItemsSource="{Binding Mods}" SelectedIndex="{Binding SelectedIndex}" HorizontalAlignment="Stretch" >
+		<ListBox Background="{StaticResource BackgroundColorSecondary}" IsEnabled="{Binding ButtonsEnabled}" Margin="10,0,10,10" Grid.Row="1" ItemsSource="{Binding Mods}" SelectedIndex="{Binding SelectedIndex}" HorizontalAlignment="Stretch" MinHeight="180">
 			<ListBox.ItemTemplate>
 				<DataTemplate>
 					<WrapPanel>
@@ -44,15 +45,16 @@
 				</DataTemplate>
 			</ListBox.ItemTemplate>
 		</ListBox>
-		<Label Grid.Row="2" HorizontalAlignment="Center">Actions for Active Version</Label>
-		<WrapPanel Grid.Row="3" Margin="30" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept" Margin="0,5,5,5">Upload to Nebula</Button>
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="20,5,5,5"/>
-		</WrapPanel>
-		<WrapPanel Grid.Row="3" Margin="15,65" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="0,5,5,5">Delete from Nebula</Button>
-			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="18,5,5,5">Delete Locally</Button>
-		</WrapPanel>
+		<Label Grid.Row="2" Margin="0,5,0,0" HorizontalAlignment="Center">Actions for Active Version</Label>
 	</Grid>
+	<WrapPanel Margin="12,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept">Upload to Nebula</Button>
+		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="24,0,0,0"/>
+	</WrapPanel>
+	<WrapPanel Margin="1,8,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="0,0,5,0">Delete from Nebula</Button>
+		<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="18,0,0,0">Delete Locally</Button>
+	</WrapPanel>
+	</StackPanel>
 	
 </UserControl>

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -47,8 +47,8 @@
 		</ListBox>
 		<Label Grid.Row="2" Margin="0,5,0,0" HorizontalAlignment="Center">Actions for Active Version</Label>
 	</Grid>
-	<WrapPanel Margin="11,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept">Upload to Nebula</Button>
+	<WrapPanel Margin="0,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+		<Button Width="146" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept">Upload to Nebula</Button>
 		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="24,0,0,0"/>
 	</WrapPanel>
 	<WrapPanel Margin="0,8,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -45,11 +45,11 @@
 			</ListBox.ItemTemplate>
 		</ListBox>
 		<Label Grid.Row="2" HorizontalAlignment="Center">Actions for Active Version</Label>
-		<WrapPanel Grid.Row="3" Margin="10" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+		<WrapPanel Grid.Row="3" Margin="5" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
 			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept" Margin="0,5,5,5">Upload to Nebula</Button>
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="20,5,5,5"/>
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="20,5,5,5">Delete from Nebula</Button>
-			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="20,5,5,5">Delete Locally</Button>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="10,5,5,5"/>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="10,5,5,5">Delete from Nebula</Button>
+			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="10,5,5,5">Delete Locally</Button>
 		</WrapPanel>
 	</Grid>
 	

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -47,11 +47,11 @@
 		</ListBox>
 		<Label Grid.Row="2" Margin="0,5,0,0" HorizontalAlignment="Center">Actions for Active Version</Label>
 	</Grid>
-	<WrapPanel Margin="12,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+	<WrapPanel Margin="11,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
 		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Accept">Upload to Nebula</Button>
 		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Secondary" Margin="24,0,0,0"/>
 	</WrapPanel>
-	<WrapPanel Margin="1,8,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+	<WrapPanel Margin="0,8,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
 		<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="0,0,5,0">Delete from Nebula</Button>
 		<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="18,0,0,0">Delete Locally</Button>
 	</WrapPanel>

--- a/Knossos.NET/Views/Templates/FsoFlagsView.axaml
+++ b/Knossos.NET/Views/Templates/FsoFlagsView.axaml
@@ -14,11 +14,11 @@
 
 	<StackPanel>
 		<Label>Global Settings:</Label>
-		<TextBox Text="{Binding GlobalCmd}" TextWrapping="Wrap" Height="50" Foreground="White" IsReadOnly="True"></TextBox>
+		<TextBox  Margin="5" HorizontalAlignment="Stretch" Text="{Binding GlobalCmd}" TextWrapping="Wrap" Height="50" Foreground="White" IsReadOnly="True"></TextBox>
 		<Label FontSize="11">Global settings flags and values will always be added to the command line at launch and will override any custom value of the same flag here.</Label>
 		
 		<Label>Cmdline:</Label>
-		<TextBox Text="{Binding CmdLine}" TextWrapping="Wrap" Height="100" Foreground="White"></TextBox>
+		<TextBox  Margin="5" HorizontalAlignment="Stretch" Text="{Binding CmdLine}" TextWrapping="Wrap" Height="100" Foreground="White"></TextBox>
 		
 		<TreeView ItemsSource="{Binding Flags}">
 			<TreeView.DataTemplates>


### PR DESCRIPTION
This adjust a lot of spacing in the details sub tab to make it look fine in the default resolution and keeps them looking good by disallowing them from moving when the size is changed.

Images of changes:
![Screen Shot 2023-11-23 at 11 18 59 PM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/6eb46290-3a11-49ab-9fa1-56f2a7668e95)

![Screen Shot 2023-11-23 at 11 19 05 PM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/a5864a61-c67b-4f77-aff1-58050274aa52)

![Screen Shot 2023-11-23 at 11 16 03 PM](https://github.com/KnossosNET/Knossos.NET/assets/12529946/2142fdeb-2e53-4bef-a3b0-0f33013e9175)
