### PR TITLE
Two Fixes

### DIFF
--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -218,7 +218,7 @@
 						<!-- VSYNC -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">VSync</Label> 
-							<CheckBox Tag="-no_vsync" IsChecked="{Binding !Vsync}"></CheckBox>
+							<CheckBox Tag="-no_vsync" IsChecked="{Binding Vsync}"></CheckBox>
 						</WrapPanel>
 						<!-- FPS Cap -->
 						<WrapPanel>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -16,10 +16,10 @@
 		<Border Margin="0,5,0,5" Grid.Row="0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
-					<Button Command="{Binding QuickSetupCommand}" FontSize="22" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
+					<Button Command="{Binding QuickSetupCommand}" FontSize="20" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
 					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="510,0,0,0" Classes="Cancel">Reset</Button>
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
-					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="22" Classes="Accept" Margin="10,0,0,0">Save</Button>
+					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="20" Classes="Accept" Margin="10,0,0,0">Save</Button>
 				</WrapPanel>
 				<TextBlock Margin="10,15,3,3" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please navigate to another tab before playing, as this tab constantly scans for option file changes.</TextBlock>
 			</StackPanel>

--- a/Knossos.NET/Views/Windows/ModSettingsView.axaml
+++ b/Knossos.NET/Views/Windows/ModSettingsView.axaml
@@ -40,7 +40,7 @@
 					<TextBlock Margin="5,0,0,0" TextWrapping="Wrap" Foreground="Red" Text="{Binding BuildMissingWarning}"/>
 					<Button IsVisible="{Binding !ConfigureBuildOpen}" Command="{Binding ConfigureBuildCommand}" Margin="5" FontWeight="Bold" FontSize="18" Classes="Secondary">Configure</Button>
 					<v:FsoFlagsView Content="{Binding FsoFlags}"/>
-					<CheckBox IsChecked="{Binding IgnoreGlobalCmd}" Margin="5,5,0,0" ToolTip.Tip="This means that global settings and global cmdline is not applied to the mod.">Do not apply settings or global cmdline on this mod</CheckBox>
+					<CheckBox IsChecked="{Binding IgnoreGlobalCmd}" Margin="5,5,0,0" ToolTip.Tip="This means that global settings and global Command Line is not applied to the mod.">Do not apply global settings or global Command Line on this mod</CheckBox>
 					<!--FSO Build END -->
 						
 					<!--Dependencies Settings-->


### PR DESCRIPTION
The logic for `vsync` was backwards, as checking the vsync box on incorrectly set the `no_vsync` flag on. This PR fixes that, and tests confirm it not works as expected.

Also updates the user-facing wording of `cmdline` to now match the `Command Line` wording that is shown in the updated Settings tab.