### PR TITLE
Remove span html, remove list hack

### DIFF
--- a/Knossos.NET/Classes/BBCode.cs
+++ b/Knossos.NET/Classes/BBCode.cs
@@ -101,11 +101,11 @@ namespace BBcodes
                     _rules.Add(new BBCodeRules("[br]", "<br>", ""));
                     _rules.Add(new BBCodeRules("[hr]", "<hr><br>", ""));
 
-                    _rules.Add(new BBCodeRules("[list]", "<ul>", ""));
+                    _rules.Add(new BBCodeRules("[list]", "<ul style='padding-top:-30px;'>", ""));
                     _rules.Add(new BBCodeRules("[/list]", "</ul>", ""));
-                    _rules.Add(new BBCodeRules("[ul]", "<ul>", ""));
+                    _rules.Add(new BBCodeRules("[ul]", "<ul style='padding-top:-30px;'>", ""));
                     _rules.Add(new BBCodeRules("[/ul]", "</ul>", ""));
-                    _rules.Add(new BBCodeRules("[ol]", "<ol>", ""));
+                    _rules.Add(new BBCodeRules("[ol]", "<ol style='padding-top:-30px;'>", ""));
                     _rules.Add(new BBCodeRules("[/ol]", "</ol>", ""));
                     _rules.Add(new BBCodeRules("[li]", "<li>", ""));
                     _rules.Add(new BBCodeRules("[/li]", "</li>", ""));
@@ -212,7 +212,6 @@ namespace BBcodes
             //input = input.Replace("\r\n", "<br />");
             //input = input.Replace("\r", "<br />");
             //input = input.Replace("\n", "<br />");
-            input = input.Replace("[*]", "<br />");
             return input;
         }
 

--- a/Knossos.NET/ViewModels/Windows/DevModDescriptionEditorViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/DevModDescriptionEditorViewModel.cs
@@ -29,7 +29,7 @@ namespace Knossos.NET.ViewModels
                     try
                     {
                         var html = BBCode.ConvertToHtml(Description, BBCode.BasicRules);
-                        DescriptionHtml = "<body style=\"overflow: hidden;\"><span style=\"white-space: pre-line;color:white;overflow: hidden;\">" + html + "</span></body>";
+                        DescriptionHtml = "<body style='overflow: hidden;white-space: pre-line;color:white;text-align: left;'>" + html + "</body>";
                     }
                     catch (Exception ex) 
                     {

--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -218,7 +218,7 @@ namespace Knossos.NET.ViewModels
                     if (modVersions[index].description != null)
                     {
                         var html = BBCode.ConvertToHtml(modVersions[index].description!, BBCode.BasicRules);
-                        Description = "<body style=\"overflow: hidden;\"><span style=\"white-space: pre-line;color:white;overflow: hidden;\">" + html + "</span></body>";
+                        Description = "<body style='overflow: hidden;white-space: pre-line;color:white;text-align: left;'>" + html + "</body>";
                         //Log.WriteToConsole(html);
                     }
                     if (modVersions[index].owners != null && modVersions[index].owners!.Any()) 

--- a/Knossos.NET/Views/Windows/DevModDescriptionEditorView.axaml
+++ b/Knossos.NET/Views/Windows/DevModDescriptionEditorView.axaml
@@ -32,8 +32,8 @@
 					<Button Command="{Binding ToolBar}" CommandParameter="[hr]" ToolTip.Tip="Horizontal Line [hr]">Line</Button>
 					<Label VerticalContentAlignment="Center">-</Label>
 					<Button Command="{Binding ToolBar}" CommandParameter="[list]&#x0a;	Element&#x0a;	Element&#x0a;	Element&#x0a;[/list]" ToolTip.Tip="Simple List:&#x0a;[list]&#x0a;	Element&#x0a;	Element&#x0a;	Element&#x0a;[/list]">SList</Button>
-					<Button Command="{Binding ToolBar}" CommandParameter="[ul]&#x0a;[*]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[/ul]" ToolTip.Tip="Unordered List:&#x0a;[ul]&#x0a; [*] -> (HtmlRenderer bug workaround)&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;[/ul]">UList</Button>
-					<Button Command="{Binding ToolBar}" CommandParameter="[ol]&#x0a;[*]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[/ol]" ToolTip.Tip="Ordered List:&#x0a;[ol]&#x0a; [*] -> (HtmlRenderer bug workaround)&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;[/ol]">OList</Button>
+					<Button Command="{Binding ToolBar}" CommandParameter="[ul]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[/ul]" ToolTip.Tip="Unordered List:&#x0a;[ul]&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;[/ul]">UList</Button>
+					<Button Command="{Binding ToolBar}" CommandParameter="[ol]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[li]Element[/li]&#x0a;[/ol]" ToolTip.Tip="Ordered List:&#x0a;[ol]&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;	[li]Element[/li]&#x0a;[/ol]">OList</Button>
 					<Label VerticalContentAlignment="Center">-</Label>
 					<Button Command="{Binding ToolBar}" CommandParameter="[left]Align left[/left]" ToolTip.Tip="Align: Left &#x0a;[left][/left]">Left</Button>
 					<Button Command="{Binding ToolBar}" CommandParameter="[center]Align center[/center]" ToolTip.Tip="Align: Center &#x0a;[center][/center]">Center</Button>


### PR DESCRIPTION
It looks like it was the span element what was breaking lists. This was completelty breaking some descriptions like of inferno classic

before:
![image](https://github.com/KnossosNET/Knossos.NET/assets/2444336/8ef1eaac-5466-4d78-9412-5a7cfef29b16)

after:
![image](https://github.com/KnossosNET/Knossos.NET/assets/2444336/f62193dd-ba60-472c-b7b7-85b3a08d1ffd)
