### PR TITLE
Fix three small button issues

### DIFF
--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -18,7 +18,7 @@
 				<WrapPanel Margin="0,10,0,0">
 					<Button Command="{Binding QuickSetupCommand}" FontSize="20" Background="Black" Margin="5,0,0,0">Quick Setup Guide</Button>
 					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="510,0,0,0" Classes="Cancel">Reset</Button>
-					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
+					<Button Command="{Binding ReloadFlagData}" FontSize="20" Margin="10,0,0,0">Reload Data</Button>
 					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="20" Classes="Accept" Margin="10,0,0,0">Save</Button>
 				</WrapPanel>
 				<TextBlock Margin="10,15,3,3" TextWrapping="Wrap" FontSize="16" VerticalAlignment="Center" >Please navigate to another tab before playing, as this tab constantly scans for option file changes.</TextBlock>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -16,7 +16,7 @@
 		<Border Margin="0,5,0,5" Grid.Row="0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
-					<Button Command="{Binding QuickSetupCommand}" FontSize="20" Background="Black" Margin="5,0,0,0" Classes="Secondary">Quick Setup Guide</Button>
+					<Button Command="{Binding QuickSetupCommand}" FontSize="20" Background="Black" Margin="5,0,0,0">Quick Setup Guide</Button>
 					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="510,0,0,0" Classes="Cancel">Reset</Button>
 					<Button Command="{Binding ReloadFlagData}" Foreground="White" FontSize="20" Background="Black" Margin="10,0,0,0" Classes="Option">Reload Data</Button>
 					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="20" Classes="Accept" Margin="10,0,0,0">Save</Button>

--- a/Knossos.NET/Views/Windows/ModDetailsView.axaml
+++ b/Knossos.NET/Views/Windows/ModDetailsView.axaml
@@ -79,7 +79,7 @@
 		<!--Screenshoots/Video-->
 		<Grid MaxWidth="1600" ColumnDefinitions="Auto,*,Auto" Grid.Row="3" Margin="20" IsVisible="{Binding Screenshots.Count}">
 			<Button Name="left" Grid.Column="0" VerticalAlignment="Center" Padding="10,20" Margin="4">
-				<Path Data="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z" Fill="Black"/>
+				<Path Data="M20,11V13H8L13.5,18.5L12.08,19.92L4.16,12L12.08,4.08L13.5,5.5L8,11H20Z" Fill="White"/>
 			</Button>
 			<Carousel Name="carousel" Grid.Column="1" ItemsSource="{Binding Screenshots}">
 				<Carousel.PageTransition>
@@ -97,7 +97,7 @@
 				</Carousel.DataTemplates>
 			</Carousel>
 			<Button Name="right" Grid.Column="2" VerticalAlignment="Center" Padding="10,20" Margin="4">
-				<Path Data="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z" Fill="Black"/>
+				<Path Data="M4,11V13H16L10.5,18.5L11.92,19.92L19.84,12L11.92,4.08L10.5,5.5L16,11H4Z" Fill="White"/>
 			</Button>
 		</Grid>
 	</Grid>


### PR DESCRIPTION
The left and right arrows for screenshots in the mod details screen were never changed to white, and two buttons had extra color details in the options screen.  This fixes both of those things.