### PR TITLE
Remove unnecessary Task.Run and await during loose files decompression

### DIFF
--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -1860,7 +1860,7 @@ namespace Knossos.NET.ViewModels
                                 throw new TaskCanceledException();
                             }
 
-                            var compressedSize = await Task.Run(async () => VPCompression.DecompressStream(input, output));
+                            VPCompression.DecompressStream(input, output);
 
                             //Delete original
                             input.Dispose();


### PR DESCRIPTION
This was not needed and just creating a warning