### PR TITLE
Refresh the ini if preferred path changes

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -128,6 +128,10 @@ namespace Knossos.NET
             }
             else
             {
+                if (KnUtils.isMacOS){
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "HardLightProductions", "FreeSpaceOpen");
+                }
+
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "HardLightProductions", "FreeSpaceOpen");
             }
 

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -189,7 +189,13 @@ namespace Knossos.NET.ViewModels
         /// </summary>
         public void LoadData()
         {
+            var old_path = KnUtils.GetFSODataFolderPath();
             var flagData = GetFlagData();
+
+            // reset the ini info if we have gotten an updated preferred path from FSO.
+            if (old_path != KnUtils.GetFSODataFolderPath()){
+                Knossos.globalSettings.Load();
+            }
             /* Knossos Settings */
             if (Knossos.globalSettings.basePath != null)
             {


### PR DESCRIPTION
So, this took a little while to figure out.  The symptom was that KNet was only respecting my resolution once I had at least opened the settings tab.  The settings tab was reloading the ini from an updated preferred path from the FSO executable.  KNet was not using this preferred path when it first attempted to load the ini because the load order is ini and default settings first, then executables, then flags.  It would get the preferred path in flags.

This PR allows KNet to reload the ini if the preferred path changes.  Now, I believe this should allow KNet to load the correct ini whenever the preferred path from the executable changes, although I believe this would only be true if the user switches to portable mode.

Fixes #80

In draft, until I have confirmation that this does not break anything.