### PR TITLE
Set progress when decompress is complete

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -694,6 +694,8 @@ namespace Knossos.NET
 
                 if (!result)
                     cancellationTokenSource?.Cancel();
+                else 
+                    progressCallback?.Invoke(100);
 
                 return result;
             });


### PR DESCRIPTION
Since it looks like the value from the progress values from the decompression wrappers is a little borked at random times, we should manually set this progress bar to 100 when the decompression task is finished so that we don't get a UI bug.

Fixes #81 