### PR TITLE
Change guessed path of FSO data folder in linux

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -131,7 +131,10 @@ namespace Knossos.NET
                 if (KnUtils.isMacOS){
                     return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "HardLightProductions", "FreeSpaceOpen");
                 }
-
+                if(IsLinux)
+                {
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "HardLightProductions", "FreeSpaceOpen");
+                }
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "HardLightProductions", "FreeSpaceOpen");
             }
 


### PR DESCRIPTION
This should fix the initial saving of the fs2_open.ini to a wrong path if the fso pref path is not yet avalible..