### PR TITLE
Make the search bar retain search terms between tabs

### DIFF
--- a/Knossos.NET/ViewModels/ModListViewModel.cs
+++ b/Knossos.NET/ViewModels/ModListViewModel.cs
@@ -32,24 +32,26 @@ namespace Knossos.NET.ViewModels
             get { return search; }
             set 
             {
-                this.SetProperty(ref search, value);
-                if (value.Trim() != string.Empty)
-                {
-                    foreach(var mod in Mods)
+                if (value != Search){
+                    this.SetProperty(ref search, value);
+                    if (value.Trim() != string.Empty)
                     {
-                        if( mod.Name != null && mod.Name.ToLower().Contains(value.ToLower()))
+                        foreach(var mod in Mods)
                         {
-                            mod.Visible = true;
-                        }
-                        else
-                        {
-                            mod.Visible = false;
+                            if( mod.Name != null && mod.Name.ToLower().Contains(value.ToLower()))
+                            {
+                                mod.Visible = true;
+                            }
+                            else
+                            {
+                                mod.Visible = false;
+                            }
                         }
                     }
-                }
-                else
-                {
-                    Mods.ForEach(m => m.Visible = true);
+                    else
+                    {
+                        Mods.ForEach(m => m.Visible = true);
+                    }
                 }
             }
         }

--- a/Knossos.NET/ViewModels/NebulaModListViewModel.cs
+++ b/Knossos.NET/ViewModels/NebulaModListViewModel.cs
@@ -77,7 +77,7 @@ namespace Knossos.NET.ViewModels
         /// <summary>
         /// Open the tab and slowly display modcards to avoid ui lock
         /// </summary>
-        public async void OpenTab()
+        public async void OpenTab(string newSearch)
         {
             if (IsLoading)
             {
@@ -115,8 +115,8 @@ namespace Knossos.NET.ViewModels
                     Log.Add(Log.LogSeverity.Error, "NebulaModListViewModel.OpenTab", ex);
                 }
 
-
             }
+            Search = newSearch;
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Knossos.NET.ViewModels
                 if (IsTabOpen)
                 {
                     IsTabOpen = false;
-                    OpenTab();
+                    OpenTab(search);
                 }
             });
         }

--- a/Knossos.NET/ViewModels/NebulaModListViewModel.cs
+++ b/Knossos.NET/ViewModels/NebulaModListViewModel.cs
@@ -45,24 +45,26 @@ namespace Knossos.NET.ViewModels
             get { return search; }
             set 
             {
-                this.SetProperty(ref search, value);
-                if (value.Trim() != string.Empty)
-                {
-                    foreach(var mod in Mods)
+                if (value != Search){
+                    this.SetProperty(ref search, value);
+                    if (value.Trim() != string.Empty)
                     {
-                        if( mod.Name != null && mod.Name.ToLower().Contains(value.ToLower()))
+                        foreach(var mod in Mods)
                         {
-                            mod.Visible = true;
-                        }
-                        else
-                        {
-                            mod.Visible = false;
+                            if( mod.Name != null && mod.Name.ToLower().Contains(value.ToLower()))
+                            {
+                                mod.Visible = true;
+                            }
+                            else
+                            {
+                                mod.Visible = false;
+                            }
                         }
                     }
-                }
-                else
-                {
-                    Mods.ForEach(m => m.Visible = true);
+                    else
+                    {
+                        Mods.ForEach(m => m.Visible = true);
+                    }
                 }
             }
         }

--- a/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 
 namespace Knossos.NET.ViewModels
 {
@@ -37,6 +38,8 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string uiConsoleOutput = string.Empty;
 
+        internal string sharedSearch = string.Empty;
+
         internal int tabIndex = 0;
         internal int TabIndex
         {
@@ -46,10 +49,25 @@ namespace Knossos.NET.ViewModels
                 /* Execute code when user changes tab */
                 if (value != tabIndex)
                 {
+                    // Things to do on tab exit
+                    if (tabIndex == 0) //Exiting the Play tab.
+                    {
+                        sharedSearch = InstalledModsView.Search;
+                    }
+                    if (tabIndex == 1) //Exiting the Nebula tab.
+                    {
+                        sharedSearch =  NebulaModsView.Search;
+                    }
+
+                    // Things to do on tab entrance
                     this.SetProperty(ref tabIndex, value);
+                    if (tabIndex == 0) //Play Tab
+                    {
+                        InstalledModsView.Search = sharedSearch;
+                    }
                     if (tabIndex == 1) //Nebula Mods
                     {
-                        NebulaModsView.OpenTab();
+                        NebulaModsView.OpenTab(sharedSearch);
                     }
                     if (tabIndex == 4) //PXO
                     {


### PR DESCRIPTION
This stores the most recent search text from the play and nebula tabs in the Main View Model, and seems to avoid any issues loading the Nebula tab tiles.  