### PR TITLE
Add cleanup old mod versions option to mod install

### DIFF
--- a/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
+++ b/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
@@ -111,7 +111,7 @@ namespace Knossos.NET.ViewModels
         /// Resets the mod editor
         /// Reloads the currently loaded mod in editor if it matches the passed id, null for always
         /// </summary>
-        /// <param name="mod"></param>
+        /// <param name="modid"></param>
         public void ResetModEditor(string? modid = null)
         {
             if (ModEditor != null && ( modid == null || modid == ModEditor.ActiveVersion.id))

--- a/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
+++ b/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
@@ -108,6 +108,20 @@ namespace Knossos.NET.ViewModels
         }
 
         /// <summary>
+        /// Resets the mod editor
+        /// Reloads the currently loaded mod in editor if it matches the passed id, null for always
+        /// </summary>
+        /// <param name="mod"></param>
+        public void ResetModEditor(string? modid = null)
+        {
+            if (ModEditor != null && ( modid == null || modid == ModEditor.ActiveVersion.id))
+            {
+                ModEditor = new DevModEditorViewModel();
+                ModEditor.StartModEditor(Mods[selectedIndex]);
+            }
+        }
+
+        /// <summary>
         /// Delete a mod from the Dev Mod list
         /// </summary>
         /// <param name="modid"></param>

--- a/Knossos.NET/ViewModels/ModListViewModel.cs
+++ b/Knossos.NET/ViewModels/ModListViewModel.cs
@@ -237,5 +237,26 @@ namespace Knossos.NET.ViewModels
                 Mods.Remove(modCard);
             }
         }
+
+        /// <summary>
+        /// Deletes a specific mod version from the UI modcard version list
+        /// IF this is the last version of a mod the modcard will be deleted instead
+        /// </summary>
+        /// <param name="mod"></param>
+        public void RemoveModVersion(Mod mod)
+        {
+            var modCard = Mods.FirstOrDefault(m => m.ID == mod.id);
+            if (modCard != null)
+            {
+                if(modCard.GetNumberOfModVersions() > 1)
+                {
+                    modCard.DeleteModVersion(mod);
+                }
+                else
+                {
+                    Mods.Remove(modCard);
+                }
+            }
+        }
     }
 }

--- a/Knossos.NET/ViewModels/TaskViewModel.cs
+++ b/Knossos.NET/ViewModels/TaskViewModel.cs
@@ -208,7 +208,7 @@ namespace Knossos.NET.ViewModels
         /// <param name="mod"></param>
         /// <param name="reinstallPkgs"></param>
         /// <param name="manualCompress"></param>
-        public async void InstallMod(Mod mod, List<ModPackage>? reinstallPkgs = null, bool manualCompress = false)
+        public async void InstallMod(Mod mod, List<ModPackage>? reinstallPkgs = null, bool manualCompress = false, bool cleanupOldVersions = false)
         {
             if (Knossos.GetKnossosLibraryPath() == null)
             {
@@ -234,7 +234,7 @@ namespace Knossos.NET.ViewModels
                         TaskList.Add(newTask);
                         taskQueue.Enqueue(newTask);
                     });
-                    await newTask.InstallMod(mod, cancelSource, reinstallPkgs, manualCompress).ConfigureAwait(false);
+                    await newTask.InstallMod(mod, cancelSource, reinstallPkgs, manualCompress, cleanupOldVersions).ConfigureAwait(false);
                 }
             }
         }

--- a/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
@@ -180,6 +180,15 @@ namespace Knossos.NET.ViewModels
         }
 
         /// <summary>
+        /// Remove a installed mod version from the modcard UI
+        /// </summary>
+        /// <param name="mod"></param>
+        public void RemoveInstalledModVersion(Mod mod)
+        {
+            InstalledModsView.RemoveModVersion(mod);
+        }
+
+        /// <summary>
         /// Load settings to settings tab
         /// </summary>
         public void GlobalSettingsLoadData()

--- a/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
@@ -50,6 +50,10 @@ namespace Knossos.NET.ViewModels
         internal string installSize = string.Empty;
         [ObservableProperty]
         internal string freeSpace = string.Empty;
+        [ObservableProperty]
+        internal bool cleanupVisible = false;
+        [ObservableProperty]
+        internal bool cleanupEnabled = true;
 
         internal Mod? selectedMod;
         internal Mod? SelectedMod
@@ -139,6 +143,7 @@ namespace Knossos.NET.ViewModels
         {
             ModInstallList.Clear();
             DataLoaded = false;
+            CleanupVisible = false;
             Compress = false;
             List <Mod> allMods;
             if(SelectedMod != null)
@@ -197,6 +202,10 @@ namespace Knossos.NET.ViewModels
                 Name = SelectedMod.title;
                 Version = SelectedMod.version;
                 await ProcessMod(SelectedMod,allMods);
+            }
+            if (!IsInstalled && SelectedMod != null && ModVersions.Count > 1 && ModVersions.IndexOf(SelectedMod) > 0)
+            {
+                CleanupVisible = true;
             }
             DataLoaded = true;
             allMods.Clear();
@@ -349,10 +358,16 @@ namespace Knossos.NET.ViewModels
         {
             foreach (var mod in ModInstallList)
             {
+                var cleanOldVersions = false;
                 if (mod == SelectedMod)
+                {
                     mod.devMode = InstallInDevMode;
+                    //Only for the mod we are installing, we need to check if the option is visible AND enabled
+                    if(CleanupVisible && CleanupEnabled)
+                        cleanOldVersions = true;
+                }
                 if (mod.isSelected)
-                    TaskViewModel.Instance!.InstallMod(mod, null, Compress);
+                    TaskViewModel.Instance!.InstallMod(mod, null, Compress, cleanOldVersions);
             }
             ModInstallList.Clear();
 

--- a/Knossos.NET/Views/Windows/ModInstallView.axaml
+++ b/Knossos.NET/Views/Windows/ModInstallView.axaml
@@ -20,7 +20,7 @@
 		<vm:ModInstallViewModel/>
 	</Design.DataContext>
 	
-	<Grid MinHeight="400" MinWidth="300" RowDefinitions="Auto,*,Auto, Auto" Background="{StaticResource BackgroundColorPrimary}">
+	<Grid MinHeight="400" MinWidth="300" RowDefinitions="Auto,*,Auto, Auto, Auto" Background="{StaticResource BackgroundColorPrimary}">
 		<Label IsVisible="{Binding !DataLoaded}" Grid.Row="0" Margin="0,20,0,0" FontWeight="Bold" FontSize="28" HorizontalAlignment="Center">Loading data from repo...</Label>
 		<StackPanel IsVisible="{Binding DataLoaded}" Margin="0,20,0,0" Grid.Row="0">
 			<TextBlock Text="{Binding Name}" IsVisible="{Binding DataLoaded}" Margin="0,10,0,0" FontWeight="Bold" FontSize="28" HorizontalAlignment="Center"></TextBlock>
@@ -67,6 +67,7 @@
 				</StackPanel>
 			</StackPanel>
 		</StackPanel>
+		<CheckBox IsVisible="{Binding CleanupVisible}" IsChecked="{Binding CleanupEnabled}" Grid.Row="4" HorizontalAlignment="Center" ToolTip.Tip="Delete older versions than the one you are installing if its not in use by other mods. Note: This only applies to this mod and not to its dependencies.">Remove old versions of this mod</CheckBox>
 	</Grid>
 	
 </Window>


### PR DESCRIPTION
Adds an option (default on) to cleanup old versions of the mod we are currently installing

If this option is enabled any mod version older than the one we are installing will be checked, if it is not in use it will be deleted.

This ended up being a little more complex that i originally belived, so i will like to test it a bit more before merging.