### PR TITLE
Support mod metadata update

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -234,7 +234,7 @@ namespace Knossos.NET.Models
                                 if (versionInNebula != null)
                                     versionInNebula.inNebula = true;
                                 var newer = isInstalled.MaxBy(x => new SemanticVersion(x.version));
-                                if (newer != null && new SemanticVersion(newer.version) < new SemanticVersion(mod.version))
+                                if (newer != null && ( new SemanticVersion(newer.version) < new SemanticVersion(mod.version) || newer.lastUpdate != mod.lastUpdate))
                                 {
                                     Dispatcher.UIThread.Invoke(() => MainWindowViewModel.Instance?.MarkAsUpdateAvalible(mod.id), DispatcherPriority.Background);
                                 }
@@ -407,7 +407,7 @@ namespace Knossos.NET.Models
                                 }
                             });
                             var newer = isInstalled.MaxBy(x => new SemanticVersion(x.version));
-                            if (newer != null && new SemanticVersion(newer.version) < new SemanticVersion(m.version))
+                            if (newer != null && ( new SemanticVersion(newer.version) < new SemanticVersion(m.version) || newer.lastUpdate != m.lastUpdate ))
                             {
                                 await Dispatcher.UIThread.InvokeAsync(() => MainWindowViewModel.Instance?.MarkAsUpdateAvalible(m.id), DispatcherPriority.Background);
                             }

--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -234,7 +234,7 @@ namespace Knossos.NET.Models
                                 if (versionInNebula != null)
                                     versionInNebula.inNebula = true;
                                 var newer = isInstalled.MaxBy(x => new SemanticVersion(x.version));
-                                if (newer != null && ( new SemanticVersion(newer.version) < new SemanticVersion(mod.version) || newer.lastUpdate != mod.lastUpdate))
+                                if (newer != null && ( new SemanticVersion(newer.version) < new SemanticVersion(mod.version) || newer.version == mod.version && newer.lastUpdate != mod.lastUpdate))
                                 {
                                     Dispatcher.UIThread.Invoke(() => MainWindowViewModel.Instance?.MarkAsUpdateAvalible(mod.id), DispatcherPriority.Background);
                                 }
@@ -407,7 +407,7 @@ namespace Knossos.NET.Models
                                 }
                             });
                             var newer = isInstalled.MaxBy(x => new SemanticVersion(x.version));
-                            if (newer != null && ( new SemanticVersion(newer.version) < new SemanticVersion(m.version) || newer.lastUpdate != m.lastUpdate ))
+                            if (newer != null && ( new SemanticVersion(newer.version) < new SemanticVersion(m.version) || newer.version == m.version && newer.lastUpdate != m.lastUpdate ))
                             {
                                 await Dispatcher.UIThread.InvokeAsync(() => MainWindowViewModel.Instance?.MarkAsUpdateAvalible(m.id), DispatcherPriority.Background);
                             }

--- a/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
@@ -50,6 +50,8 @@ namespace Knossos.NET.ViewModels
         internal string installSize = string.Empty;
         [ObservableProperty]
         internal string freeSpace = string.Empty;
+        [ObservableProperty]
+        internal bool isMetaUpdate = false;
 
         internal Mod? selectedMod;
         internal Mod? SelectedMod
@@ -138,6 +140,7 @@ namespace Knossos.NET.ViewModels
         private async void UpdateSelectedVersion()
         {
             ModInstallList.Clear();
+            IsMetaUpdate = false;
             DataLoaded = false;
             Compress = false;
             List <Mod> allMods;
@@ -175,6 +178,7 @@ namespace Knossos.NET.ViewModels
                     SelectedMod.installed = true;
                     InstallInDevMode = installed.devMode;
                     CanSelectDevMode = false;
+                    IsMetaUpdate = Mod.IsMetaUpdate(SelectedMod,installed);
                 }
                 else
                 {

--- a/Knossos.NET/Views/Windows/ModInstallView.axaml
+++ b/Knossos.NET/Views/Windows/ModInstallView.axaml
@@ -36,12 +36,8 @@
 			<Label ToolTip.Tip="Download size consist of LZMA2 7z compressed files with max compression, the actual extracted size will be considerable higher than this value. It is recommended that you have at least double free space than what it is indicated here." Content="{Binding InstallSize}" Margin="5" FontSize="18" HorizontalAlignment="Center"></Label>
 			<Label Content="{Binding FreeSpace}" Margin="5,0,5,5" FontSize="18" HorizontalAlignment="Center"></Label>
 			<Label IsVisible="{Binding IsInstalled}" HorizontalAlignment="Center" FontWeight="Black" Foreground="Green"> This version is installed, you can add optional packages</Label>
-<<<<<<< Updated upstream
 			<Button Command="{Binding VerifyCommand}" Margin="5" IsVisible="{Binding IsInstalled}" HorizontalAlignment="Center" Classes="Quaternary">Verify</Button>
-=======
 			<Label IsVisible="{Binding IsMetaUpdate}" HorizontalAlignment="Center" FontWeight="Black" Foreground="{StaticResource ModCardBorderUpdate}"> A metadata update is available for this mod</Label>
-			<Button Command="{Binding VerifyCommand}" Margin="5" IsVisible="{Binding IsInstalled}" HorizontalAlignment="Center" Classes="Tertiary">Verify</Button>
->>>>>>> Stashed changes
 		</StackPanel>
 		<TreeView IsVisible="{Binding DataLoaded}" Grid.Row="1" Margin="30" ItemsSource="{Binding ModInstallList}"  HorizontalAlignment="Center">
 			<TreeView.Styles>

--- a/Knossos.NET/Views/Windows/ModInstallView.axaml
+++ b/Knossos.NET/Views/Windows/ModInstallView.axaml
@@ -36,7 +36,12 @@
 			<Label ToolTip.Tip="Download size consist of LZMA2 7z compressed files with max compression, the actual extracted size will be considerable higher than this value. It is recommended that you have at least double free space than what it is indicated here." Content="{Binding InstallSize}" Margin="5" FontSize="18" HorizontalAlignment="Center"></Label>
 			<Label Content="{Binding FreeSpace}" Margin="5,0,5,5" FontSize="18" HorizontalAlignment="Center"></Label>
 			<Label IsVisible="{Binding IsInstalled}" HorizontalAlignment="Center" FontWeight="Black" Foreground="Green"> This version is installed, you can add optional packages</Label>
+<<<<<<< Updated upstream
 			<Button Command="{Binding VerifyCommand}" Margin="5" IsVisible="{Binding IsInstalled}" HorizontalAlignment="Center" Classes="Quaternary">Verify</Button>
+=======
+			<Label IsVisible="{Binding IsMetaUpdate}" HorizontalAlignment="Center" FontWeight="Black" Foreground="{StaticResource ModCardBorderUpdate}"> A metadata update is available for this mod</Label>
+			<Button Command="{Binding VerifyCommand}" Margin="5" IsVisible="{Binding IsInstalled}" HorizontalAlignment="Center" Classes="Tertiary">Verify</Button>
+>>>>>>> Stashed changes
 		</StackPanel>
 		<TreeView IsVisible="{Binding DataLoaded}" Grid.Row="1" Margin="30" ItemsSource="{Binding ModInstallList}"  HorizontalAlignment="Center">
 			<TreeView.Styles>


### PR DESCRIPTION
Check if metadata is different during mod modify and inform it. Update data if user chooses to install.

Check lastUpdated date if the newer mod installed equals to the newwer one in nebula to check for meta updates