### PR TITLE
Filter system flags out of mod cmdline

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -918,7 +918,7 @@ namespace Knossos.NET
             }
 
             /* Build the cmdline, take in consideration systemcmd, globalcmd, modcmd(with user changes if any) */
-            var modCmd = mod.GetModCmdLine()?.Split('-');
+            var modCmd = mod.GetModCmdLine()?.Split('-').ToList();
             var systemCmd = Knossos.globalSettings.GetSystemCMD(fsoBuild)?.Split('-');
             var globalCmd = Knossos.globalSettings.globalCmdLine?.Split('-');
 
@@ -926,10 +926,18 @@ namespace Knossos.NET
             {
                 if (!mod.modSettings.ignoreGlobalCmd)
                 {
+                    if (modCmd != null && modCmd.Any())
+                    {
+                        foreach(var flag in modCmd.ToList())
+                        {
+                            if(GlobalSettings.SystemFlags.Contains(flag.ToLower().Trim()))
+                                modCmd.Remove(flag);
+                        }
+                    }
                     cmdline = KnUtils.CmdLineBuilder(cmdline, systemCmd);
                     cmdline = KnUtils.CmdLineBuilder(cmdline, globalCmd);
                 }
-                cmdline = KnUtils.CmdLineBuilder(cmdline, modCmd);
+                cmdline = KnUtils.CmdLineBuilder(cmdline, modCmd?.ToArray());
             }
             else
             {

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -930,7 +930,7 @@ namespace Knossos.NET
                     {
                         foreach(var flag in modCmd.ToList())
                         {
-                            if(GlobalSettings.SystemFlags.Contains(flag.ToLower().Trim()))
+                            if(GlobalSettings.SystemFlags.Contains(flag.ToLower().Trim().Split(' ')[0]))
                                 modCmd.Remove(flag);
                         }
                     }

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -45,7 +45,7 @@ namespace Knossos.NET.Models
     {
         /// <summary>
         /// Flags handled by globalsettings, any flag that is present in this array
-        /// will be ignored in mod cmdline if it exist.
+        /// will be ignored in mod cmdline if present.
         /// Must be in lowercase
         /// </summary>
         public static readonly string[] SystemFlags =

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -43,6 +43,22 @@ namespace Knossos.NET.Models
     /// </summary>
     public class GlobalSettings
     {
+        /// <summary>
+        /// Flags handled by globalsettings, any flag that is present in this array
+        /// will be ignored in mod cmdline if it exist.
+        /// Must be in lowercase
+        /// </summary>
+        public static readonly string[] SystemFlags =
+        {
+            "enable_shadows", "shadow_quality", "aa",
+            "aa_preset", "fxaa", "fxaa_preset",
+            "smaa", "smaa_preset", "msaa",
+            "soft_particles", "no_deferred", "window",
+            "fullscreen_window", "no_vsync", "no_post_process",
+            "no_fps_capping", "fps", "nosound",
+            "nomusic"
+        };
+
         struct Resolution
         {
             public uint width { get; set; }


### PR DESCRIPTION
Make sure mods cant override global settings unless the specific option to do so is enabled