### PR TITLE
Fix mod settings not being saved

### DIFF
--- a/Knossos.NET/ViewModels/Templates/DevModFsoSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModFsoSettingsViewModel.cs
@@ -48,13 +48,13 @@ namespace Knossos.NET.ViewModels
                         }
                         else
                         {
-                            Log.Add(Log.LogSeverity.Warning, "ModSettingsViewModel.Constructor()", "Missing user-saved build version for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId + " and version: " + editor.ActiveVersion.modSettings.customBuildVersion);
+                            Log.Add(Log.LogSeverity.Warning, "DevModFsoSettingsViewModel.Constructor()", "Missing user-saved build version for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId + " and version: " + editor.ActiveVersion.modSettings.customBuildVersion);
                             fsoPicker = new FsoBuildPickerViewModel(null);
                         }
                     }
                     else
                     {
-                        Log.Add(Log.LogSeverity.Warning, "ModSettingsViewModel.Constructor()", "Missing user-saved build id for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId);
+                        Log.Add(Log.LogSeverity.Warning, "DevModFsoSettingsViewModel.Constructor()", "Missing user-saved build id for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId);
                         fsoPicker = new FsoBuildPickerViewModel(null);
                     }
                 }

--- a/Knossos.NET/ViewModels/Templates/DevModFsoSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModFsoSettingsViewModel.cs
@@ -145,6 +145,7 @@ namespace Knossos.NET.ViewModels
                 }
                 editor.ActiveVersion.cmdline = CmdLine;
                 editor.ActiveVersion.modSettings.Save();
+                editor.ActiveVersion.SaveJson();
             }
         }
     }


### PR DESCRIPTION
This fixes Mod settings being saved in the FSO settings screen by making sure that the changed info is saved to the Mod's JSON.  This also makes two log entries in the same screen more accurate.

Thanks to ShivanSPS for explaining how this works.  Tested and works as expected.

Fixes #105 