### PR TITLE
generate checksums for builds on release

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -112,6 +112,12 @@ jobs:
           ARCH: aarch64
         run: ${{ github.workspace }}/ci/create_appimage.sh
 
+      - name: Generate checksums
+        run: |
+          cd $OUTPUT_DIR
+          sha256sum *.* >checksums.txt
+          cat checksums.txt
+
       - name: Generate Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
Create a list of build checksums when publishing a new release. At least partially addresses issue #28.