### PR TITLE
Support a separed optional fso build for flag data

### DIFF
--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -18,7 +18,8 @@ namespace Knossos.NET.Models
         Fred2,
         Fred2Debug,
         QtFred,
-        QtFredDebug
+        QtFredDebug,
+        Flags
     }
 
     public enum FsoExecArch
@@ -241,7 +242,11 @@ namespace Knossos.NET.Models
         /// <returns>A FlagsJsonV1 structure or null if failed</returns>
         public FlagsJsonV1? GetFlagsV1()
         {
-            var fullpath = GetExec(FsoExecType.Release);
+            var fullpath = GetExec(FsoExecType.Flags);
+            if (fullpath == null)
+            {
+                fullpath = GetExec(FsoExecType.Release);
+            }
             if (fullpath == null)
             {
                 fullpath = GetExec(FsoExecType.Debug);
@@ -581,6 +586,8 @@ namespace Knossos.NET.Models
 
                 case "qtfred": return FsoExecType.QtFred;
 
+                case "flags": return FsoExecType.Flags;
+
                 default:
                     Log.Add(Log.LogSeverity.Warning, "FsoBuild.GetExecType", "Unable to determine FSO Exec Type. Label: " + label);
                     return FsoExecType.Unknown;
@@ -602,6 +609,7 @@ namespace Knossos.NET.Models
                 case FsoExecType.Fred2Debug: return "fred2 debug";
                 case FsoExecType.QtFred: return "qtfred";
                 case FsoExecType.QtFredDebug: return "qtfred debug";
+                case FsoExecType.Flags: return "flags";
             }
             return null;
         }


### PR DESCRIPTION
This allows to include a FSO executable on a FSO Build mod only to get flag data from it.

Now this may not seem as very usefull, but for example in ARM64 linux i can use the modified 3.7.2 FSO build, IF knet still has another newer build to get the flags from.

This will allow the use of FSO builds that are below or equal 3.8.0 (thats were the json flags were added) whiout having to download any other FSO build so knet can still configure video and audio... if a newer build is also packed along it marked as the "flags" build

