### PR TITLE
Filter Mod Details screen buttons by Mod type And Make Version text instead of a combobox for build details

### DIFF
--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -59,6 +59,8 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal bool build = false;
         [ObservableProperty]
+        internal string buildVersion = string.Empty;
+        [ObservableProperty]
         internal string owners = string.Empty;
         /* UI Variables */
         [ObservableProperty]
@@ -128,7 +130,10 @@ namespace Knossos.NET.ViewModels
             devMode = modJson.devMode;
             
             if (modVersions.Any() && modVersions[0].type == ModType.engine)
+            {
                 Build = true;
+                BuildVersion = modVersions[0].version;
+            }
 
             if (Knossos.globalSettings.ttsDescription && Knossos.globalSettings.enableTts)
             {
@@ -161,7 +166,10 @@ namespace Knossos.NET.ViewModels
                 LoadVersion(0);
 
             if (modVersions.Any() && modVersions[0].type == ModType.engine)
+            {
                 Build = true;
+                BuildVersion = modVersions[0].version;
+            }
 
             if(Knossos.globalSettings.ttsDescription && Knossos.globalSettings.enableTts) 
             {

--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -57,6 +57,8 @@ namespace Knossos.NET.ViewModels
         private ModCardViewModel? modCard = null;
         internal bool devMode { get; set; } = false;
         [ObservableProperty]
+        internal bool build = false;
+        [ObservableProperty]
         internal string owners = string.Empty;
         /* UI Variables */
         [ObservableProperty]
@@ -124,6 +126,10 @@ namespace Knossos.NET.ViewModels
             VersionItems.Add(item);
             LoadVersion(0);
             devMode = modJson.devMode;
+            
+            if (modVersions.Any() && modVersions[0].type == ModType.engine)
+                Build = true;
+
             if (Knossos.globalSettings.ttsDescription && Knossos.globalSettings.enableTts)
             {
                 //PlayDescription(200);
@@ -153,6 +159,9 @@ namespace Knossos.NET.ViewModels
 
             if (modVersions.Count == 1)
                 LoadVersion(0);
+
+            if (modVersions.Any() && modVersions[0].type == ModType.engine)
+                Build = true;
 
             if(Knossos.globalSettings.ttsDescription && Knossos.globalSettings.enableTts) 
             {

--- a/Knossos.NET/Views/Windows/ModDetailsView.axaml
+++ b/Knossos.NET/Views/Windows/ModDetailsView.axaml
@@ -27,14 +27,14 @@
 			<!--Buttons and Mod info-->
 			<Grid IsVisible="{Binding IsInstalled}" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowDefinitions="Auto,Auto" HorizontalAlignment="Center" Margin="0,10,0,0">
 				<WrapPanel Grid.Row="0" Grid.Column="0">
-					<Button Command="{Binding ButtonCommandPlay}" Content="Play" Grid.Column="0" Classes="Accept Rounded" Margin="5" Width="100" ></Button>
-					<Button Command="{Binding ButtonCommandFred2}" Content="Fred2" Grid.Column="0" Classes="Secondary Rounded" Margin="5" Width="100" ></Button>
-					<Button Command="{Binding ButtonCommandSettings}" Content="Settings" Classes="Quaternary Rounded" Margin="5" Width="100" ></Button>
+					<Button Command="{Binding ButtonCommandPlay}" IsVisible="{Binding !Build}" IsEnabled="{Binding !Build}" Content="Play" Grid.Column="0" Classes="Accept Rounded" Margin="5" Width="100" ></Button>
+					<Button Command="{Binding ButtonCommandFred2}" IsVisible="{Binding !Build}" IsEnabled="{Binding !Build}" Content="Fred2" Grid.Column="0" Classes="Secondary Rounded" Margin="5" Width="100" ></Button>
+					<Button Command="{Binding ButtonCommandSettings}" IsVisible="{Binding !Build}" IsEnabled="{Binding !Build}" Content="Settings" Classes="Quaternary Rounded" Margin="5" Width="100" ></Button>
 					<Button IsVisible="{Binding !IsLocalMod}" Command="{Binding ButtonCommandReport}" Content="Report" Classes="Settings Rounded" Margin="5" Width="100" ></Button>
 				</WrapPanel>
 				<WrapPanel Grid.Row="1" Grid.Column="0">
-					<Button Command="{Binding ButtonCommandPlayDebug}" Content="Debug" Grid.Column="0" Classes="Tertiary Rounded" Margin="5" Width="100" ></Button>
-					<Button Command="{Binding ButtonCommandQtFred}" Content="QtFred" Grid.Column="0" Margin="5" Width="100" Classes="Settings Rounded"></Button>
+					<Button Command="{Binding ButtonCommandPlayDebug}" IsVisible="{Binding !Build}" IsEnabled="{Binding !Build}" Content="Debug" Grid.Column="0" Classes="Tertiary Rounded" Margin="5" Width="100" ></Button>
+					<Button Command="{Binding ButtonCommandQtFred}" IsVisible="{Binding !Build}" IsEnabled="{Binding !Build}" Content="QtFred" Grid.Column="0" Margin="5" Width="100" Classes="Settings Rounded"></Button>
 					<Button Command="{Binding ButtonCommandForum}" Content="Forum" IsVisible="{Binding ForumAvalible}" Classes="Settings Rounded" Margin="5" Width="100" ></Button>
 					<Button IsVisible="{Binding !devMode}" Command="{Binding ButtonCommandDelete}" Content="Delete" Classes="Cancel Rounded" Margin="5" Width="100" ></Button>
 				</WrapPanel>

--- a/Knossos.NET/Views/Windows/ModDetailsView.axaml
+++ b/Knossos.NET/Views/Windows/ModDetailsView.axaml
@@ -39,7 +39,8 @@
 					<Button IsVisible="{Binding !devMode}" Command="{Binding ButtonCommandDelete}" Content="Delete" Classes="Cancel Rounded" Margin="5" Width="100" ></Button>
 				</WrapPanel>
 				<Label Content="Version" Grid.Column="3" Margin="20,0,20,0" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
-				<ComboBox SelectedIndex="{Binding ItemSelectedIndex}" IsEnabled="{Binding !Build}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="20,5,20,0" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
+				<ComboBox IsEnabled="{Binding !Build}" IsVisible="{Binding !Build}" SelectedIndex="{Binding ItemSelectedIndex}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="20,5,20,0" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
+				<Label IsVisible="{Binding Build}"  Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White" Content="{Binding BuildVersion}"/>
 				<Label Content="Released" Grid.Column="4" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="{Binding Released}" Grid.Column="4" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="Last Updated" Grid.Column="5" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>

--- a/Knossos.NET/Views/Windows/ModDetailsView.axaml
+++ b/Knossos.NET/Views/Windows/ModDetailsView.axaml
@@ -39,7 +39,7 @@
 					<Button IsVisible="{Binding !devMode}" Command="{Binding ButtonCommandDelete}" Content="Delete" Classes="Cancel Rounded" Margin="5" Width="100" ></Button>
 				</WrapPanel>
 				<Label Content="Version" Grid.Column="3" Margin="20,0,20,0" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
-				<ComboBox SelectedIndex="{Binding ItemSelectedIndex}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="20,5,20,0" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
+				<ComboBox SelectedIndex="{Binding ItemSelectedIndex}" IsEnabled="{Binding !Build}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="20,5,20,0" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
 				<Label Content="Released" Grid.Column="4" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="{Binding Released}" Grid.Column="4" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="Last Updated" Grid.Column="5" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>


### PR DESCRIPTION
Since Play, Fred and other buttons don't make sense in the context of builds, disable and hide those buttons if we are looking at build details.