### PR TITLE
Partially fix taskview scroll

### DIFF
--- a/Knossos.NET/Views/TaskView.axaml
+++ b/Knossos.NET/Views/TaskView.axaml
@@ -12,20 +12,16 @@
 		<vm:TaskViewModel/>
 	</Design.DataContext>
 
-	<ScrollViewer IsVisible="{Binding TaskList.Count}">
-		<Grid>
-			<WrapPanel HorizontalAlignment="Right" ZIndex="1">
-				<Button Command="{Binding CleanCommand}" ToolTip.Tip="Clean completed or cancelled tasks">Clear</Button>
-			</WrapPanel>
-			<Grid RowDefinitions="Auto" ZIndex="0">
-				<ItemsControl Grid.Row="0" ItemsSource="{Binding TaskList}">
-					<ItemsControl.ItemTemplate>
-						<DataTemplate>
-							<v:TaskItemView Content="{Binding}"/>
-						</DataTemplate>
-					</ItemsControl.ItemTemplate>
-				</ItemsControl>
-			</Grid>
+	<ScrollViewer IsVisible="{Binding TaskList.Count}" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+		<Grid RowDefinitions="*">
+			<Button Grid.Row="0" ZIndex="1" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="5" Command="{Binding CleanCommand}" ToolTip.Tip="Clean completed or cancelled tasks">Clear</Button>
+			<ItemsControl ZIndex="0" Grid.Row="0" VerticalAlignment="Top" ItemsSource="{Binding TaskList}">
+				<ItemsControl.ItemTemplate>
+					<DataTemplate>
+						<v:TaskItemView Content="{Binding}"/>
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
 		</Grid>
 	</ScrollViewer>
 </UserControl>

--- a/Knossos.NET/Views/Windows/MainWindow.axaml
+++ b/Knossos.NET/Views/Windows/MainWindow.axaml
@@ -68,6 +68,6 @@
 			</TabItem>
 		</TabControl>
 		<GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>
-		<v:TaskView Grid.Row="2" Content="{Binding TaskView}" VerticalAlignment="Top"/>
+		<v:TaskView Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" MaxHeight="550" Content="{Binding TaskView}"/>
 	</Grid>
 </Window>

--- a/Knossos.NET/Views/Windows/MainWindow.axaml
+++ b/Knossos.NET/Views/Windows/MainWindow.axaml
@@ -21,7 +21,7 @@
 		<Grid.RowDefinitions>
 			<RowDefinition Height="*"></RowDefinition>
 			<RowDefinition Height="4"></RowDefinition>
-			<RowDefinition Height="Auto" MaxHeight="550"></RowDefinition>
+			<RowDefinition Height="Auto" MaxHeight="350"></RowDefinition>
 		</Grid.RowDefinitions>
 		<TabControl Grid.Row="0" SelectedIndex="{Binding TabIndex}">
 			<!--Installed Mods / Home-->
@@ -68,6 +68,6 @@
 			</TabItem>
 		</TabControl>
 		<GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>
-		<v:TaskView Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" MaxHeight="550" Content="{Binding TaskView}"/>
+		<v:TaskView Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" MaxHeight="350" Content="{Binding TaskView}"/>
 	</Grid>
 </Window>


### PR DESCRIPTION
Partial fix to the missing scroll on taskview, if the task list is longer than 550 pixels it will correctly display the scrollbar. But if the user makes the program window smaller than what is needed to display the full tasklist the scrollbar will not be displayed or updated, UNLESS the users move the expander what makes the grid update the height so the scrollviewer can work correctly.

I have no idea if this is an avalonia bug or a incorrect implementation, i will make a note to ask about it.

Edit: i reduced the tasklist  max height to 350 pixels