### PR TITLE
Display private mods for user on nebula login view

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -1146,10 +1146,13 @@ namespace Knossos.NET.Models
         /// Get an array of private mods that the user has access to.
         /// </summary>
         /// <returns>An array of mods</returns>
-        public static async Task<Mod[]?> GetPrivateMods()
+        public static async Task<Mod[]?> GetPrivateMods(bool tryUseCache = false)
         {
             try
             {
+                if (tryUseCache && privateMods != null)
+                    return privateMods;
+
                 var reply = await ApiCall("mod/list_private", null, true, 30, ApiMethod.GET);
                 if (reply.Value.mods != null && reply.Value.mods.Any())
                 {

--- a/Knossos.NET/ViewModels/Templates/NebulaLoginViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/NebulaLoginViewModel.cs
@@ -48,7 +48,7 @@ namespace Knossos.NET.ViewModels
                         EditableIDs = string.Join(", ", ids);
                     });
                 }
-                var privMods = await Nebula.GetPrivateMods(true).ConfigureAwait(false); ;
+                var privMods = await Nebula.GetPrivateMods(true).ConfigureAwait(false);
                 if (privMods != null)
                 {
                     foreach (var mod in privMods)

--- a/Knossos.NET/ViewModels/Templates/NebulaLoginViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/NebulaLoginViewModel.cs
@@ -28,6 +28,9 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string editableIDs = string.Empty;
 
+        [ObservableProperty]
+        internal string privateMods = string.Empty;
+
         public async void UpdateUI()
         {
             UserLoggedIn = Nebula.userIsLoggedIn;
@@ -43,6 +46,17 @@ namespace Knossos.NET.ViewModels
                     {
                         EditableIDs = string.Join(", ", ids);
                     });
+                }
+                var privMods = await Nebula.GetPrivateMods(true);
+                if (privMods != null)
+                {
+                    foreach (var mod in privMods)
+                    {
+                        Dispatcher.UIThread.Invoke(() =>
+                        {
+                            PrivateMods += mod + ", ";
+                        });
+                    }
                 }
             }
         }
@@ -62,11 +76,6 @@ namespace Knossos.NET.ViewModels
             else
             {
                 UpdateUI();
-                var ids = await Nebula.GetEditableModIDs();
-                if(ids != null)
-                {
-                    EditableIDs = string.Join(", ", ids);
-                }
             }
         }
 

--- a/Knossos.NET/ViewModels/Templates/NebulaLoginViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/NebulaLoginViewModel.cs
@@ -37,6 +37,7 @@ namespace Knossos.NET.ViewModels
             RegisterNewUser = false;
             UserName = Nebula.userName;
             UserPass = Nebula.userPass;
+            PrivateMods = string.Empty;
             if(UserLoggedIn) 
             { 
                 var ids = await Nebula.GetEditableModIDs().ConfigureAwait(false);
@@ -47,7 +48,7 @@ namespace Knossos.NET.ViewModels
                         EditableIDs = string.Join(", ", ids);
                     });
                 }
-                var privMods = await Nebula.GetPrivateMods(true);
+                var privMods = await Nebula.GetPrivateMods(true).ConfigureAwait(false); ;
                 if (privMods != null)
                 {
                     foreach (var mod in privMods)

--- a/Knossos.NET/Views/Templates/NebulaLoginView.axaml
+++ b/Knossos.NET/Views/Templates/NebulaLoginView.axaml
@@ -28,6 +28,8 @@
 			</WrapPanel>
 			<Label HorizontalAlignment="Center" IsVisible="{Binding UserLoggedIn}" Margin="20" FontSize="20">Mods IDs you have write access to</Label>
 			<TextBox Background="Transparent" IsReadOnly="True" IsVisible="{Binding UserLoggedIn}" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Text="{Binding EditableIDs}"></TextBox>
+			<Label HorizontalAlignment="Center" IsVisible="{Binding UserLoggedIn}" Margin="20" FontSize="20">Private mods you have access to</Label>
+			<TextBox Background="Transparent" IsReadOnly="True" IsVisible="{Binding UserLoggedIn}" TextWrapping="Wrap" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Text="{Binding PrivateMods}"></TextBox>
 		</StackPanel>
 	</ScrollViewer>
 </UserControl>


### PR DESCRIPTION
Added a list of private mods the user has access to in the nebula login page.

Also got rid of a duplicated call to Nebula.GetEditableModIds.