### PR TITLE
Clear EditableIDs and PrivateMods arrays during Nebula logoff

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -1031,6 +1031,8 @@ namespace Knossos.NET.Models
             apiUserToken = null;
             settings.user = null;
             settings.pass = null;
+            editableIds = null;
+            privateMods = null;
             SaveSettings();
         }
 


### PR DESCRIPTION
Data from the old user were still loaded for the current session.