### PR TITLE
rework CI workflow to build on proper host

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -15,8 +15,8 @@ env:
   PUBLISH_DIR: ./build/publish
 
 jobs:
-  publish:
-    name: Publish builds
+  build-win:
+    name: Windows builds
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -42,26 +42,70 @@ jobs:
           mkdir -p "$OUTPUT_DIR"
           mkdir -p "$PUBLISH_DIR"
 
-      - name: Publish all RIDs
+      - name: Publish Windows RIDs
         shell: bash
-        run: ./ci/publish_all.sh
+        run: ./ci/publish_all_host.sh
 
       - name: Archive builds
         shell: bash
         run: |
           cd "$PUBLISH_DIR"
-          tar -czvf builds.tgz --exclude='*.pdb' *
+          tar -czvf win-builds.tgz --exclude='*.pdb' *
 
       - name: Upload build archive
         uses: actions/upload-artifact@v3
         with:
-          name: builds
-          path: ${{ env.PUBLISH_DIR }}/builds.tgz
+          name: win-builds
+          path: ${{ env.PUBLISH_DIR }}/win-builds.tgz
+          retention-days: 5
+
+  build-mac:
+    name: macOS builds
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: '${{ github.ref }}'
+
+      - name: Set environment
+        shell: bash
+        run: |
+          echo "VERSION=$(echo ${{ github.ref_name }} | cut -c 2-)" >> $GITHUB_ENV
+          echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Create directories
+        shell: bash
+        run: |
+          mkdir -p "$OUTPUT_DIR"
+          mkdir -p "$PUBLISH_DIR"
+
+      - name: Publish macOS RIDs
+        shell: bash
+        run: ./ci/publish_all_host.sh
+
+      - name: Archive builds
+        shell: bash
+        run: |
+          cd "$PUBLISH_DIR"
+          tar -czvf mac-builds.tgz --exclude='*.pdb' *
+
+      - name: Upload build archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: mac-builds
+          path: ${{ env.PUBLISH_DIR }}/mac-builds.tgz
           retention-days: 5
 
   package_release:
-    name: Package and release
-    needs: publish
+    name: Linux builds, package and release
+    needs: [build-win, build-mac]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -76,26 +120,43 @@ jobs:
           echo "VERSION=$(echo ${{ github.ref_name }} | cut -c 2-)" >> $GITHUB_ENV
           echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
 
+      - name: Create directories
+        shell: bash
+        run: |
+          mkdir -p "$OUTPUT_DIR"
+          mkdir -p "$PUBLISH_DIR"
+
       - name: Install utilities
         # zip for packaging windows builds
         # nsis for windows installer
         run: sudo apt-get update && sudo apt-get install zip nsis
 
-      - name: Create directories
-        run: |
-          mkdir -p "$OUTPUT_DIR"
-          mkdir -p "$PUBLISH_DIR"
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
 
-      - name: Download build archive
+      - name: Publish Linux RIDs
+        shell: bash
+        run: ./ci/publish_all_host.sh
+
+      - name: Download Windows build artifact
         uses: actions/download-artifact@v3
         with:
-          name: builds
+          name: win-builds
           path: ${{ env.PUBLISH_DIR }}
 
-      - name: Extract build archive
+      - name: Download macOS build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: mac-builds
+          path: ${{ env.PUBLISH_DIR }}
+
+      - name: Extract build archives
         run: |
           cd "$PUBLISH_DIR"
-          tar -xzvf builds.tgz
+          tar -xzvf win-builds.tgz
+          tar -xzvf mac-builds.tgz
 
       - name: Package all RIDs
         run: ${{ github.workspace }}/ci/package_all.sh
@@ -125,6 +186,5 @@ jobs:
       - name: Generate Release
         uses: softprops/action-gh-release@v1
         with:
-          # body_path: ${{ github.workspace }}/CHANGES.md
           draft: true
           files: ${{ env.OUTPUT_DIR }}/*

--- a/ci/publish_all_host.sh
+++ b/ci/publish_all_host.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+fail_msg() {
+    echo "$1"
+    exit 1
+}
+
+#
+# This script should be run in, or with the working directory set to, the root project directory
+#
+
+pushd "$(readlink -f "$(dirname "${BASH_SOURCE[0]}")"/..)" > /dev/null
+
+# grab default variables
+source ./packaging/vars
+
+[ -n "$NAME" ] || fail_msg "ERROR: Name isn't specified!"
+[ -n "$ID" ]   || fail_msg "ERROR: ID isn't specified!"
+[ -n "$RIDS" ] || fail_msg "ERROR: Runtime IDs not specified!"
+
+PUBLISH_DIR="$(readlink -f ${PUBLISH_DIR:="./build/publish"})"
+
+[ -n "$PUBLISH_DIR" ] || fail_msg "ERROR: Publish directory isn't set!"
+[ -d "$PUBLISH_DIR" ] || fail_msg "ERROR: Publish location isn't a directory!"
+
+# get RID for this host to limit builds
+host="$(uname | tr '[:upper:]' '[:lower:]')"
+host_rid=
+
+case "$host" in
+    linux*)
+        host_rid="linux"
+        ;;
+    darwin*)
+        host_rid="osx"
+        ;;
+    mingw*)
+        host_rid="win"
+        ;;
+    msys*)
+        host_rid="win"
+        ;;
+    windows*)
+        host_rid="win"
+        ;;
+    cygwin*)
+        host_rid="win"
+        ;;
+    *)
+        fail_msg "ERROR: Unknown host!"
+        ;;
+esac
+
+# Publish all runtime identifiers we need
+for rid in $RIDS; do
+    type="$(echo $rid | cut -d- -f1)"
+    # if rid type doesn't match host then skip
+    [ "$type" = "$host_rid" ] || continue
+
+    echo
+    echo "Publishing $rid ..."
+    echo
+
+    dotnet publish "$NAME/$NAME.csproj" -r $rid -c Release --self-contained -p:PublishSingleFile=true -o "$PUBLISH_DIR/$rid"
+done
+
+echo
+echo "Done."
+echo


### PR DESCRIPTION
Mac builds need to be signed so build those on a Mac runner. Linux builds shouldn't require special treatment but build on a Linux host anyway. Windows runner now only builds for Windows.