### PR TITLE
Load NebulaModCard images only when the card is visible

### DIFF
--- a/Knossos.NET/ViewModels/NebulaModListViewModel.cs
+++ b/Knossos.NET/ViewModels/NebulaModListViewModel.cs
@@ -153,8 +153,8 @@ namespace Knossos.NET.ViewModels
                     }
                 }
                 var card = new NebulaModCardViewModel(modJson);
-                if (IsLoading)
-                    card.Visible = false;
+                if (!IsLoading)
+                    card.Visible = true;
                 Mods.Insert(i, card);
             }
             else
@@ -190,7 +190,7 @@ namespace Knossos.NET.ViewModels
                         }
                     }
                     var card = new NebulaModCardViewModel(mod);
-                    card.Visible = false;
+                    //card.Visible = false;
                     newModCardList.Insert(i, card);
                 }
                 else

--- a/Knossos.NET/ViewModels/Templates/NebulaModCardViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/NebulaModCardViewModel.cs
@@ -23,8 +23,27 @@ namespace Knossos.NET.ViewModels
         internal string? ModVersion { get { return modJson != null ? modJson.version : null; } }
         [ObservableProperty]
         internal Bitmap? tileImage;
-        [ObservableProperty]
         internal bool visible = true;
+        internal bool Visible
+        {
+            get 
+            { 
+                return visible; 
+            }
+            set
+            {
+                if(visible != value)
+                {
+                    SetProperty(ref visible, value);
+                    if(value && TileImage == null && modJson != null)
+                    {
+                        Dispatcher.UIThread.Invoke(() => {
+                            LoadImage(modJson.fullPath, modJson.tile);
+                        });
+                    }
+                }
+            }
+        }
         [ObservableProperty]
         internal bool isInstalling = false;
 
@@ -44,7 +63,8 @@ namespace Knossos.NET.ViewModels
             Log.Add(Log.LogSeverity.Information, "NebulaModCardViewModel(Constructor)", "Creating mod card for " + modJson);
             modJson.ClearUnusedData();
             this.modJson = modJson;
-            LoadImage(modJson.fullPath,modJson.tile);
+            //Moved to load when visible only
+            //LoadImage(modJson.fullPath, modJson.tile);
         }
 
         /* Button Commands */

--- a/Knossos.NET/ViewModels/Templates/NebulaModCardViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/NebulaModCardViewModel.cs
@@ -23,7 +23,7 @@ namespace Knossos.NET.ViewModels
         internal string? ModVersion { get { return modJson != null ? modJson.version : null; } }
         [ObservableProperty]
         internal Bitmap? tileImage;
-        internal bool visible = true;
+        internal bool visible = false;
         internal bool Visible
         {
             get 


### PR DESCRIPTION
This should save about 75 to 100mb of ram if you never open the nebula tab.

The idea is that the tile image should only be loaded into a bitmap for display when the modcard changes from hidden to visible for the first time, and if you never open the nebula tab this effectively avoids having all those images cached to ram, what right now is a good 75 to 100mb ram usage reduction, that will go away as soon as you click the nebula tab.

While this is general is a small change with good gains, maybe we should wait to after 0.2.0 to merge it. Opinions?