### PR TITLE
Add image file size limits to mod editor

### DIFF
--- a/Knossos.NET/ViewModels/Templates/DevModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModDetailsViewModel.cs
@@ -194,6 +194,16 @@ namespace Knossos.NET.ViewModels
                     //Get File Hash (new filename)
                     using (FileStream? file = new FileStream(filepath, FileMode.Open, FileAccess.Read))
                     {
+                        //300kb limit
+                        if(file.Length > 307200)
+                        {
+                            var length = file.Length;
+                            file.Close();
+                            Dispatcher.UIThread.Invoke(() => {
+                                MessageBox.Show(MainWindow.instance!, "The image file size (" + length + " bytes) is over the max limit allowed (307200 bytes)", "Selected image file too is too big", MessageBox.MessageBoxButtons.OK);
+                            });
+                            throw new Exception("The image file size (" + length + " bytes) is over the max limit allowed (307200 bytes)");
+                        }
                         var filename = string.Empty;
                         using (SHA256 checksum = SHA256.Create())
                         {
@@ -249,6 +259,16 @@ namespace Knossos.NET.ViewModels
                     //Get File Hash (new filename)
                     using (FileStream? file = new FileStream(filepath, FileMode.Open, FileAccess.Read))
                     {
+                        //10MB limit
+                        if (file.Length > 10485760)
+                        {
+                            var length = file.Length;
+                            file.Close();
+                            Dispatcher.UIThread.Invoke(() => {
+                                MessageBox.Show(MainWindow.instance!, "The image file size (" + length + " bytes) is over the max limit allowed (10485760 bytes)", "Selected image file too is too big", MessageBox.MessageBoxButtons.OK);
+                            });
+                            throw new Exception("The image file size (" + length + " bytes) is over the max limit allowed (10485760 bytes)");
+                        }
                         var filename = string.Empty;
                         using (SHA256 checksum = SHA256.Create())
                         {
@@ -273,7 +293,7 @@ namespace Knossos.NET.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Add(Log.LogSeverity.Error, "DevModDetailsViewModel.ChangeTileImage", ex);
+                Log.Add(Log.LogSeverity.Error, "DevModDetailsViewModel.ChangeBannerImage", ex);
             }
         }
 
@@ -374,6 +394,16 @@ namespace Knossos.NET.ViewModels
                     //Get File Hash (new filename)
                     using (FileStream? file = new FileStream(filepath, FileMode.Open, FileAccess.Read))
                     {
+                        //10MB limit
+                        if (file.Length > 10485760)
+                        {
+                            var length = file.Length;
+                            file.Close();
+                            Dispatcher.UIThread.Invoke(() => {
+                                MessageBox.Show(MainWindow.instance!, "The image file size (" + length + " bytes) is over the max limit allowed (10485760 bytes)", "Selected image file too is too big", MessageBox.MessageBoxButtons.OK);
+                            });
+                            throw new Exception("The image file size (" + length + " bytes) is over the max limit allowed (10485760 bytes)");
+                        }
                         var filename = string.Empty;
                         using (SHA256 checksum = SHA256.Create())
                         {

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -232,6 +232,7 @@ namespace Knossos.NET.ViewModels
              *  8) Check modid to see if it exist, and if does the user must have write permisions to it. --done
              *  9) All dependencies must be released mods, either public or private
              *  10) If mod is public it cant depend on a private dependency
+             *  11) if the tile image size is over the maximum allowed (300kb) --done
              *  
              *  WARNINGS:
              *  -(Always) Warn about the mod visibility before upload, for both private and public, and what it means. --done
@@ -326,6 +327,14 @@ namespace Knossos.NET.ViewModels
                                 ButtonsEnabled = true;
                                 return;
                             }
+                        }
+
+                        //if the tile image size is over the maximum allowed (300kb)
+                        if (!string.IsNullOrEmpty(mod.tile) && File.Exists(Path.Combine(mod.fullPath,mod.tile)) && new FileInfo(Path.Combine(mod.fullPath, mod.tile)).Length > 307200)
+                        {
+                            await MessageBox.Show(MainWindow.instance!, "The mod tile image is over the maximum of 300kb allowed.", "Basic Check Fail", MessageBox.MessageBoxButtons.OK);
+                            ButtonsEnabled = true;
+                            return;
                         }
 
                         //If type = Engine check if the enviroment string is valid and the execs are accesible.

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -65,10 +65,10 @@
 					<Border Width="152" Height="227" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="150" Height="225" Source="{Binding TileImage}"></Image>
 					</Border>
-					<Label Margin="5,5,0,0" HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large.</Label>
+					<Label Margin="5,5,0,0" HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large, 300KB max.</Label>
 				</StackPanel>
 			</WrapPanel>
-			<WrapPanel Margin="130,0,0,0">
+			<WrapPanel Margin="160,0,0,0">
 				<Button Command="{Binding ChangeTileImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
 				<Button Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 			</WrapPanel>
@@ -79,8 +79,8 @@
 					<Border Margin="45,5,5,5" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="535" Height="150" Source="{Binding BannerImage}"></Image>
 					</Border>
-					<Label Margin="125,5,0,0" Foreground="Yellow" FontSize="12">This image should be 1070x300 pixels large.</Label>
-					<WrapPanel Margin="130,0,0,0">
+					<Label HorizontalAlignment="Center" Margin="0,5,0,0" Foreground="Yellow" FontSize="12">This image should be 1070x300 pixels large. 10MB max, 1MB or less recommended.</Label>
+					<WrapPanel HorizontalAlignment="Center">
 						<Button Command="{Binding ChangeBannerImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
 						<Button Command="{Binding RemoveBannerImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 					</WrapPanel>


### PR DESCRIPTION
Do not allow tile images bigger than 300kb or banner/screenshoots over 10MB (this is the nebula upload limit)