### PR TITLE
remove list padding to fix layout issue on mod descriptions

### DIFF
--- a/Knossos.NET/Classes/BBCode.cs
+++ b/Knossos.NET/Classes/BBCode.cs
@@ -101,11 +101,11 @@ namespace BBcodes
                     _rules.Add(new BBCodeRules("[br]", "<br>", ""));
                     _rules.Add(new BBCodeRules("[hr]", "<hr><br>", ""));
 
-                    _rules.Add(new BBCodeRules("[list]", "<ul style='padding-top:-30px;'>", ""));
+                    _rules.Add(new BBCodeRules("[list]", "<ul>", ""));
                     _rules.Add(new BBCodeRules("[/list]", "</ul>", ""));
-                    _rules.Add(new BBCodeRules("[ul]", "<ul style='padding-top:-30px;'>", ""));
+                    _rules.Add(new BBCodeRules("[ul]", "<ul>", ""));
                     _rules.Add(new BBCodeRules("[/ul]", "</ul>", ""));
-                    _rules.Add(new BBCodeRules("[ol]", "<ol style='padding-top:-30px;'>", ""));
+                    _rules.Add(new BBCodeRules("[ol]", "<ol>", ""));
                     _rules.Add(new BBCodeRules("[/ol]", "</ol>", ""));
                     _rules.Add(new BBCodeRules("[li]", "<li>", ""));
                     _rules.Add(new BBCodeRules("[/li]", "</li>", ""));


### PR DESCRIPTION
Lists were offset 30px upwards which caused them to render over other text. This was very noticeable with mod descriptions on FSPort and BPC, and any other mod description which might use a heading on a list.