### PR TITLE
Improve default visibility of bottom buttons on quicksetup guide

### DIFF
--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -13,7 +13,7 @@
 		WindowStartupLocation="CenterScreen"
 		Title="Quick Setup Guide" 
 		SizeToContent="WidthAndHeight"
-		MaxWidth="600"
+		MaxWidth="800"
 		MinHeight="400"
 		CanResize="True">
 


### PR DESCRIPTION
On some of the text boxes with longer text I've Widens the default max width of QuickSetup Guide. I noticed I have to manually resize the window to see the buttons on the bottom to click on, and I have had a two reports of folks not knowing there were buttons to click on since they didn't see them due to the window constraints. I tested this change and it works better for always displaying the buttons. Would be happy to discuss more, too.