### PR TITLE
fix and tweak mod details view 

### DIFF
--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -153,7 +153,7 @@ namespace Knossos.NET.ViewModels
             //Data loads on selected index change
             ItemSelectedIndex = selectedIndex;
 
-            if (modVersions.Count == 1)
+            if (modVersions.Count > 0)
                 LoadVersion(0);
 
             if (modVersions.Any() && modVersions[0].type == ModType.engine)

--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -74,13 +74,13 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal Bitmap? banner = null;
         [ObservableProperty]
-        internal bool forumAvailable = true;
+        internal bool forumAvailable = false;
         [ObservableProperty]
-        internal bool isInstalled = true;
+        internal bool isInstalled = false;
         [ObservableProperty]
         internal bool isPlayingTTS = false;
         [ObservableProperty]
-        internal bool ttsAvailable = true;
+        internal bool ttsAvailable = false;
         [ObservableProperty]
         internal bool hasBanner = false;
         [ObservableProperty]
@@ -135,15 +135,6 @@ namespace Knossos.NET.ViewModels
                 BuildVersion = modVersions[0].version;
             }
 
-            if (Knossos.globalSettings.ttsDescription && Knossos.globalSettings.enableTts)
-            {
-                //PlayDescription(200);
-            }
-            else
-            {
-                TtsAvailable = false;
-            }
-
             this.dialog = dialog;
         }
 
@@ -169,15 +160,6 @@ namespace Knossos.NET.ViewModels
             {
                 Build = true;
                 BuildVersion = modVersions[0].version;
-            }
-
-            if(Knossos.globalSettings.ttsDescription && Knossos.globalSettings.enableTts) 
-            {
-                //PlayDescription(200);
-            }
-            else
-            {
-                TtsAvailable = false;
             }
         }
 
@@ -232,11 +214,16 @@ namespace Knossos.NET.ViewModels
                     await modVersions[index].LoadFulLNebulaData().ConfigureAwait(false);
                 }
                 Dispatcher.UIThread.Invoke(()=>{ 
-                    if (modVersions[index].description != null)
+                    if ( !string.IsNullOrEmpty(modVersions[index].description) )
                     {
                         var html = BBCode.ConvertToHtml(modVersions[index].description!, BBCode.BasicRules);
                         Description = "<body style='overflow: hidden;white-space: pre-line;color:white;text-align: left;'>" + html + "</body>";
                         //Log.WriteToConsole(html);
+
+                        if(Knossos.globalSettings.ttsDescription && Knossos.globalSettings.enableTts)
+                        {
+                            TtsAvailable = true;
+                        }
                     }
                     if (modVersions[index].owners != null && modVersions[index].owners!.Any()) 
                     {

--- a/Knossos.NET/Views/Windows/ModDetailsView.axaml
+++ b/Knossos.NET/Views/Windows/ModDetailsView.axaml
@@ -39,14 +39,14 @@
 					<Button IsVisible="{Binding !devMode}" Command="{Binding ButtonCommandDelete}" Content="Delete" Classes="Cancel Rounded" Margin="5" Width="100" ></Button>
 				</WrapPanel>
 				<Label Content="Version" Grid.Column="3" Margin="20,0,20,0" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
-				<ComboBox IsEnabled="{Binding !Build}" IsVisible="{Binding !Build}" SelectedIndex="{Binding ItemSelectedIndex}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="20,5,20,0" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
+				<ComboBox IsEnabled="{Binding !Build}" IsVisible="{Binding !Build}" SelectedIndex="{Binding ItemSelectedIndex}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="20,5,20,0" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalAlignment="Top" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
 				<Label IsVisible="{Binding Build}"  Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White" Content="{Binding BuildVersion}"/>
 				<Label Content="Released" Grid.Column="4" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="{Binding Released}" Grid.Column="4" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="Last Updated" Grid.Column="5" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="{Binding LastUpdated}" Grid.Column="5" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="Owners" Grid.Column="6" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
-				<TextBlock Text="{Binding Owners}" TextWrapping="Wrap" Grid.Column="6" Grid.Row="1" FontWeight="Bold" FontSize="12" Foreground="White"/>
+				<TextBlock Text="{Binding Owners}" TextWrapping="Wrap" Grid.Column="6" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalAlignment="Top" HorizontalAlignment="Center" Foreground="White"/>
 			</Grid>
 			
 			<!--Nebula View-->
@@ -55,7 +55,7 @@
 					<Button Command="{Binding ButtonCommandForum}" Content="Forum" IsVisible="{Binding ForumAvailable}" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" CornerRadius="40" HorizontalContentAlignment="Center" HorizontalAlignment="Center" Background="LightCoral" Margin="5" Width="100" ></Button>
 				</WrapPanel>
 				<Label Content="Newest Version" Grid.Column="3" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
-				<ComboBox IsEnabled="False" SelectedIndex="{Binding ItemSelectedIndex}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="5" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
+				<ComboBox IsEnabled="False" SelectedIndex="{Binding ItemSelectedIndex}" ItemsSource="{Binding VersionItems}" MinWidth="125" Margin="5" Grid.Column="3" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalAlignment="Top" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"></ComboBox>
 				<Label Content="Released" Grid.Column="4" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="{Binding Released}" Grid.Column="4" Grid.Row="1" FontWeight="Bold" FontSize="12" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Foreground="White"/>
 				<Label Content="Last Updated" Grid.Column="5" Margin="5" Grid.Row="0" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Center" HorizontalContentAlignment="Center" Foreground="White"/>


### PR DESCRIPTION
This will default most controls on the mod details view to not being available/seen and instead adds or enables them as appropriate. For mods that are not installed this looks better than the current way where there is an abrupt change to remove/swap controls when the details finally load. Installed mods load fast enough that this view change shouldn't be noticed.

This also fixes a bug where details aren't shown if more than one version of the mod is installed, as can happen with mediavps.