### PR TITLE
Add Software rendering support

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -873,5 +873,65 @@ namespace Knossos.NET
 
             return false;
         }
+
+        /// <summary>
+        /// Try to get an Enviroment Variable, checks process, user and machine global levels
+        /// </summary>
+        /// <param name="variableName"></param>
+        /// <returns>string value or null if not found or exception</returns>
+        public static string? GetEnvironmentVariable(string variableName)
+        {
+            //Check all 3 targets
+            try
+            {
+                string? returnValue = Environment.GetEnvironmentVariable(variableName, EnvironmentVariableTarget.Process);
+
+                if (returnValue != null)
+                {
+                    return returnValue;
+                }
+                else
+                {
+                    returnValue = Environment.GetEnvironmentVariable(variableName, EnvironmentVariableTarget.User);
+
+                    if (returnValue != null)
+                    {
+                        return returnValue;
+                    }
+                    else
+                    {
+                        return Environment.GetEnvironmentVariable(variableName, EnvironmentVariableTarget.Machine);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "KnUtils.GetEnvironmentVariable()", ex);
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Sets an Enviroment Variable
+        /// Default target is process level, optional user and machine(global) levels
+        /// Note: User and machine levels only works on Windows.
+        /// </summary>
+        /// <param name="variableName"></param>
+        /// <param name="value"></param>
+        /// <param name="target"></param>
+        /// <returns>true if successful or false otherwise</returns>
+        public static bool SetEnvironmentVariable(string variableName, string? value, EnvironmentVariableTarget target = EnvironmentVariableTarget.Process)
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable(variableName, value, target);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "KnUtils.SetEnvironmentVariable()", ex);
+            }
+            return false;
+        }
     }
 }

--- a/Knossos.NET/Program.cs
+++ b/Knossos.NET/Program.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Platform;
 using System;
 
 namespace Knossos.NET
@@ -9,13 +10,67 @@ namespace Knossos.NET
         // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
         // yet and stuff might break.
         [STAThread]
-        public static void Main(string[] args) => BuildAvaloniaApp()
-            .StartWithClassicDesktopLifetime(args);
+        public static void Main(string[] args)
+        {
+            bool softwareRendering = false;
+
+            //Check app args
+            foreach (var arg in args)
+            {
+                if (arg.ToLower() == "-software")
+                {
+                    softwareRendering = true;
+                }
+            }
+
+            //Check enviroment variables
+            var renderMode = KnUtils.GetEnvironmentVariable("KNET_RENDER_MODE");
+
+            if (renderMode != null && renderMode.ToLower() == "software")
+            {
+                softwareRendering = true;
+            }
+
+            //Start App
+            BuildAvaloniaApp(softwareRendering).StartWithClassicDesktopLifetime(args);
+        }
 
         // Avalonia configuration, don't remove; also used by visual designer.
-        public static AppBuilder BuildAvaloniaApp()
-            => AppBuilder.Configure<App>()
-                .UsePlatformDetect()
-                .LogToTrace();
+        public static AppBuilder BuildAvaloniaApp(bool softwareRendering)
+        {
+            //Disable Hardware Renderer
+            if(softwareRendering)
+            {
+                return AppBuilder.Configure<App>()
+                       .UsePlatformDetect()
+                       .LogToTrace()
+                       .With(new Win32PlatformOptions
+                       {   //Windows
+                           RenderingMode = new[]
+                           {
+                                Win32RenderingMode.Software
+                           }
+                       })
+                       .With(new X11PlatformOptions
+                       {   //Linux
+                           RenderingMode = new[]
+                           {
+                               X11RenderingMode.Software
+                           }
+                       })
+                       .With(new AvaloniaNativePlatformOptions
+                       {   //MacOS
+                           RenderingMode = new[]
+                           {
+                               AvaloniaNativeRenderingMode.Software
+                           }
+                       });
+            }
+
+            //Default
+            return AppBuilder.Configure<App>()
+                   .UsePlatformDetect()
+                   .LogToTrace();
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ If no version is given (KnossosNET.exe -playmod mod-id) the highest version of t
 The "Mod Settings" window displays the cmdline to play that mod directly via quick launch.<br />
 
 <br /><br />
+## **Software Rendering Mode:**<br />
+By default Knet will render the UI in the GPU, can be set to run completely on software rendering what effectively avoids any use of the user GPU, this will come at the cost of increased CPU usage, what should not be a problem when in idle.
+<br />
+You can force the software rendering mode by using the "-software" cmdline argument or by setting an environment variable "KNET_RENDER_MODE" to "software".
+
+<br /><br />
 ## **mod.ini Support:**<br />
 Using legacy mod.ini files for mod folders is also supported, and some additional keys were added to extend support. mod.ini can be used to attempt to load an old mod or to manually add a mod to the launcher whiout having to write a mod.json file. The folder still has to be placed in the correct path inside the library as with any other mod.<br />
 


### PR DESCRIPTION
Add support to set software render mode by cmdline or environment variable.

Waiting to see if there is any way from code to check the actual status to see if i can display that information.
When this is enabled hardware acceleration is, for sure, disabled. But if software mode is not enforced it could either be hardware or software, if hardware acceleration could not be enabled in the user system for whatever reason.