### PR TITLE
Update color on QuickSetup Guide

### DIFF
--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -16,7 +16,7 @@
 		<Border Margin="0,5,0,5" Grid.Row="0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 			<StackPanel>
 				<WrapPanel Margin="0,10,0,0">
-					<Button Command="{Binding QuickSetupCommand}" FontSize="20" Background="Black" Margin="5,0,0,0">Quick Setup Guide</Button>
+					<Button Command="{Binding QuickSetupCommand}" FontSize="20" Classes="Quaternary" Margin="5,0,0,0">Quick Setup Guide</Button>
 					<Button Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" Margin="510,0,0,0" Classes="Cancel">Reset</Button>
 					<Button Command="{Binding ReloadFlagData}" FontSize="20" Margin="10,0,0,0">Reload Data</Button>
 					<Button Command="{Binding SaveCommand}"  FontWeight="Bold" FontSize="20" Classes="Accept" Margin="10,0,0,0">Save</Button>


### PR DESCRIPTION
I've noticed and heard from some folks that the current button color on the Quick Setup Guide does not standout much. Following chats with ShivanSPS on Discord I updated it to blue (since the other colors are already used by other buttons in the header row, and blue looked nice IMO).

Current:
![image](https://github.com/KnossosNET/Knossos.NET/assets/14077810/ff1a758e-4aa3-41c0-8933-bef38d4e05c9)

New:
![image](https://github.com/KnossosNET/Knossos.NET/assets/14077810/8144bd8a-23a2-4bdc-88cc-b6681e595f19)
