### PR TITLE
BTA Changes, aka TC mods changes

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -757,97 +757,6 @@ namespace Knossos.NET
                 }
             }
 
-            /* Build mod flag */
-            foreach (var modid in mod.GetModFlagList())
-            {
-                /* Load this mod */
-                if (modid == mod.id)
-                {
-                    /* Dev Mode ON */
-                    if (mod.devMode)
-                    {
-                        foreach (var pkg in mod.packages.OrderBy(x => x.name))
-                        {
-                            if (pkg.isEnabled)
-                            {
-                                if (modFlag.Length > 0)
-                                {
-                                    modFlag += "," + mod.folderName + Path.DirectorySeparatorChar + pkg.folder;
-                                }
-                                else
-                                {
-                                    modFlag += mod.folderName + Path.DirectorySeparatorChar + pkg.folder;
-                                }
-                            }
-                        }
-
-                        //If standalone the multi.cfg will be on mod root\data to avoid uploading it to nebula
-                        if (standaloneServer)
-                        {
-                            if (modFlag.Length > 0)
-                            {
-                                modFlag += "," + mod.folderName;
-                            }
-                            else
-                            {
-                                modFlag += mod.folderName;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        //avoid passing FS2 in modflag because fs2retail runs off the working folder
-                        if (mod.id != "FS2")
-                        {
-                            if (modFlag.Length > 0)
-                            {
-                                modFlag += "," + mod.folderName;
-                            }
-                            else
-                            {
-                                modFlag += mod.folderName;
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    foreach (var depMod in modList)
-                    {
-                        if (depMod.id == modid)
-                        {
-                            /* Dev Mode ON */
-                            if (depMod.devMode)
-                            {
-                                foreach (var pkg in depMod.packages)
-                                {
-                                    if(modFlag.Length > 0)
-                                    {
-                                        modFlag += "," + depMod.folderName + Path.DirectorySeparatorChar + pkg.folder;
-                                    }
-                                    else
-                                    {
-                                        modFlag += depMod.folderName + Path.DirectorySeparatorChar + pkg.folder;
-                                    }
-                                    
-                                }
-                            }
-                            else
-                            {
-                                if (modFlag.Length > 0)
-                                {
-                                    modFlag += "," + depMod.folderName;
-                                }
-                                else
-                                {
-                                    modFlag += depMod.folderName;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
             /* Determine root folder */
             var rootPath = string.Empty;
 
@@ -900,7 +809,97 @@ namespace Knossos.NET
                 Log.Add(Log.LogSeverity.Information, "Knossos.PlayMod()", "Used working folder : " + rootPath);
             }
 
-            if(fsoBuild == null)
+            /* Build mod flag */
+            foreach (var modid in mod.GetModFlagList())
+            {
+                /* Load this mod */
+                if (modid == mod.id)
+                {
+                    /* Dev Mode ON */
+                    if (mod.devMode)
+                    {
+                        foreach (var pkg in mod.packages.OrderBy(x => x.name))
+                        {
+                            if (pkg.isEnabled)
+                            {
+                                if (modFlag.Length > 0)
+                                {
+                                    modFlag += "," + Path.GetRelativePath(rootPath, mod.fullPath + Path.DirectorySeparatorChar + pkg.folder);
+                                }
+                                else
+                                {
+                                    modFlag += Path.GetRelativePath(rootPath, mod.fullPath + Path.DirectorySeparatorChar + pkg.folder);
+                                }
+                            }
+                        }
+
+                        //If standalone the multi.cfg will be on mod root\data to avoid uploading it to nebula
+                        if (standaloneServer)
+                        {
+                            if (modFlag.Length > 0)
+                            {
+                                modFlag += "," + Path.GetRelativePath(rootPath, mod.fullPath);
+                            }
+                            else
+                            {
+                                modFlag += Path.GetRelativePath(rootPath, mod.fullPath);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        //avoid passing FS2 in modflag because fs2retail runs off the working folder
+                        if (mod.id != "FS2")
+                        {
+                            if (modFlag.Length > 0)
+                            {
+                                modFlag += "," + mod.folderName;
+                            }
+                            else
+                            {
+                                modFlag += mod.folderName;
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var depMod in modList)
+                    {
+                        if (depMod.id == modid)
+                        {
+                            /* Dev Mode ON */
+                            if (depMod.devMode)
+                            {
+                                foreach (var pkg in depMod.packages)
+                                {
+                                    if (modFlag.Length > 0)
+                                    {
+                                        modFlag += "," + Path.GetRelativePath(rootPath, depMod.fullPath + Path.DirectorySeparatorChar + pkg.folder);
+                                    }
+                                    else
+                                    {
+                                        modFlag += Path.GetRelativePath(rootPath, depMod.fullPath + Path.DirectorySeparatorChar + pkg.folder);
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                if (modFlag.Length > 0)
+                                {
+                                    modFlag += "," + Path.GetRelativePath(rootPath, depMod.fullPath);
+                                }
+                                else
+                                {
+                                    modFlag += Path.GetRelativePath(rootPath, depMod.fullPath);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (fsoBuild == null)
             {
                 Log.Add(Log.LogSeverity.Error, "Knossos.PlayMod()", "Unable to find a valid FSO build for this mod!");
                 if(hasBuildDependency)

--- a/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
@@ -166,7 +166,8 @@ namespace Knossos.NET.ViewModels
 
                 foreach (var mod in mods)
                 {
-                    if (usedIds.IndexOf(mod.id) == -1 && modParent != null && modParent == mod.parent)
+                    //I have disabled the comparison that disallows TCs to depend on mods, and mods to depend on a mod from other TC
+                    if (usedIds.IndexOf(mod.id) == -1 /*&& modParent != null && modParent == mod.parent*/)
                     {
                         var itemMod = new ComboBoxItem();
                         itemMod.Content = mod.title + "  [ "+ mod.id+" ]";

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -276,7 +276,8 @@ namespace Knossos.NET.ViewModels
                             return;
                         }
 
-                        //If type = TC check it must have no mod dependencies of other mod parent
+                        //If type = TC check it must have no mod dependencies of other mod parent. Update: This was disabled
+                        /*
                         if (mod.type == ModType.tc)
                         {
                             foreach(var pkg in mod.packages)
@@ -304,6 +305,7 @@ namespace Knossos.NET.ViewModels
                                 }
                             }
                         }
+                        */
 
                         //If type = mod and parent is not "FS2" it must have a dependency pointing to a TC/Version mod.
                         if(mod.type == ModType.mod && mod.parent != "FS2")


### PR DESCRIPTION
This include 3 changes:

1) Update the mod flag generation to take relative paths instead assuming same rootpack
2) Remove the UI limitation prenventing TCs from having mods dependencies and allow mod to depend on other TC/MODs
3) Remove pre-upload check preventing TCs to depend on mods

All this is old-knossos behaviour.