### PR TITLE
Mod install/modify rework

### DIFF
--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -956,7 +956,7 @@ namespace Knossos.NET.Models
         [JsonIgnore]
         public string tooltip { get; set; } = string.Empty;
         /// <summary>
-        /// Used to indicate a pkg is needed during mod install chkbox selection
+        /// Used to indicate a pkg is needed during mod install checkbox selection
         /// Used to change checkbox foreground color during mod install/modify display
         /// </summary>
         [JsonIgnore]
@@ -973,7 +973,7 @@ namespace Knossos.NET.Models
 
         /// <summary>
         /// Used to store the original dependency reference during mod.GetMissingDependencies
-        /// Usefull to track down the original pkg this dependency belong to with
+        /// Useful to track down the original pkg this dependency belongs to
         /// mod.FindPackageWithDependency()
         /// Not saved in Json
         /// </summary>

--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -236,6 +236,7 @@ namespace Knossos.NET.Models
                                     missingDep.id = dep.id;
                                     missingDep.version = dep.version;
                                     missingDep.packages = missingPkg;
+                                    missingDep.originalDependency = dep;
                                     missingDependencyList.Add(missingDep);
                                 }
                             }
@@ -885,6 +886,26 @@ namespace Knossos.NET.Models
             }
             return false;
         }
+
+        /// <summary>
+        /// Try to track down the mod pkg that a ModDependency belongs too
+        /// </summary>
+        /// <param name="dependency"></param>
+        /// <returns>Returns the modpkg or null if not found</returns>
+        public ModPackage? FindPackageWithDependency(ModDependency? dependency)
+        {
+            if(dependency != null && packages != null && packages.Any())
+            {
+                foreach(var pkg in packages)
+                {
+                    if(pkg.dependencies != null && pkg.dependencies.FirstOrDefault(dep => dep == dependency) != null)
+                    {
+                        return pkg;
+                    }
+                }
+            }
+            return null;
+        }
     }
 
     public class ModMember
@@ -917,10 +938,29 @@ namespace Knossos.NET.Models
         public object? checkNotes { get; set; }
 
         /* Knet Only */
+        /// <summary>
+        /// used for pkg display in a checkbox.
+        /// NOT Saved in the json
+        /// </summary>
         [JsonIgnore]
         public bool isSelected { get; set; } = false;
-
+        /// <summary>
+        /// used for display (to enable/disabled chkbox) and to enable/disable the package in devmode
+        /// Saved in the json
+        /// </summary>
         public bool isEnabled { get; set; } = true;
+        /// <summary>
+        /// Used to display checkbox tooltip
+        /// NOT saved in the Json
+        /// </summary>
+        [JsonIgnore]
+        public string tooltip { get; set; } = string.Empty;
+        /// <summary>
+        /// Used to indicate a pkg is needed during mod install chkbox selection
+        /// Used to change checkbox foreground color during mod install/modify display
+        /// </summary>
+        [JsonIgnore]
+        public bool isRequired { get; set; } = false;
         [JsonIgnore]
         public int buildScore { get; set; } = 0;
     }
@@ -930,6 +970,15 @@ namespace Knossos.NET.Models
         public string id { get; set; } = string.Empty; // required
         public string? version { get; set; } // required, https://getcomposer.org/doc/01-basic-usage.md#package-versions
         public List<string>? packages { get; set; } // optional, specifies which optional and recommended packages are also required
+
+        /// <summary>
+        /// Used to store the original dependency reference during mod.GetMissingDependencies
+        /// Usefull to track down the original pkg this dependency belong to with
+        /// mod.FindPackageWithDependency()
+        /// Not saved in Json
+        /// </summary>
+        [JsonIgnore]
+        public ModDependency? originalDependency;
 
         /// <summary>
         /// Returns the best installed mod that meets this dependency by semantic version, null if none.

--- a/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Knossos.NET.Classes;
 using Knossos.NET.Models;
 using Knossos.NET.Views;
 using System;
@@ -209,6 +210,9 @@ namespace Knossos.NET.ViewModels
                 }
                 else
                 {
+                    //If this mod-version is not installed we have any other version of it installed?
+                    var otherVersionInstalled = Knossos.GetInstalledModList(SelectedMod.id)?.MaxBy(m => new SemanticVersion(m.version));
+   
                     foreach(var pkg in SelectedMod.packages)
                     {
                         switch (pkg.status)
@@ -225,6 +229,21 @@ namespace Knossos.NET.ViewModels
                                 pkg.isEnabled = true;
                                 pkg.isSelected = false;
                                 break;
+                        }
+
+                        //Copy pkg selection from the installed version if we can
+                        if (otherVersionInstalled != null && pkg.status != "required")
+                        {
+                            var pkgExist = otherVersionInstalled.packages.FirstOrDefault(p=>p.name == pkg.name);
+                            if (pkgExist != null)
+                            {
+                                pkg.isSelected = true;
+                            }
+                            else
+                            {
+                                pkg.isSelected = false;
+                            }
+                            pkg.tooltip = "\n\nNote: Selection status was copied from installed version: " + otherVersionInstalled.version;
                         }
                     }
 
@@ -306,11 +325,11 @@ namespace Knossos.NET.ViewModels
                                     var originalPkg = mod.FindPackageWithDependency(dep.originalDependency);
                                     if(originalPkg != null)
                                     {
-                                        pkg.tooltip += "\nRequired by MOD: " + mod + "\nPKG: " + originalPkg.name;
+                                        pkg.tooltip += "\n\nRequired by MOD: " + mod + "\nPKG: " + originalPkg.name;
                                     }
                                     else
                                     {
-                                        pkg.tooltip += "\nRequired by MOD: " + mod;
+                                        pkg.tooltip += "\n\nRequired by MOD: " + mod;
                                     }
                                 }
                             }

--- a/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
@@ -320,14 +320,17 @@ namespace Knossos.NET.ViewModels
                                 pkg.isSelected = true;
                                 pkg.isRequired = true;
 
-                                if (!pkg.tooltip.Contains(mod.ToString()))
+                                var originalPkg = mod.FindPackageWithDependency(dep.originalDependency);
+                                if(originalPkg != null)
                                 {
-                                    var originalPkg = mod.FindPackageWithDependency(dep.originalDependency);
-                                    if(originalPkg != null)
+                                    if (!pkg.tooltip.Contains(mod + "\nPKG: " + originalPkg.name))
                                     {
                                         pkg.tooltip += "\n\nRequired by MOD: " + mod + "\nPKG: " + originalPkg.name;
                                     }
-                                    else
+                                }
+                                else
+                                {
+                                    if (!pkg.tooltip.Contains(mod.ToString()))
                                     {
                                         pkg.tooltip += "\n\nRequired by MOD: " + mod;
                                     }

--- a/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
@@ -210,7 +210,7 @@ namespace Knossos.NET.ViewModels
                 }
                 else
                 {
-                    //If this mod-version is not installed we have any other version of it installed?
+                    //If this mod-version is not installed, do we have any other version of it installed?
                     var otherVersionInstalled = Knossos.GetInstalledModList(SelectedMod.id)?.MaxBy(m => new SemanticVersion(m.version));
    
                     foreach(var pkg in SelectedMod.packages)
@@ -312,7 +312,7 @@ namespace Knossos.NET.ViewModels
                     {
                         if (dep != null && dep.packages != null)
                         {
-                            //Auto select needed packages and inform in the tooltip and change foreground
+                            //Auto select needed packages and inform via tooltip, updating the foreground
                             var depPkg = dep.packages.FirstOrDefault(dp => dp == pkg.name);
                             if (depPkg != null && pkg.status != "required")
                             {

--- a/Knossos.NET/Views/Windows/ModInstallView.axaml
+++ b/Knossos.NET/Views/Windows/ModInstallView.axaml
@@ -12,7 +12,7 @@
 		xmlns:models="using:Knossos.NET.Models"
 		Icon="/Assets/knossos-icon.ico"
 		SizeToContent="Width"
-		Height="500"
+		Height="600"
 		Title="{Binding Title}"
 		CanResize="True">
 	
@@ -54,7 +54,8 @@
 				</TreeDataTemplate>
 				<DataTemplate DataType="models:ModPackage">
 					<WrapPanel>
-						<CheckBox Checked="CheckBox_Changed" Unchecked="CheckBox_Changed" ToolTip.Tip="{Binding notes}" Content="{Binding name}" IsChecked="{Binding isSelected}" IsEnabled="{Binding isEnabled}" Width="350"></CheckBox>
+						<CheckBox IsVisible="{Binding !isRequired}" Checked="CheckBox_Changed" Unchecked="CheckBox_Changed" ToolTip.Tip="{Binding tooltip}" Content="{Binding name}" IsChecked="{Binding isSelected}" IsEnabled="{Binding isEnabled}" Width="350"></CheckBox>
+						<CheckBox IsVisible="{Binding isRequired}" Foreground="Orange" Checked="CheckBox_Changed" Unchecked="CheckBox_Changed" ToolTip.Tip="{Binding tooltip}" Content="{Binding name}" IsChecked="{Binding isSelected}" IsEnabled="{Binding isEnabled}" Width="350"></CheckBox>
 					</WrapPanel>
 				</DataTemplate>
 			</TreeView.DataTemplates>


### PR DESCRIPTION
This is a important change to the mod install and modify system.

In short what was changed:

1) During mod install or modify pkg status was used, this resulted in sometime the package status being changed in the local json from recommended/optional to required sometimes. I seem to remember that my original intention was to revert those values back to their original value before saving the json but it seems i completely forgot about it.
Now the pkg status is not changed anymore.

2) Do not longer force a needed pkg to be forced selected. 
When a pkg was referenced as a dependency the old system marked it as required forcing the checkbox to be selected and disabled, so it could not be unchecked.
This behaviour causes problems on some cases so now all pkgs in in that condition will be selected on be default, and the foreground for the checkbox will be orange indicating it is important, and the tooltip will indicate that the pkg is requiered by a mod/pkg.

3) Do not check by default recommended pkg for installed mods during mod modify, this fixes the reported mod modify bug on discord.

4) Add missing delete mod pkg function.

5) Also implement #137 
Note: This will only apply for the current mod we are installing and not for potential dependencies of it.
