### PR TITLE
Make mod detail selection consistent

### DIFF
--- a/Knossos.NET/ViewModels/Templates/ModCardViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/ModCardViewModel.cs
@@ -96,11 +96,13 @@ namespace Knossos.NET.ViewModels
         {
             modJson.ClearUnusedData();
             Log.Add(Log.LogSeverity.Information, "ModCardViewModel.AddModVersion()", "Adding additional version for mod id: " + ID + " -> " + modJson.folderName);
+            string currentVersion = modVersions[activeVersionIndex].version;
             modVersions.Add(modJson);
-            if (SemanticVersion.Compare(modJson.version, modVersions[activeVersionIndex].version) > 0)
+            modVersions.Sort((o1, o2) => -SemanticVersion.Compare(o1.version, o2.version));
+            if (SemanticVersion.Compare(modJson.version, currentVersion) > 0)
             {
                 Log.Add(Log.LogSeverity.Information, "ModCardViewModel.AddModVersion()", "Changing active version for " + modJson.title + " from " + modVersions[activeVersionIndex].version + " to " + modJson.version);
-                activeVersionIndex = modVersions.Count - 1;
+                activeVersionIndex = modVersions.FindIndex((m) => m.version.Equals(modJson.version));
                 Name = modJson.title;
                 ModVersion = modJson.version + " (+" + (modVersions.Count - 1) + ")";
                 LoadImage();

--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -154,7 +154,7 @@ namespace Knossos.NET.ViewModels
             ItemSelectedIndex = selectedIndex;
 
             if (modVersions.Count > 0)
-                LoadVersion(0);
+                LoadVersion(selectedIndex);
 
             if (modVersions.Any() && modVersions[0].type == ModType.engine)
             {

--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -153,8 +153,10 @@ namespace Knossos.NET.ViewModels
             //Data loads on selected index change
             ItemSelectedIndex = selectedIndex;
 
-            if (modVersions.Count > 0)
+            if (modVersions.Count > selectedIndex)
                 LoadVersion(selectedIndex);
+            else if (modVersions.Count > 0)
+                LoadVersion(0);
 
             if (modVersions.Any() && modVersions[0].type == ModType.engine)
             {


### PR DESCRIPTION
Previously, clicking detail on a mod card could cause two annoyances:
1. Clicking detail, regardless of current mod selection, would always select the first build in the mod list. This is somewhat unintuitive, since users probably don't expect a change just from clicking on detail. Changed to actually open the detail pane on whatever mod version was selected.
2. The mod list is not properly ordered by version. Hence, not only is the version list itself completely all over the place, but also the "select first" issue would select a potentially old version of the mod. This fixes this, by properly resorting the list whenever a mod is added