### PR TITLE
Add Version Date to Install Screen

### DIFF
--- a/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModInstallViewModel.cs
@@ -26,6 +26,8 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string version = string.Empty;
         [ObservableProperty]
+        internal string releaseDate = string.Empty;
+        [ObservableProperty]
         internal string name = string.Empty;
         [ObservableProperty]
         internal int selectedIndex = -1;
@@ -265,6 +267,11 @@ namespace Knossos.NET.ViewModels
                 Compress=SelectedMod.modSettings.isCompressed;
                 Name = SelectedMod.title;
                 Version = SelectedMod.version;
+                if (SelectedMod.lastUpdate != null){                
+                    ReleaseDate = SelectedMod.lastUpdate;
+                } else {
+                    ReleaseDate = "Was not listed in repository";
+                }
                 await ProcessMod(SelectedMod,allMods);
             }
             if (!IsInstalled && SelectedMod != null && ModVersions.Count > 1 && ModVersions.IndexOf(SelectedMod) > 0)

--- a/Knossos.NET/Views/Windows/ModInstallView.axaml
+++ b/Knossos.NET/Views/Windows/ModInstallView.axaml
@@ -25,7 +25,7 @@
 		<StackPanel IsVisible="{Binding DataLoaded}" Margin="0,20,0,0" Grid.Row="0">
 			<TextBlock Text="{Binding Name}" IsVisible="{Binding DataLoaded}" Margin="0,10,0,0" FontWeight="Bold" FontSize="28" HorizontalAlignment="Center"></TextBlock>
 			<Label FontSize="16" Margin="5" IsVisible="{Binding HasWriteAccess}" Foreground="DarkGoldenrod" HorizontalAlignment="Center">You have write access to this mod.</Label>
-			<Label FontSize="16" Margin="5" IsVisible="{Binding ForceDevMode}" Foreground="DarkGoldenrod" HorizontalAlignment="Center">DevMode install is forced ON</Label>
+			<Label FontSize="16" Margin="5" IsVisible="{Binding ForceDevMode}" Foreground="DarkGoldenrod" HorizontalAlignment="Center">DevMode install is forced ON</Label>			
 			<ComboBox ItemsSource="{Binding ModVersions}" SelectedItem="{Binding SelectedMod}" SelectedIndex="{Binding SelectedIndex}"  IsVisible="{Binding DataLoaded}" Margin="0,10,0,0" FontWeight="Bold" FontSize="22" HorizontalAlignment="Center">
 				<ComboBox.ItemTemplate>
 					<DataTemplate>
@@ -33,6 +33,8 @@
 					</DataTemplate>
 				</ComboBox.ItemTemplate>
 			</ComboBox>
+			<TextBlock Margin="0,5,0,0" FontSize="14" HorizontalAlignment="Center" >Version Release Date: </TextBlock>
+			<TextBlock FontSize="14" HorizontalAlignment="Center" Text="{Binding ReleaseDate}"></TextBlock>
 			<Label ToolTip.Tip="Download size consist of LZMA2 7z compressed files with max compression, the actual extracted size will be considerable higher than this value. It is recommended that you have at least double free space than what it is indicated here." Content="{Binding InstallSize}" Margin="5" FontSize="18" HorizontalAlignment="Center"></Label>
 			<Label Content="{Binding FreeSpace}" Margin="5,0,5,5" FontSize="18" HorizontalAlignment="Center"></Label>
 			<Label IsVisible="{Binding IsInstalled}" HorizontalAlignment="Center" FontWeight="Black" Foreground="Green"> This version is installed, you can add optional packages</Label>


### PR DESCRIPTION
Because it would be much more involved to add it to the combo box, add the release date to the text in the description.

Fixes #154 

How it looks.  (Two different versions to show the date changes when the selection changes)

![Screenshot 2024-02-19 061106](https://github.com/KnossosNET/Knossos.NET/assets/12529946/f8952e34-d65d-4d67-92cf-eed33d2ba81e)

![Screenshot 2024-02-19 061123](https://github.com/KnossosNET/Knossos.NET/assets/12529946/eb0740fc-c38a-453d-8faa-141d3265f96d)
