### PR TITLE
Fix AA name overflows and improve tool tips for video options

### DIFF
--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -140,18 +140,18 @@
 						<!-- Resolution -->
 						<WrapPanel Margin="5,0,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Display Resolution</TextBlock>
-							<ComboBox SelectedIndex="{Binding BitsSelectedIndex}" IsVisible="{Binding FlagDataLoaded}" Grid.Column="2" Width="100" Margin="10,0,0,0">
+							<ComboBox ToolTip.Tip="Bit depth of display resolution. Should autodetect best option by default (likely 32)." SelectedIndex="{Binding BitsSelectedIndex}" IsVisible="{Binding FlagDataLoaded}" Grid.Column="2" Width="100" Margin="10,0,0,0">
 								<ComboBoxItem Tag="32">32 Bit</ComboBoxItem>
 								<ComboBoxItem Tag="16" IsEnabled="{Binding Enable16BitColor}">16 bit</ComboBoxItem>
 							</ComboBox>
 							<TextBlock Text="First download a FSO build to enable this setting." IsVisible="{Binding !FlagDataLoaded}" VerticalAlignment="Center" Foreground="Red" FontWeight="Bold" Grid.Column="1" Width="500" Margin="10,0,0,0"></TextBlock>
-							<ComboBox SelectedIndex="{Binding ResolutionSelectedIndex}" ItemsSource="{Binding ResolutionItems}" IsVisible="{Binding FlagDataLoaded}" Grid.Column="1" Width="300" Margin="10,0,0,0"></ComboBox>
+							<ComboBox ToolTip.Tip="Display resolution FSO will run at. Default is your system display resolution." SelectedIndex="{Binding ResolutionSelectedIndex}" ItemsSource="{Binding ResolutionItems}" IsVisible="{Binding FlagDataLoaded}" Grid.Column="1" Width="300" Margin="10,0,0,0"></ComboBox>
 							<Button Margin="130,0,0,0" Command="{Binding OpenPerformanceHelp}" Classes="Quaternary" Content="Tips to Optimize Game Performance" ToolTip.Tip="View help for optimizing performance" HorizontalAlignment="Right"></Button>
 						</WrapPanel>
 						<!-- Resolution -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Texture Filtering</TextBlock>
-							<ComboBox SelectedIndex="{Binding TextureSelectedIndex}" Grid.Column="1" Width="100" Margin="10,0,0,0">
+							<ComboBox ToolTip.Tip="Trilinear is recommended for most systems." SelectedIndex="{Binding TextureSelectedIndex}" Grid.Column="1" Width="100" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Bilinear</ComboBoxItem>
 								<ComboBoxItem Tag="1">Trilinear</ComboBoxItem>
 							</ComboBox>
@@ -159,7 +159,7 @@
 						<!-- Window -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label VerticalAlignment="Center" Grid.Column="0" Width="200">Windowed Mode</Label>
-							<ComboBox SelectedIndex="{Binding WindowMode}" Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<ComboBox ToolTip.Tip="It is recommended to run in windowed mode at the same resolution as your system display. There is no need to enable the borderless mode, as windowed mode is already borderless at native resolution." SelectedIndex="{Binding WindowMode}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Windowed</ComboBoxItem>
 								<ComboBoxItem Tag="1">Borderless</ComboBoxItem>
 								<ComboBoxItem Tag="2">Fullscreen</ComboBoxItem>
@@ -168,7 +168,7 @@
 						<!-- Shadows -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Label VerticalAlignment="Center" Grid.Column="0" Width="200">Shadows</Label>
-							<ComboBox ToolTip.Tip="High performance impact, especially at Ultra" Tag="-shadow_quality" SelectedIndex="{Binding ShadowQualitySelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<ComboBox ToolTip.Tip="Enables shadow mapping. High performance impact, especially at Ultra. Disabled by default." Tag="-shadow_quality" SelectedIndex="{Binding ShadowQualitySelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 								<ComboBoxItem Tag="1">Low</ComboBoxItem>
 								<ComboBoxItem Tag="2">Medium</ComboBoxItem>
@@ -178,8 +178,8 @@
 						</Grid>
 						<!-- AA Filter -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Post-process Anti-aliasing</Label>
-							<ComboBox Tag="-aa_preset" SelectedIndex="{Binding AaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Post-processing AA</Label>
+							<ComboBox ToolTip.Tip="Enables anti-aliasing (AA) step which helps smooth model edges. Enabled by default at 'SMAA Low'." Tag="-aa_preset" SelectedIndex="{Binding AaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 								<ComboBoxItem Tag="1">FXAA Low</ComboBoxItem>
 								<ComboBoxItem Tag="2">FXAA Medium</ComboBoxItem>
@@ -192,8 +192,8 @@
 						</Grid>
 						<!-- SMAA Filter -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-						<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Multisample Anti-aliasing</Label>
-						<ComboBox ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
+						<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample AA</Label>
+						<ComboBox ToolTip.Tip="Extra anti-aliasing (AA) step that is separate from the less expensive 'Post-processing AA' step. High performance impact, especially at Ultra or at >= 4k resolution. Disabled by default." Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 							<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 							<ComboBoxItem Tag="4">High</ComboBoxItem>
 							<ComboBoxItem Tag="8">Ultra</ComboBoxItem>
@@ -202,33 +202,33 @@
 						<!-- Enable deferred lighting -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Deferred Lighting</Label> 
-							<CheckBox Tag="-no_deferred" IsChecked="{Binding EnableDeferredLighting}"></CheckBox>
+							<CheckBox ToolTip.Tip="Enables dynamic lighting, such as from weapons, explosions, and ships. Enabled by default." Tag="-no_deferred" IsChecked="{Binding EnableDeferredLighting}"></CheckBox>
 						</WrapPanel>
 						<!-- Enable soft particles -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Soft Particles</Label> 
-							<CheckBox Tag="-soft_particles" IsChecked="{Binding EnableSoftParticles}"></CheckBox>
+							<CheckBox ToolTip.Tip="Enables softer, more natural blending of overlapping effects. Enabled by default." Tag="-soft_particles" IsChecked="{Binding EnableSoftParticles}"></CheckBox>
 						</WrapPanel>
-						<!-- Disable Post Processing -->
+						<!-- Enable Post Processing -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Post Processing</Label> 
-							<CheckBox Tag="-no_post_process" IsChecked="{Binding PostProcess}"></CheckBox>
+							<CheckBox ToolTip.Tip="Enable basic Post Processing, which helps ensure visuals are balanced. Enabled by default." Tag="-no_post_process" IsChecked="{Binding PostProcess}"></CheckBox>
 						</WrapPanel>
 
 						<!-- VSYNC -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">VSync</Label> 
-							<CheckBox Tag="-no_vsync" IsChecked="{Binding Vsync}"></CheckBox>
+							<CheckBox ToolTip.Tip="Enable vertical sync, which ensures the game FPS matches the monitor FPS. Enabled by default." Tag="-no_vsync" IsChecked="{Binding Vsync}"></CheckBox>
 						</WrapPanel>
 						<!-- FPS Cap -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Limit to 120 FPS</Label> 
-							<CheckBox Tag="-no_fps_capping" IsChecked="{Binding !NoFpsCapping}"></CheckBox>
+							<CheckBox ToolTip.Tip="Caps the frames-per-second (FPS) of FSO to 120. Enabled by default." Tag="-no_fps_capping" IsChecked="{Binding !NoFpsCapping}"></CheckBox>
 						</WrapPanel>
 						<!-- Show FPS -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label> 
-							<CheckBox Tag="-fps" IsChecked="{Binding ShowFps}"></CheckBox>
+							<CheckBox ToolTip.Tip="Displays a counter of the frames-per-second (FPS) in the upper left corner of the screen during missions. Disabled by default." Tag="-fps" IsChecked="{Binding ShowFps}"></CheckBox>
 						</WrapPanel>
 					</StackPanel>
 				</Border>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -178,7 +178,7 @@
 						</Grid>
 						<!-- AA Filter -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Post-processing Anti-Aliasing</Label>
+							<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Post-process Anti-aliasing</Label>
 							<ComboBox Tag="-aa_preset" SelectedIndex="{Binding AaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 								<ComboBoxItem Tag="1">FXAA Low</ComboBoxItem>
@@ -192,7 +192,7 @@
 						</Grid>
 						<!-- SMAA Filter -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-						<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Extra Multisample Anti-Aliasing</Label>
+						<Label Grid.Column="0" Width="200" VerticalAlignment="Center">Multisample Anti-aliasing</Label>
 						<ComboBox ToolTip.Tip="High performance impact, especially at Ultra or at >= 4k resolution" Tag="-msaa" SelectedIndex="{Binding MsaaSelectedIndex}" Grid.Column="1" Width="150" Margin="10,0,0,0">
 							<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 							<ComboBoxItem Tag="4">High</ComboBoxItem>

--- a/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
+++ b/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
@@ -12,8 +12,8 @@
 		CanResize="False">
 	
 	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
-		<TextBlock Margin="10,20,20,10" TextWrapping="Wrap">If in-game performance is slow, close the game and then try disabling "Extra Multi Sample Anti-Aliasing" and "Shadows".</TextBlock>
-		<TextBlock Margin="10,10,20,10" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and then "Post-processing Anti-Aliasing".</TextBlock>
+		<TextBlock Margin="10,20,20,10" TextWrapping="Wrap">If in-game performance is slow, close the game and then try disabling "Multisample Anti-aliasing" and "Shadows".</TextBlock>
+		<TextBlock Margin="10,10,20,10" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and then "Post-process Anti-aliasing".</TextBlock>
 		<TextBlock Margin="10,10,20,20" TextWrapping="Wrap">And always remember to click the "Save" button!</TextBlock>
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
+++ b/Knossos.NET/Views/Windows/PerformanceHelpView.axaml
@@ -12,8 +12,8 @@
 		CanResize="False">
 	
 	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
-		<TextBlock Margin="10,20,20,10" TextWrapping="Wrap">If in-game performance is slow, close the game and then try disabling "Multisample Anti-aliasing" and "Shadows".</TextBlock>
-		<TextBlock Margin="10,10,20,10" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and then "Post-process Anti-aliasing".</TextBlock>
+		<TextBlock Margin="10,20,20,10" TextWrapping="Wrap">If in-game performance is slow, close the game and then try disabling "Extra Multisample AA" and "Shadows". Note, "Extra Multisample AA" is an added, more expensive anti-aliasing step and if it is disabled then "Post-processing AA" will still be be applied. </TextBlock>
+		<TextBlock Margin="10,10,20,10" TextWrapping="Wrap">The next best options to disable are "Deferred Lighting" and then "Post-processing AA".</TextBlock>
 		<TextBlock Margin="10,10,20,20" TextWrapping="Wrap">And always remember to click the "Save" button!</TextBlock>
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -83,7 +83,7 @@
 		<StackPanel IsVisible="{Binding Page6}" Grid.Row="0" >
 			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Finishing</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Finally, before launching a mod go to the "Settings" tab and configure video and audio settings, as well as any joysticks you may have installed. Always remember to click "Save" after changing any values.</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">It is recommended to run in windowed mode at the same resolution as your desktop resolution. There is no need to enable the borderless mode, as windowed mode is already borderless at native resolution.</TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">It is recommended to run in windowed mode at the same resolution as your system display. There is no need to enable the borderless mode, as windowed mode is already borderless at native resolution.</TextBlock>
 		</StackPanel>
 		
 		<!--Navigation-->


### PR DESCRIPTION
The new text PR makes two of the longer names in the Video options slightly cutoff. One option is to move the drop downs and check boxes more to the right, but then they would be out of alignment with the rest of the columns from other sections. Another, simpler option might be to just shorten the names, since they are rather long compared to other option  names. From my tests, editing the names is the easiest and looks the best.  Would be happy to refine as requested of course.