### PR TITLE
Improve New Mod Name During Creation

### DIFF
--- a/Knossos.NET/ViewModels/Windows/DevModCreateNewViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/DevModCreateNewViewModel.cs
@@ -24,17 +24,31 @@ namespace Knossos.NET.ViewModels
             get { return modId; }
             set 
             {
-                SetProperty(ref modId, Regex.Replace(value.Replace(" ", ""), "[^a-zA-Z0-9_]+", "", RegexOptions.Compiled));
+                SetProperty(ref modId, Regex.Replace(value.Replace(" ", "_"), "[^a-zA-Z0-9_]+", "", RegexOptions.Compiled));
+
+                if (modName == lastmodName){
+                    modIDManual = true;
+                }
             }
         }
+
+        // These two variables help track if the user is manually setting the mod ID.
+        internal string lastmodName = string.Empty;
+        internal bool modIDManual = false;
+
         internal string modName = string.Empty;
         internal string ModName
         {
             get { return modName; }
             set
             {
-                SetProperty(ref modName, Regex.Replace(value, "[^a-zA-Z0-9-__ ]+", "", RegexOptions.Compiled));
-                ModId = modName;
+                SetProperty(ref modName, value);
+
+                if (modName != lastmodName && !modIDManual){
+                    ModId = modName;
+                }
+
+                lastmodName = modName;
             }
         }
         [ObservableProperty]


### PR DESCRIPTION
1) Remove the regex replace for mod names, as there is no restriction in the mod dev details tab. 

2) Automatically replace spaces with underscores in the modID 

3) Keep track of whether the user has manually set the ModID, and stop automatically setting the ModID from the mod name, if so.

Tested.

Fixes #151 
In draft until I hear back from ShivanSpS about whether having arbitrary characters in the mod name is supported by Nebula.