### PR TITLE
Fix Knossos Not sorting mods on startup

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -609,6 +609,11 @@ namespace Knossos.NET
                     await QuickLaunch();
                 }
             }
+
+            Dispatcher.UIThread.Invoke(() =>
+            {
+                MainWindowViewModel.Instance?.InstalledModsView?.ChangeSort(MainWindowViewModel.Instance?.sharedSortType!);
+            });
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/ModListViewModel.cs
+++ b/Knossos.NET/ViewModels/ModListViewModel.cs
@@ -17,7 +17,7 @@ namespace Knossos.NET.ViewModels
         /// <summary>
         /// Current Sort Mode
         /// </summary>
-        internal MainWindowViewModel.SortType sortType = MainWindowViewModel.SortType.name;
+        internal MainWindowViewModel.SortType sortType = MainWindowViewModel.SortType.unsorted;
 
         internal string search = string.Empty;
         internal string Search
@@ -137,12 +137,15 @@ namespace Knossos.NET.ViewModels
                 {
                     Dispatcher.UIThread.Invoke( () =>
                     {
-                        sortType = newSort;
                         var tempList = Mods.ToList();
-                        tempList.Sort(CompareMods);
-                        for (int i = 0; i < tempList.Count; i++)
-                        {
-                            Mods.Move(Mods.IndexOf(tempList[i]), i);
+                        // Only sort and update to the new sort type if we have mods to sort!
+                        if (tempList.Any()){
+                            sortType = newSort;
+                            tempList.Sort(CompareMods);
+                            for (int i = 0; i < tempList.Count; i++)
+                            {
+                                Mods.Move(Mods.IndexOf(tempList[i]), i);
+                            }
                         }
                         GC.Collect();
                     },DispatcherPriority.Background);

--- a/Knossos.NET/ViewModels/NebulaModListViewModel.cs
+++ b/Knossos.NET/ViewModels/NebulaModListViewModel.cs
@@ -20,7 +20,7 @@ namespace Knossos.NET.ViewModels
         /// <summary>
         /// Current Sort Mode
         /// </summary>
-        internal MainWindowViewModel.SortType sortType = MainWindowViewModel.SortType.name;
+        internal MainWindowViewModel.SortType sortType = MainWindowViewModel.SortType.unsorted;
 
         /// <summary>
         /// The user has opened this tab in this session?

--- a/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
@@ -50,7 +50,8 @@ namespace Knossos.NET.ViewModels
         {
             name,
             release,
-            update
+            update,
+            unsorted
         }
 
         internal SortType sharedSortType = SortType.name;
@@ -69,7 +70,7 @@ namespace Knossos.NET.ViewModels
                         sharedSearch = InstalledModsView.Search;
 
                         // Change and save to the new sort type.
-                        if (sharedSortType != InstalledModsView.sortType)
+                        if (sharedSortType != InstalledModsView.sortType && InstalledModsView.sortType != SortType.unsorted)
                         {
                             sharedSortType = InstalledModsView.sortType;
                             Knossos.globalSettings.Save(false);
@@ -79,7 +80,7 @@ namespace Knossos.NET.ViewModels
                     {
                         sharedSearch = NebulaModsView.Search;
 
-                        if (sharedSortType != NebulaModsView.sortType)
+                        if (sharedSortType != NebulaModsView.sortType && NebulaModsView.sortType != SortType.unsorted)
                         {
                             sharedSortType = NebulaModsView.sortType;
                             Knossos.globalSettings.Save(false);


### PR DESCRIPTION
There were two issues:

1) The mod sorting was happening before the mods were loaded

2) If the saved mod preference was loading by name, it would do nothing since that was the default.

This commit sets the initial value to unsorted, sorts when there are actually mods to sort, and only saves a non-unsorted preference.

Fixes #147 