### PR TITLE
Set File.Move() on installer update.exe update to override existing file

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -399,7 +399,7 @@ namespace Knossos.NET
 
                                             if (KnUtils.WasInstallerUsed())
                                             {
-                                                File.Move(Path.Combine(KnUtils.GetKnossosDataFolderPath(), "update" + extension), Path.Combine(updateFilesFolder, "update" + extension));
+                                                File.Move(Path.Combine(KnUtils.GetKnossosDataFolderPath(), "update" + extension), Path.Combine(updateFilesFolder, "update" + extension), true);
                                             }
                                             else
                                             {


### PR DESCRIPTION
When i was updating the installer version 0.2.0-RC10 to 1.0 i got an error

"you cant create a file that already exists" on "kn_update\update.exe"

I have no idea why that file was there maybe was a leftover with an older version from before we implemented the scripts, as the script should have cleared it. Anyway, overrwritting the file if it exist seems to be the right solution. I dont really know how to test it but it should work.
