### PR TITLE
Ignore installed builds whiout any valid executables when clicking play

### DIFF
--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -163,6 +163,20 @@ namespace Knossos.NET.Models
         }
 
         /// <summary>
+        /// Returns true if this build contains at least one executable
+        /// that can be executed on this system.
+        /// Note: pkg list must be already loaded
+        /// </summary>
+        public bool IsValidBuild()
+        {
+            if(executables.Count > 0 && executables.FirstOrDefault(x=>x.isValid) != null)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
         /// Updates Updates Build Json data
         /// This updates everything, including stability and the executables array
         /// </summary>

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -716,7 +716,7 @@ namespace Knossos.NET
                         if (fsoBuild == null && mod.modSettings.customBuildId == null)
                         {
                             hasBuildDependency = true;
-                            fsoBuild = dep.SelectBuild();
+                            fsoBuild = dep.SelectBuild(true);
                         }
                     }
                 }

--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -1068,15 +1068,16 @@ namespace Knossos.NET.Models
 
         /// <summary>
         /// Returns the best installed build that meets this dependency by semantic version, null if none.
+        /// Optional: Only select builds with at least one valid executabl
         /// </summary>
         /// <returns>FsoBuild or null</returns>
-        public FsoBuild? SelectBuild()
+        public FsoBuild? SelectBuild(bool onlyWithValidExecutable = false)
         {
             FsoBuild? validBuild = null;
 
             foreach (var build in Knossos.GetInstalledBuildsList(id, FsoStability.Stable))
             {
-                if (SemanticVersion.SastifiesDependency(version, build.version))
+                if ((!onlyWithValidExecutable || onlyWithValidExecutable && build.IsValidBuild()) && SemanticVersion.SastifiesDependency(version, build.version))
                 {
                   
                     if (validBuild == null)
@@ -1097,7 +1098,7 @@ namespace Knossos.NET.Models
             {
                 foreach (var build in Knossos.GetInstalledBuildsList(id, FsoStability.RC))
                 {
-                    if (SemanticVersion.SastifiesDependency(version, build.version))
+                    if ((!onlyWithValidExecutable || onlyWithValidExecutable && build.IsValidBuild()) && SemanticVersion.SastifiesDependency(version, build.version))
                     {
 
                         if (validBuild == null)
@@ -1119,7 +1120,7 @@ namespace Knossos.NET.Models
             {
                 foreach (var build in Knossos.GetInstalledBuildsList(id, FsoStability.Nightly))
                 {
-                    if (SemanticVersion.SastifiesDependency(version, build.version))
+                    if ((!onlyWithValidExecutable || onlyWithValidExecutable && build.IsValidBuild()) && SemanticVersion.SastifiesDependency(version, build.version))
                     {
 
                         if (validBuild == null)
@@ -1141,7 +1142,7 @@ namespace Knossos.NET.Models
             {
                 foreach (var build in Knossos.GetInstalledBuildsList(id, FsoStability.Custom))
                 {
-                    if (SemanticVersion.SastifiesDependency(version, build.version))
+                    if ((!onlyWithValidExecutable || onlyWithValidExecutable && build.IsValidBuild()) && SemanticVersion.SastifiesDependency(version, build.version))
                     {
 
                         if (validBuild == null)


### PR DESCRIPTION
Build selection is done by what is selected by the dependency semantic version, semantic version can give you an invalid build, in the case of Wings of Dawn and linux.

17.0.0 contains linux exec, but 17.0.1 does not, if you manually install 17.0.0 linux build and 17.0.1 windows build is installed, wod will still try to select 17.0.1 on linux what will fail. This pr makes that when clicking play, builds whiout valid executables will not be longer considered for builds selection.

Not sure if something can be done during mod install to avoid this same scenario. As things are installing wod on linux will install an empty 17.0.1 because there arent any linux executables in that build. 

EDIT: Ok i got a check in during mod install, this will try a maximum of 10 times to get an alternative build that sastifies the dependency if the currently selected one has an incompatible enviroment string.
This is nasty but it is the only thing i could think off since repo_minimal does not allow to properly do this check at the mod install stage.

I checked it with x64 and arm64 linux and it seens to behave as expected, but ill suggest that more testing is done here during mod install.