### PR TITLE
Create debug filters window

### DIFF
--- a/Knossos.NET/Classes/DebugFilters.cs
+++ b/Knossos.NET/Classes/DebugFilters.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using Knossos.NET.ViewModels;
 
 namespace Knossos.NET.Classes{
 
@@ -18,6 +19,13 @@ namespace Knossos.NET.Classes{
 
             [ObservableProperty]
             internal bool enabled = false;
+
+            public void SaveConfig(){
+                if (DebugFiltersViewModel.Instance != null){
+                    DebugFiltersViewModel.Instance.SaveConfig();
+                }
+            }
+
         }
 
         [ObservableProperty]
@@ -25,14 +33,12 @@ namespace Knossos.NET.Classes{
         [ObservableProperty]
         internal ObservableCollection<DebugFilter> filters = new ObservableCollection<DebugFilter>();
 
-        public void AddCustom(string customFilter){
+        public void AddCustom(string customFilter, bool enabled){
             var newFilter = new DebugFilter();
             newFilter.Filter = customFilter;
-            newFilter.Enabled = true;
+            newFilter.Enabled = enabled;
 
             Filters.Add(newFilter);
         }
-        
-        // TODO!  Create a save function
     }
 }

--- a/Knossos.NET/Classes/DebugFilters.cs
+++ b/Knossos.NET/Classes/DebugFilters.cs
@@ -35,6 +35,14 @@ namespace Knossos.NET.Classes{
 
         public void AddCustom(string customFilter, bool enabled){
             var newFilter = new DebugFilter();
+            
+            // Strings longer than 31 trigger an assert in FSO.
+            // We could remove the assert, but we still need to support older builds.
+            if (customFilter.Length > 31)
+            {
+                customFilter = customFilter.Trim().Substring(0, 31);
+            }
+
             newFilter.Filter = customFilter;
             newFilter.Enabled = enabled;
 

--- a/Knossos.NET/Classes/DebugFilters.cs
+++ b/Knossos.NET/Classes/DebugFilters.cs
@@ -6,22 +6,23 @@ using System.Collections.ObjectModel;
 
 namespace Knossos.NET.Classes{
 
-
     public partial class DebugFilterCategory  : ObservableObject
     {
-        public string typeName { get; set; } = string.Empty;
-
-        public partial class DebugFilter
+        public partial class DebugFilter : ObservableObject
         {        
-            [JsonPropertyName("Filter")]
-            public string filterName { get; set; } = string.Empty;
-            public string description { get; set; } = string.Empty;
+            [JsonPropertyName("Filter"), ObservableProperty]
+            internal string filterName = string.Empty;
+            [JsonPropertyName("Description"), ObservableProperty]
+            internal string description = string.Empty;
 
-            public bool enabled = false;
+            [ObservableProperty]
+            internal bool enabled = false;
         }
 
         [ObservableProperty]
-        public ObservableCollection<DebugFilter> questions = new ObservableCollection<DebugFilter>();
+        internal string typeName = string.Empty;
+        [ObservableProperty]
+        internal ObservableCollection<DebugFilter> filters = new ObservableCollection<DebugFilter>();
 
         // TODO!  Create a save function
     }

--- a/Knossos.NET/Classes/DebugFilters.cs
+++ b/Knossos.NET/Classes/DebugFilters.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 
 namespace Knossos.NET.Classes{
 
@@ -24,6 +25,14 @@ namespace Knossos.NET.Classes{
         [ObservableProperty]
         internal ObservableCollection<DebugFilter> filters = new ObservableCollection<DebugFilter>();
 
+        public void AddCustom(string customFilter){
+            var newFilter = new DebugFilter();
+            newFilter.Filter = customFilter;
+            newFilter.Enabled = true;
+
+            Filters.Add(newFilter);
+        }
+        
         // TODO!  Create a save function
     }
 }

--- a/Knossos.NET/Classes/DebugFilters.cs
+++ b/Knossos.NET/Classes/DebugFilters.cs
@@ -1,0 +1,28 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Knossos.NET.Classes{
+
+
+    public partial class DebugFilterCategory  : ObservableObject
+    {
+        public string typeName { get; set; } = string.Empty;
+
+        public partial class DebugFilter
+        {        
+            [JsonPropertyName("Filter")]
+            public string filterName { get; set; } = string.Empty;
+            public string description { get; set; } = string.Empty;
+
+            public bool enabled = false;
+        }
+
+        [ObservableProperty]
+        public ObservableCollection<DebugFilter> questions = new ObservableCollection<DebugFilter>();
+
+        // TODO!  Create a save function
+    }
+}

--- a/Knossos.NET/Classes/DebugFilters.cs
+++ b/Knossos.NET/Classes/DebugFilters.cs
@@ -11,7 +11,7 @@ namespace Knossos.NET.Classes{
         public partial class DebugFilter : ObservableObject
         {        
             [JsonPropertyName("Filter"), ObservableProperty]
-            internal string filterName = string.Empty;
+            internal string filter = string.Empty;
             [JsonPropertyName("Description"), ObservableProperty]
             internal string description = string.Empty;
 
@@ -20,7 +20,7 @@ namespace Knossos.NET.Classes{
         }
 
         [ObservableProperty]
-        internal string typeName = string.Empty;
+        internal string typename = string.Empty;
         [ObservableProperty]
         internal ObservableCollection<DebugFilter> filters = new ObservableCollection<DebugFilter>();
 

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -20,6 +20,7 @@ namespace Knossos.NET
         public readonly static string ToolRepoURL = "https://raw.githubusercontent.com/KnossosNET/Knet-Tool-Repo/main/knet_tools.json";
         public readonly static string GitHubUpdateRepoURL = "https://api.github.com/repos/KnossosNET/Knossos.NET";
         public readonly static string FAQURL = "https://raw.githubusercontent.com/KnossosNET/KNet-General-Resources-Repo/main/communityfaq.json";
+        public readonly static string debugFilterURL = "https://www.johnfernandez.dev";
         private static List<Mod> installedMods = new List<Mod>();
         private static List<FsoBuild> engineBuilds = new List<FsoBuild>();
         private static List<Tool> modTools = new List<Tool>();

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -20,7 +20,7 @@ namespace Knossos.NET
         public readonly static string ToolRepoURL = "https://raw.githubusercontent.com/KnossosNET/Knet-Tool-Repo/main/knet_tools.json";
         public readonly static string GitHubUpdateRepoURL = "https://api.github.com/repos/KnossosNET/Knossos.NET";
         public readonly static string FAQURL = "https://raw.githubusercontent.com/KnossosNET/KNet-General-Resources-Repo/main/communityfaq.json";
-        public readonly static string debugFilterURL = "https://www.johnfernandez.dev";
+        public readonly static string debugFilterURL = "https://raw.githubusercontent.com/KnossosNET/KNet-General-Resources-Repo/main/debug-filters.json";
         private static List<Mod> installedMods = new List<Mod>();
         private static List<FsoBuild> engineBuilds = new List<FsoBuild>();
         private static List<Tool> modTools = new List<Tool>();

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -1133,5 +1133,16 @@ namespace Knossos.NET.ViewModels
                 }
             }).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Open Debug Filter Dialog
+        /// </summary>
+        internal async void OpenDebugFilterView()
+        {
+            var dialog = new Views.DebugFiltersView();
+            dialog.DataContext = new DebugFiltersViewModel();
+            await dialog.ShowDialog<DebugFiltersView?>(MainWindow.instance!);
+        }
+
     }
 }

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -5,9 +5,11 @@ using Knossos.NET.Classes;
 using Knossos.NET.Models;
 using Knossos.NET.Views;
 using System.Collections.ObjectModel;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Net.Http;
+using System.IO;
 using Avalonia.Threading;
 
 
@@ -18,6 +20,8 @@ namespace Knossos.NET.ViewModels
     /// </summary>
     public partial class DebugFiltersViewModel : ViewModelBase 
     {
+        public static DebugFiltersViewModel? Instance { get; set; }
+
         [ObservableProperty]
         internal ObservableCollection<DebugFilterCategory> categories = new ObservableCollection<DebugFilterCategory>();
         [ObservableProperty]
@@ -60,8 +64,98 @@ namespace Knossos.NET.ViewModels
                 }
             }
 
-            // TODO! Add loading of saved settings here.
+            // Load info from any valid config
+            bool configFound = false;
 
+            foreach(var mod in Knossos.GetInstalledModList(null))
+            {
+                try {
+                    // Debug filter files are always in the data folder.
+                    var path = Path.Combine(mod.fullPath, "data", "debug_filter.cfg");
+                    if (File.Exists(path)) 
+                    {
+                        configFound = true;
+                        using (StreamReader reader = new StreamReader(Path.Combine(mod.fullPath, "data", "debug_filter.cfg"))) 
+                        {
+                            string? line;
+                            while ((line = reader.ReadLine()) != null)
+                            {
+                                bool enable = true;
+                                string option = string.Empty;
+
+                                // Treat it just like FSO does.  Use the first character to tell if it's enabled or disabled.
+                                if (line.StartsWith("+"))
+                                {
+                                    enable = true;
+                                    option = line.Substring(1).Trim();
+                                } else if (line.StartsWith("-"))
+                                {
+                                    enable = false;
+                                    option = line.Substring(1).Trim();
+                                }
+
+                                if (option != string.Empty)
+                                {
+                                    bool found = false;
+                                    foreach (var category in Categories)
+                                    {
+                                        foreach (var filter in category.Filters)
+                                        {
+                                            if (filter.Filter.Trim().ToLower() == option.ToLower())
+                                            {
+                                                filter.Enabled = enable;
+                                                found = true;
+                                                break;
+                                            }
+                                            
+                                        }
+                                        if (found) 
+                                        {
+                                            break;
+                                        }
+                                    }
+
+                                    // if we didn't have a match in the standard categories
+                                    if (!found)
+                                    {
+                                        foreach (var category in Categories)
+                                        {
+                                            if (category.Typename == "Custom")
+                                            {
+                                                found = true;
+                                                category.AddCustom(option, enable);
+                                                break;
+                                            }
+                                        }
+                                    }
+
+                                    // if we also didn't have a custom category setup.
+                                    if (!found)
+                                    {
+                                        var customCategory = new DebugFilterCategory();
+                                        customCategory.Typename = "Custom";
+                                        customCategory.AddCustom(option, enable); 
+                                        Categories.Insert(0, customCategory);
+                                    }
+                                }
+                            }
+                        }
+                    }                
+                }
+                catch(Exception ex)
+                {
+                    // retry
+                    configFound = false;
+                    Log.Add(Log.LogSeverity.Warning, "DebugFiltersViewModel.LoadDebugRepo()", ex);
+                }
+                // Only process the first valid config
+                if (configFound)
+                {
+                    break;
+                }
+            }
+
+            Instance = this;
             Initialized = true;
         }
 
@@ -81,8 +175,9 @@ namespace Knossos.NET.ViewModels
             // Look for a custom category that already exists
             foreach(var category in Categories) {
                 // Add new filter to it, if so
-                if (category.Typename == "Custom"){
-                    category.AddCustom(CustomFilter);
+                if (category.Typename == "Custom")
+                {
+                    category.AddCustom(CustomFilter, true);
 
                     // Empty the text box when done.
                     CustomFilter = string.Empty;
@@ -93,12 +188,79 @@ namespace Knossos.NET.ViewModels
             // if no custom category exists, add it and then add the new filter
             var customCategory = new DebugFilterCategory();
             customCategory.Typename = "Custom";
-            customCategory.AddCustom(CustomFilter);
+            customCategory.AddCustom(CustomFilter, true);
             Categories.Insert(0, customCategory);
 
             // Empty the text box when done.
             CustomFilter = string.Empty;
+
+            SaveConfig();
+        }
+
+        public void SaveConfig(){
+            foreach(var mod in Knossos.GetInstalledModList(null))
+            {
+                if (mod.type == ModType.tc) {
+                    try 
+                    {
+                        // Debug filter files are always in the data folder.
+                        if(!Directory.Exists(Path.Combine(mod.fullPath, "data")))
+                        {
+                            Directory.CreateDirectory(Path.Combine(mod.fullPath, "data"));
+                        }
+
+                        // much easier to start over with settings the user has chosen
+                        var path = Path.Combine(mod.fullPath, "data", "debug_filter.cfg");
+                        if (File.Exists(path)) {
+                            File.Delete(path);
+                        }
+
+                        using (StreamWriter sw = new StreamWriter(path, false, new UTF8Encoding(false)))
+                        {
+                            foreach(var category in Categories)
+                            {
+                                // Every custom filter must be added or it will be lost.
+                                if (category.Typename == "Custom") 
+                                {
+                                    foreach(var filter in category.Filters)
+                                    {
+                                        if (filter.Enabled) {
+                                            sw.WriteLine("+" + filter.Filter);
+                                        } else {
+                                            sw.WriteLine("-" + filter.Filter);
+                                        }
+                                    }
+                                } 
+                                // General are on by default, so only list if they are disabled
+                                else if (category.Typename == "General")
+                                {
+                                    foreach(var filter in category.Filters)
+                                    {
+                                        if (!filter.Enabled) 
+                                        {
+                                            sw.WriteLine("-" + filter.Filter);
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    foreach(var filter in category.Filters)
+                                    {
+                                        if (filter.Enabled)
+                                        {
+                                            sw.WriteLine("+" + filter.Filter);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch(Exception ex)
+                    {
+                        Log.Add(Log.LogSeverity.Error, "DebugFiltersViewModel.SaveConfig() is unable to save: ", ex);
+                    }
+                }
+            }
         }
     }
-
 }

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -52,5 +52,11 @@ namespace Knossos.NET.ViewModels
             Initialized = true;
 
         }
+
+        public DebugFiltersViewModel()
+        {
+        }
+
     }
+
 }

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -1,0 +1,56 @@
+
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using Knossos.NET.Classes;
+using Knossos.NET.Models;
+using Knossos.NET.Views;
+using System.Collections.ObjectModel;
+using System.Text.Json;
+using System.Threading.Tasks;
+using System.Net.Http;
+using Avalonia.Threading;
+
+
+namespace Knossos.NET.ViewModels
+{
+    /// <summary>
+    /// Debug Filter View Model
+    /// </summary>
+    public partial class DebugFiltersViewModel : ViewModelBase 
+    {
+        [ObservableProperty]
+        internal ObservableCollection<DebugFilterCategory> categories = new ObservableCollection<DebugFilterCategory>();
+        [ObservableProperty]
+        private bool initialized = false;
+
+        public async Task LoadDebugRepo()
+        {
+            if (Initialized)
+                return;
+
+            try
+            {
+                HttpResponseMessage response = await KnUtils.GetHttpClient().GetAsync(Knossos.debugFilterURL).ConfigureAwait(false);
+                var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var debugRepo = JsonSerializer.Deserialize<DebugFilterCategory[]>(json)!;
+                if(debugRepo != null)
+                {
+                    foreach(var category in debugRepo)
+                    {
+                        Categories.Insert(Categories.Count, category);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "DebugFilterViewModel.LoadDebugRepo()", ex);
+                return;
+            }
+
+            // TODO! Add loading of saved settings here.
+
+            Initialized = true;
+
+        }
+    }
+}

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -147,7 +147,7 @@ namespace Knossos.NET.ViewModels
 
         public DebugFiltersViewModel()
         {
-            LoadDebugRepo();
+            Task.Run(() => LoadDebugRepo());
         }
 
         public void AddFilter()

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -47,10 +47,17 @@ namespace Knossos.NET.ViewModels
                 return;
             }
 
+            foreach(var category in Categories){
+                if (category.Typename == "General"){
+                    foreach(var filter in category.Filters){
+                        filter.Enabled = true;
+                    }
+                }
+            }
+
             // TODO! Add loading of saved settings here.
 
             Initialized = true;
-
         }
 
         public DebugFiltersViewModel()

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -22,6 +22,8 @@ namespace Knossos.NET.ViewModels
         internal ObservableCollection<DebugFilterCategory> categories = new ObservableCollection<DebugFilterCategory>();
         [ObservableProperty]
         private bool initialized = false;
+        [ObservableProperty]
+        private string customFilter = string.Empty;
 
         public async Task LoadDebugRepo()
         {
@@ -65,6 +67,35 @@ namespace Knossos.NET.ViewModels
             LoadDebugRepo();
         }
 
+        public void AddFilter()
+        {
+            // If we pressed by accident, ignore
+            if (CustomFilter == string.Empty)
+            {
+                return;
+            }
+
+            // Look for a custom category that already exists
+            foreach(var category in Categories) {
+                // Add new filter to it, if so
+                if (category.Typename == "Custom"){
+                    category.AddCustom(CustomFilter);
+
+                    // Empty the text box when done.
+                    CustomFilter = string.Empty;
+                    return;
+                }
+            }
+
+            // if no custom category exists, add it and then add the new filter
+            var customCategory = new DebugFilterCategory();
+            customCategory.Typename = "Custom";
+            customCategory.AddCustom(CustomFilter);
+            Categories.Insert(0, customCategory);
+
+            // Empty the text box when done.
+            CustomFilter = string.Empty;
+        }
     }
 
 }

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -64,95 +64,81 @@ namespace Knossos.NET.ViewModels
                 }
             }
 
-            // Load info from any valid config
-            bool configFound = false;
-
-            foreach(var mod in Knossos.GetInstalledModList(null))
-            {
-                try {
-                    // Debug filter files are always in the data folder.
-                    var path = Path.Combine(mod.fullPath, "data", "debug_filter.cfg");
-                    if (File.Exists(path)) 
+            try {
+                // Debug filter files are always in the data folder.
+                var path = Path.Combine(KnUtils.GetFSODataFolderPath(), "data", "debug_filter.cfg");
+                if (File.Exists(path)) 
+                {
+                    using (StreamReader reader = new StreamReader(Path.Combine(KnUtils.GetFSODataFolderPath(), "data", "debug_filter.cfg"))) 
                     {
-                        configFound = true;
-                        using (StreamReader reader = new StreamReader(Path.Combine(mod.fullPath, "data", "debug_filter.cfg"))) 
+                        string? line;
+                        while ((line = reader.ReadLine()) != null)
                         {
-                            string? line;
-                            while ((line = reader.ReadLine()) != null)
-                            {
-                                bool enable = true;
-                                string option = string.Empty;
+                            bool enable = true;
+                            string option = string.Empty;
 
-                                // Treat it just like FSO does.  Use the first character to tell if it's enabled or disabled.
-                                if (line.StartsWith("+"))
+                            // Treat it just like FSO does.  Use the first character to tell if it's enabled or disabled.
+                            if (line.StartsWith("+"))
+                            {
+                                enable = true;
+                                option = line.Substring(1).Trim();
+                            } else if (line.StartsWith("-"))
+                            {
+                                enable = false;
+                                option = line.Substring(1).Trim();
+                            }
+
+                            if (option != string.Empty)
+                            {
+                                bool found = false;
+                                foreach (var category in Categories)
                                 {
-                                    enable = true;
-                                    option = line.Substring(1).Trim();
-                                } else if (line.StartsWith("-"))
-                                {
-                                    enable = false;
-                                    option = line.Substring(1).Trim();
+                                    foreach (var filter in category.Filters)
+                                    {
+                                        if (filter.Filter.Trim().ToLower() == option.ToLower())
+                                        {
+                                            filter.Enabled = enable;
+                                            found = true;
+                                            break;
+                                        }
+                                        
+                                    }
+                                    if (found) 
+                                    {
+                                        break;
+                                    }
                                 }
 
-                                if (option != string.Empty)
+                                // if we didn't have a match in the standard categories
+                                if (!found)
                                 {
-                                    bool found = false;
                                     foreach (var category in Categories)
                                     {
-                                        foreach (var filter in category.Filters)
+                                        if (category.Typename == "Custom")
                                         {
-                                            if (filter.Filter.Trim().ToLower() == option.ToLower())
-                                            {
-                                                filter.Enabled = enable;
-                                                found = true;
-                                                break;
-                                            }
-                                            
-                                        }
-                                        if (found) 
-                                        {
+                                            found = true;
+                                            category.AddCustom(option, enable);
                                             break;
                                         }
                                     }
+                                }
 
-                                    // if we didn't have a match in the standard categories
-                                    if (!found)
-                                    {
-                                        foreach (var category in Categories)
-                                        {
-                                            if (category.Typename == "Custom")
-                                            {
-                                                found = true;
-                                                category.AddCustom(option, enable);
-                                                break;
-                                            }
-                                        }
-                                    }
-
-                                    // if we also didn't have a custom category setup.
-                                    if (!found)
-                                    {
-                                        var customCategory = new DebugFilterCategory();
-                                        customCategory.Typename = "Custom";
-                                        customCategory.AddCustom(option, enable); 
-                                        Categories.Insert(0, customCategory);
-                                    }
+                                // if we also didn't have a custom category setup.
+                                if (!found)
+                                {
+                                    var customCategory = new DebugFilterCategory();
+                                    customCategory.Typename = "Custom";
+                                    customCategory.AddCustom(option, enable); 
+                                    Categories.Insert(0, customCategory);
                                 }
                             }
                         }
-                    }                
-                }
-                catch(Exception ex)
-                {
-                    // retry
-                    configFound = false;
-                    Log.Add(Log.LogSeverity.Warning, "DebugFiltersViewModel.LoadDebugRepo()", ex);
-                }
-                // Only process the first valid config
-                if (configFound)
-                {
-                    break;
-                }
+                    }
+                }                
+            }
+            catch(Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Warning, "DebugFiltersViewModel.LoadDebugRepo()", ex);
             }
 
             Instance = this;
@@ -198,69 +184,65 @@ namespace Knossos.NET.ViewModels
         }
 
         public void SaveConfig(){
-            foreach(var mod in Knossos.GetInstalledModList(null))
+            try 
             {
-                if (mod.type == ModType.tc) {
-                    try 
+                if(!Directory.Exists(Path.Combine(KnUtils.GetFSODataFolderPath(), "data")))
+                {
+                    Directory.CreateDirectory(Path.Combine(KnUtils.GetFSODataFolderPath(), "data"));
+                }
+
+                // much easier to start over with settings the user has chosen
+                var path = Path.Combine(KnUtils.GetFSODataFolderPath(), "data", "debug_filter.cfg");
+                if (File.Exists(path)) {
+                    File.Delete(path);
+                }
+
+                using (StreamWriter sw = new StreamWriter(path, false, new UTF8Encoding(false)))
+                {
+                    foreach(var category in Categories)
                     {
-                        // Debug filter files are always in the data folder.
-                        if(!Directory.Exists(Path.Combine(mod.fullPath, "data")))
+                        // Every custom filter must be added or it will be lost.
+                        if (category.Typename == "Custom") 
                         {
-                            Directory.CreateDirectory(Path.Combine(mod.fullPath, "data"));
-                        }
-
-                        // much easier to start over with settings the user has chosen
-                        var path = Path.Combine(mod.fullPath, "data", "debug_filter.cfg");
-                        if (File.Exists(path)) {
-                            File.Delete(path);
-                        }
-
-                        using (StreamWriter sw = new StreamWriter(path, false, new UTF8Encoding(false)))
-                        {
-                            foreach(var category in Categories)
+                            foreach(var filter in category.Filters)
                             {
-                                // Every custom filter must be added or it will be lost.
-                                if (category.Typename == "Custom") 
-                                {
-                                    foreach(var filter in category.Filters)
-                                    {
-                                        if (filter.Enabled) {
-                                            sw.WriteLine("+" + filter.Filter);
-                                        } else {
-                                            sw.WriteLine("-" + filter.Filter);
-                                        }
-                                    }
-                                } 
-                                // General are on by default, so only list if they are disabled
-                                else if (category.Typename == "General")
-                                {
-                                    foreach(var filter in category.Filters)
-                                    {
-                                        if (!filter.Enabled) 
-                                        {
-                                            sw.WriteLine("-" + filter.Filter);
-                                        }
-                                    }
+                                if (filter.Enabled) {
+                                    sw.WriteLine("+" + filter.Filter);
+                                } else {
+                                    sw.WriteLine("-" + filter.Filter);
                                 }
-                                else
+                            }
+                        } 
+                        // General are on by default, so only list if they are disabled
+                        else if (category.Typename == "General")
+                        {
+                            foreach(var filter in category.Filters)
+                            {
+                                if (!filter.Enabled) 
                                 {
-                                    foreach(var filter in category.Filters)
-                                    {
-                                        if (filter.Enabled)
-                                        {
-                                            sw.WriteLine("+" + filter.Filter);
-                                        }
-                                    }
+                                    sw.WriteLine("-" + filter.Filter);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            foreach(var filter in category.Filters)
+                            {
+                                if (filter.Enabled)
+                                {
+                                    sw.WriteLine("+" + filter.Filter);
                                 }
                             }
                         }
                     }
-                    catch(Exception ex)
-                    {
-                        Log.Add(Log.LogSeverity.Error, "DebugFiltersViewModel.SaveConfig() is unable to save: ", ex);
-                    }
                 }
             }
+            catch(Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "DebugFiltersViewModel.SaveConfig() is unable to save: ", ex);
+            }
+        
+            
         }
     }
 }

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -55,6 +55,7 @@ namespace Knossos.NET.ViewModels
 
         public DebugFiltersViewModel()
         {
+            LoadDebugRepo();
         }
 
     }

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -69,7 +69,7 @@ namespace Knossos.NET.ViewModels
                 var path = Path.Combine(KnUtils.GetFSODataFolderPath(), "data", "debug_filter.cfg");
                 if (File.Exists(path)) 
                 {
-                    using (StreamReader reader = new StreamReader(Path.Combine(KnUtils.GetFSODataFolderPath(), "data", "debug_filter.cfg"))) 
+                    using (StreamReader reader = new StreamReader(path)) 
                     {
                         string? line;
                         while ((line = reader.ReadLine()) != null)

--- a/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DebugFiltersViewModel.cs
@@ -49,9 +49,12 @@ namespace Knossos.NET.ViewModels
                 return;
             }
 
-            foreach(var category in Categories){
-                if (category.Typename == "General"){
-                    foreach(var filter in category.Filters){
+            foreach(var category in Categories)
+            {
+                if (category.Typename == "General")
+                {
+                    foreach(var filter in category.Filters)
+                    {
                         filter.Enabled = true;
                     }
                 }

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -2972,7 +2972,7 @@ namespace Knossos.NET.ViewModels
                             try
                             {
                                 var fso = mod.GetDependency("FSO");
-                                if (fso != null && (fso.version == null || fso.version.Contains(">=") || SemanticVersion.Compare(fso.version.Replace(">=", "").Replace("<", "").Replace(">", "").Trim(), VPCompression.MinimumFSOVersion) > 0))
+                                if (fso != null && (fso.version == null || SemanticVersion.Compare(fso.version.Replace(">=", "").Replace("<", "").Replace(">", "").Trim(), VPCompression.MinimumFSOVersion) > 0))
                                     compressMod = true;
                             }
                             catch (Exception ex)

--- a/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
@@ -121,6 +121,11 @@ namespace Knossos.NET.ViewModels
                     {
                         Knossos.globalSettings.DisableIniWatch();
                     }
+                    if (tabIndex == 7) // Debug
+                    {
+                        LoadDebugRepo
+                    }
+
                 }
             }
         }
@@ -417,6 +422,16 @@ namespace Knossos.NET.ViewModels
             {
                 Log.Add(Log.LogSeverity.Error, "MainWindowViewModel.UploadKnossosConsole", ex);
             }
+        }
+
+        /// <summary>
+        /// Open Debug Filter Dialog
+        /// </summary>
+        internal async void OpenDebugFilterView()
+        {
+            var dialog = new DebugFiltersView();
+            dialog.DataContext = new DebugFiltersViewModel(dialog);
+            await dialog.ShowDialog<DevModCreateNewView?>(MainWindow.instance!);
         }
 
         internal void applySettingsToList()

--- a/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
@@ -123,7 +123,7 @@ namespace Knossos.NET.ViewModels
                     }
                     if (tabIndex == 7) // Debug
                     {
-                        LoadDebugRepo
+//                        LoadDebugRepo
                     }
 
                 }
@@ -429,9 +429,9 @@ namespace Knossos.NET.ViewModels
         /// </summary>
         internal async void OpenDebugFilterView()
         {
-            var dialog = new DebugFiltersView();
-            dialog.DataContext = new DebugFiltersViewModel(dialog);
-            await dialog.ShowDialog<DevModCreateNewView?>(MainWindow.instance!);
+            var dialog = new Views.DebugFiltersView();
+            dialog.DataContext = new DebugFiltersViewModel();
+            await dialog.ShowDialog<DebugFiltersView?>(MainWindow.instance!);
         }
 
         internal void applySettingsToList()

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -391,7 +391,7 @@
 						</Grid>
 						<!-- Debug Filter-->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
-							<Button Content="Adjust fs2open.log debug filters" Command="{Binding OpenDebugFilterView}"></Button>
+							<Button Content="Adjust Debug Filters" Command="{Binding OpenDebugFilterView}"></Button>
 						</Grid>
 					</StackPanel>
 				</Border>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -389,6 +389,10 @@
 							<Label ToolTip.Tip="Network port used by multiplayer. Default is 7808." Grid.Column="0" VerticalContentAlignment="Center" Width="210">Multiplayer Port</Label>
 							<NumericUpDown Value="{Binding MultiPort}" Grid.Column="1" Width="150"></NumericUpDown>
 						</Grid>
+						<!-- Debug Filter-->
+						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
+							<Button Content="Adjust fs2open.log debug filters" Command="{Binding OpenDebugFilterView}"></Button>
+						</Grid>
 					</StackPanel>
 				</Border>
 			</StackPanel>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -9,14 +9,42 @@
 		x:DataType="vm:DebugFiltersViewModel"
 		Icon="/Assets/knossos-icon.ico"
 		WindowStartupLocation="CenterScreen"
+		SizeToContent="WidthAndHeight"
         Title="Debug Filter Selection" 
 		CanResize="True">
 	
 	<Design.DataContext>
 		<vm:DebugFiltersViewModel/>
 	</Design.DataContext>
-	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
-		<TextBlock>Additional Debug Filters:</TextBlock>
-		
+	<StackPanel Margin="10,15,10,15" Width="500" Background="{StaticResource BackgroundColorPrimary}">
+		<TextBlock ToolTip.Tip="These are options that enable additonal FSO debug log output. They range from useful to arcane.">Debug Filters:</TextBlock>
+		    <ScrollViewer Margin="0,10,0,0" >
+                <StackPanel Margin="30,0,20,10">
+                    <ItemsControl ItemsSource="{Binding Categories}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel HorizontalAlignment="Stretch" Margin="10,10,0,0">
+                            		<TextBlock Width="500" Text="{Binding TypeName}"></TextBlock>
+									<TreeView ItemsSource="{Binding Filters}">
+										<TreeView.ItemTemplate>
+											<TreeDataTemplate>
+												<StackPanel Margin="10,10,10,10">
+													<WrapPanel>
+														<TextBlock Text="{Binding FilterName}" TextWrapping="Wrap"></TextBlock>
+													</WrapPanel>
+													<WrapPanel>
+														<TextBlock Margin="0,10,0,5" Text="{Binding Description}" TextWrapping="Wrap"></TextBlock>
+													</WrapPanel>
+												</StackPanel>
+											</TreeDataTemplate>
+										</TreeView.ItemTemplate>
+									</TreeView>                                    
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+		    </ScrollViewer>
+
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -16,7 +16,7 @@
 	<Design.DataContext>
 		<vm:DebugFiltersViewModel/>
 	</Design.DataContext>
-	<StackPanel Margin="10,15,10,15" Width="500" Background="{StaticResource BackgroundColorPrimary}">
+	<StackPanel Margin="10,15,10,15">
 		<TextBlock Margin="10,10,0,0" ToolTip.Tip="These are options that enable additonal FSO debug log output. They range from useful to arcane.">Debug Filters:</TextBlock>
 		<StackPanel Margin="30,0,20,10">
 			<ScrollViewer Margin="5,10,0,0" >

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -3,28 +3,20 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="Knossos.NET.Views.CleanupKnossosLibraryView"
+        x:Class="Knossos.NET.Views.DebugFiltersView"
 	    xmlns:v="using:Knossos.NET.Views"
 		xmlns:vm="using:Knossos.NET.ViewModels"
-		x:DataType="vm:CleanupKnossosLibraryViewModel"
+		x:DataType="vm:DebugFiltersViewModel"
 		Icon="/Assets/knossos-icon.ico"
 		WindowStartupLocation="CenterScreen"
-        Title="Knossos Library Cleanup" 
-		SizeToContent="WidthAndHeight" 
+        Title="Debug Filter Selection" 
 		CanResize="True">
 	
 	<Design.DataContext>
-		<vm:DebugFilterViewModel/>
+		<vm:DebugFiltersViewModel/>
 	</Design.DataContext>
 	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
-		<TextBlock Margin="10" TextWrapping="Wrap">The following are old versions of mods that are not needed as any dependency and can be safely deleted. Uncheck all mod versions you want to keep.</TextBlock>
-		<ListBox MaxHeight="620" ItemsSource="{Binding DeletableMods}">
-			<ListBox.ItemTemplate>
-				<DataTemplate>
-					<v:CheckableModListView Content="{Binding}"/>
-				</DataTemplate>
-			</ListBox.ItemTemplate>
-		</ListBox>
-		<Button Classes="Secondary" Command="{Binding Cleanup}" Margin="10">Delete Selected Mods</Button>
+		<TextBlock>Additional Debug Filters:</TextBlock>
+		
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -16,10 +16,10 @@
 	<Design.DataContext>
 		<vm:DebugFiltersViewModel/>
 	</Design.DataContext>
-	<StackPanel Margin="10,15,10,15">
-		<TextBlock Margin="10,10,0,0" ToolTip.Tip="These are options that enable additonal FSO debug log output. They range from useful to arcane.">Debug Filters:</TextBlock>
-		<StackPanel Margin="30,0,20,10">
-			<ScrollViewer Margin="5,10,0,0" >
+	<ScrollViewer>
+		<StackPanel Margin="10,15,10,15">
+			<TextBlock Margin="10,10,0,0" ToolTip.Tip="These are options that enable additonal FSO debug log output. They range from useful to arcane.">Debug Filters:</TextBlock>
+			<StackPanel Margin="30,0,20,10">
 				<ItemsControl ItemsSource="{Binding Categories}">
 					<ItemsControl.ItemTemplate>
 						<DataTemplate>
@@ -29,7 +29,7 @@
 									<TreeView.ItemTemplate>
 										<TreeDataTemplate>
 											<StackPanel Margin="10,10,10,10">
-												<WrapPanel>
+												<WrapPanel Background="{StaticResource BackgroundColorPrimary}">
 													<CheckBox Margin="5,0,0,0" ToolTip.Tip="Enabled or disabled this filter." IsChecked="{Binding Enabled}"></CheckBox>
 													<TextBlock Margin="5,5,0,0" Text="{Binding Filter}" TextWrapping="Wrap"></TextBlock>
 												</WrapPanel>
@@ -44,7 +44,8 @@
 						</DataTemplate>
 					</ItemsControl.ItemTemplate>
 				</ItemsControl>
-			</ScrollViewer>
+			
+			</StackPanel>
 		</StackPanel>
-	</StackPanel>
+	</ScrollViewer>
 </Window>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -19,7 +19,7 @@
 		<StackPanel Margin="10,15,10,15">
 			<WrapPanel HorizontalAlignment="Right">
 				<TextBox Text="{Binding CustomFilter}" Width="200" Margin="10,10,0,0"></TextBox>
-				<Button Command="{Binding AddFilter}" Margin="20,9,10,0" Content="Add Custom Filter" Classes="Primary" ToolTip.Tip="When a filter is missing from this list or a custom build with custom filters is in use, use this button to add this filter to the Custom Filters category."></Button>
+				<Button Command="{Binding AddFilter}" Margin="20,9,10,0" Content="Add Custom Filter" Classes="Primary" ToolTip.Tip="When a filter is missing from this list or a custom build with custom filters is in use, use this button to add this filter to the Custom Filters category.  Note that custom filters can only be 31 characters long to maintain compatibility with all builds."></Button>
 			</WrapPanel>
 			<WrapPanel HorizontalAlignment="Right">
 				

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -37,7 +37,7 @@
 										<TreeDataTemplate>
 											<StackPanel Margin="10,10,10,10">
 												<WrapPanel Background="{StaticResource BackgroundColorPrimary}">
-													<CheckBox Margin="5,0,0,0" ToolTip.Tip="Enabled or disabled this filter." IsChecked="{Binding Enabled}"></CheckBox>
+													<CheckBox Command="{Binding SaveConfig}" Margin="5,0,0,0" ToolTip.Tip="Enabled or disabled this filter." IsChecked="{Binding Enabled}"></CheckBox>
 													<TextBlock Margin="5,8,0,0" Text="{Binding Filter}" TextWrapping="Wrap"></TextBlock>
 												</WrapPanel>
 												<WrapPanel>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -17,34 +17,34 @@
 		<vm:DebugFiltersViewModel/>
 	</Design.DataContext>
 	<StackPanel Margin="10,15,10,15" Width="500" Background="{StaticResource BackgroundColorPrimary}">
-		<TextBlock ToolTip.Tip="These are options that enable additonal FSO debug log output. They range from useful to arcane.">Debug Filters:</TextBlock>
-		    <ScrollViewer Margin="0,10,0,0" >
-                <StackPanel Margin="30,0,20,10">
-                    <ItemsControl ItemsSource="{Binding Categories}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <StackPanel HorizontalAlignment="Stretch" Margin="10,10,0,0">
-                            		<TextBlock Width="500" Text="{Binding TypeName}"></TextBlock>
-									<TreeView ItemsSource="{Binding Filters}">
-										<TreeView.ItemTemplate>
-											<TreeDataTemplate>
-												<StackPanel Margin="10,10,10,10">
-													<WrapPanel>
-														<TextBlock Text="{Binding FilterName}" TextWrapping="Wrap"></TextBlock>
-													</WrapPanel>
-													<WrapPanel>
-														<TextBlock Margin="0,10,0,5" Text="{Binding Description}" TextWrapping="Wrap"></TextBlock>
-													</WrapPanel>
-												</StackPanel>
-											</TreeDataTemplate>
-										</TreeView.ItemTemplate>
-									</TreeView>                                    
-                                </StackPanel>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </StackPanel>
-		    </ScrollViewer>
-
+		<TextBlock Margin="10,10,0,0" ToolTip.Tip="These are options that enable additonal FSO debug log output. They range from useful to arcane.">Debug Filters:</TextBlock>
+		<StackPanel Margin="30,0,20,10">
+			<ScrollViewer Margin="5,10,0,0" >
+				<ItemsControl ItemsSource="{Binding Categories}">
+					<ItemsControl.ItemTemplate>
+						<DataTemplate>
+							<StackPanel HorizontalAlignment="Stretch" Margin="10,10,0,0">
+								<TextBlock Margin="10,0,0,0" Text="{Binding Typename}"></TextBlock>
+								<TreeView ItemsSource="{Binding Filters}">
+									<TreeView.ItemTemplate>
+										<TreeDataTemplate>
+											<StackPanel Margin="10,10,10,10">
+												<WrapPanel>
+													<CheckBox Margin="5,0,0,0" ToolTip.Tip="Enabled or disabled this filter." IsChecked="{Binding Enabled}"></CheckBox>
+													<TextBlock Margin="5,5,0,0" Text="{Binding Filter}" TextWrapping="Wrap"></TextBlock>
+												</WrapPanel>
+												<WrapPanel>
+													<TextBlock Margin="0,10,0,5" Text="{Binding Description}" TextWrapping="Wrap"></TextBlock>
+												</WrapPanel>
+											</StackPanel>
+										</TreeDataTemplate>
+									</TreeView.ItemTemplate>
+								</TreeView>                                    
+							</StackPanel>
+						</DataTemplate>
+					</ItemsControl.ItemTemplate>
+				</ItemsControl>
+			</ScrollViewer>
+		</StackPanel>
 	</StackPanel>
 </Window>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -18,20 +18,28 @@
 	</Design.DataContext>
 	<ScrollViewer>
 		<StackPanel Margin="10,15,10,15">
-			<TextBlock Margin="10,10,0,0" ToolTip.Tip="These are options that enable additonal FSO debug log output. They range from useful to arcane.">Debug Filters:</TextBlock>
+			<WrapPanel HorizontalAlignment="Right">
+				<TextBox Text="{Binding CustomFilter}" Width="200" Margin="10,10,0,0"></TextBox>
+				<Button Command="{Binding AddFilter}" Margin="20,9,10,0" Content="Add Custom Filter" Classes="Primary" ToolTip.Tip="When a filter is missing from this list or a custom build with custom filters is in use, use this button to add this filter to the Custom Filters category."></Button>
+			</WrapPanel>
+			<WrapPanel HorizontalAlignment="Right">
+				
+			</WrapPanel>
 			<StackPanel Margin="30,0,20,10">
 				<ItemsControl ItemsSource="{Binding Categories}">
 					<ItemsControl.ItemTemplate>
 						<DataTemplate>
 							<StackPanel HorizontalAlignment="Stretch" Margin="10,10,0,0">
-								<TextBlock Margin="10,0,0,0" Text="{Binding Typename}"></TextBlock>
+								<WrapPanel Background="{StaticResource BackgroundColorPrimary}" >
+									<TextBlock Margin="10" Text="{Binding Typename}"></TextBlock>
+								</WrapPanel>
 								<TreeView ItemsSource="{Binding Filters}">
 									<TreeView.ItemTemplate>
 										<TreeDataTemplate>
 											<StackPanel Margin="10,10,10,10">
 												<WrapPanel Background="{StaticResource BackgroundColorPrimary}">
 													<CheckBox Margin="5,0,0,0" ToolTip.Tip="Enabled or disabled this filter." IsChecked="{Binding Enabled}"></CheckBox>
-													<TextBlock Margin="5,5,0,0" Text="{Binding Filter}" TextWrapping="Wrap"></TextBlock>
+													<TextBlock Margin="5,8,0,0" Text="{Binding Filter}" TextWrapping="Wrap"></TextBlock>
 												</WrapPanel>
 												<WrapPanel>
 													<TextBlock Margin="0,10,0,5" Text="{Binding Description}" TextWrapping="Wrap"></TextBlock>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -1,0 +1,30 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="Knossos.NET.Views.CleanupKnossosLibraryView"
+	    xmlns:v="using:Knossos.NET.Views"
+		xmlns:vm="using:Knossos.NET.ViewModels"
+		x:DataType="vm:CleanupKnossosLibraryViewModel"
+		Icon="/Assets/knossos-icon.ico"
+		WindowStartupLocation="CenterScreen"
+        Title="Knossos Library Cleanup" 
+		SizeToContent="WidthAndHeight" 
+		CanResize="True">
+	
+	<Design.DataContext>
+		<vm:DebugFilterViewModel/>
+	</Design.DataContext>
+	<StackPanel MaxWidth="500" Background="{StaticResource BackgroundColorPrimary}">
+		<TextBlock Margin="10" TextWrapping="Wrap">The following are old versions of mods that are not needed as any dependency and can be safely deleted. Uncheck all mod versions you want to keep.</TextBlock>
+		<ListBox MaxHeight="620" ItemsSource="{Binding DeletableMods}">
+			<ListBox.ItemTemplate>
+				<DataTemplate>
+					<v:CheckableModListView Content="{Binding}"/>
+				</DataTemplate>
+			</ListBox.ItemTemplate>
+		</ListBox>
+		<Button Classes="Secondary" Command="{Binding Cleanup}" Margin="10">Delete Selected Mods</Button>
+	</StackPanel>
+</Window>

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml
@@ -9,7 +9,6 @@
 		x:DataType="vm:DebugFiltersViewModel"
 		Icon="/Assets/knossos-icon.ico"
 		WindowStartupLocation="CenterScreen"
-		SizeToContent="WidthAndHeight"
         Title="Debug Filter Selection" 
 		CanResize="True">
 	

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml.cs
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace Knossos.NET.Views.Windows
+{
+    public partial class DebugFiltersView : Window
+    {
+        public DebugFiltersView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Knossos.NET/Views/Windows/DebugFiltersView.axaml.cs
+++ b/Knossos.NET/Views/Windows/DebugFiltersView.axaml.cs
@@ -1,6 +1,8 @@
+using System;
 using Avalonia.Controls;
+using Knossos.NET.ViewModels;
 
-namespace Knossos.NET.Views.Windows
+namespace Knossos.NET.Views
 {
     public partial class DebugFiltersView : Window
     {

--- a/Knossos.NET/Views/Windows/MainWindow.axaml
+++ b/Knossos.NET/Views/Windows/MainWindow.axaml
@@ -59,7 +59,7 @@
 						<WrapPanel Grid.Row="0" Margin="5">
 							<Button Margin="5" Classes="Primary" Command="{Binding OpenFS2Log}">View fs2_open.log</Button>
 							<Button Margin="5" Classes="Primary" Command="{Binding UploadFS2Log}">Upload fs2_open.log</Button>
-							<Button Margin="5" Classes="Settings" Command="{Binding OpenDebugFilterView}">Adjust fs2_open.log Filters</Button>
+							<Button Margin="5" Classes="Settings" Command="{Binding OpenDebugFilterView}">Adjust Debug Filters</Button>
 							<Button Margin="5" Classes="Settings" Command="{Binding OpenFS2Ini}">View fs2_open.ini</Button>
 						</WrapPanel>
 						<WrapPanel Grid.Row="0" Margin="5">

--- a/Knossos.NET/Views/Windows/MainWindow.axaml
+++ b/Knossos.NET/Views/Windows/MainWindow.axaml
@@ -62,6 +62,7 @@
 						<Button Margin="5" Classes="Settings" Command="{Binding OpenSettings}">View Settings File</Button>
 						<Button Margin="5" Classes="Settings" Command="{Binding OpenFS2Ini}">View fs2_open.ini</Button>
 						<Button Margin="5" Classes="Settings" Command="{Binding OpenFS2Log}">View fs2_open.log</Button>
+						<Button Margin="5" Classes="Primary" Command="{Binding OpenDebugFilterView}">Adjust Debug Filters</Button>
 					</WrapPanel>
 					<TextBox Grid.Row="1" Text="{Binding UiConsoleOutput}" IsReadOnly="True"></TextBox>
 				</Grid>

--- a/Knossos.NET/Views/Windows/MainWindow.axaml
+++ b/Knossos.NET/Views/Windows/MainWindow.axaml
@@ -55,20 +55,24 @@
 			<!--Debug-->
 			<TabItem Header="Debug">
 				<Grid RowDefinitions="Auto,*">
-					<WrapPanel Grid.Row="0" Margin="5">
-						<Button Margin="5" Classes="Primary" Command="{Binding UploadFS2Log}">Upload fs2_open.log</Button>
-						<Button Margin="5" Classes="Settings" Command="{Binding UploadKnossosConsole}">Upload Knossos Console</Button>
-						<Button Margin="5" Classes="Settings" Command="{Binding OpenLog}">View Logfile</Button>
-						<Button Margin="5" Classes="Settings" Command="{Binding OpenSettings}">View Settings File</Button>
-						<Button Margin="5" Classes="Settings" Command="{Binding OpenFS2Ini}">View fs2_open.ini</Button>
-						<Button Margin="5" Classes="Settings" Command="{Binding OpenFS2Log}">View fs2_open.log</Button>
-						<Button Margin="5" Classes="Primary" Command="{Binding OpenDebugFilterView}">Adjust Debug Filters</Button>
-					</WrapPanel>
+					<StackPanel>
+						<WrapPanel Grid.Row="0" Margin="5">
+							<Button Margin="5" Classes="Primary" Command="{Binding OpenFS2Log}">View fs2_open.log</Button>
+							<Button Margin="5" Classes="Primary" Command="{Binding UploadFS2Log}">Upload fs2_open.log</Button>
+							<Button Margin="5" Classes="Settings" Command="{Binding OpenDebugFilterView}">Adjust fs2_open.log Filters</Button>
+							<Button Margin="5" Classes="Settings" Command="{Binding OpenFS2Ini}">View fs2_open.ini</Button>
+						</WrapPanel>
+						<WrapPanel Grid.Row="0" Margin="5">
+							<Button Margin="5" Classes="Settings" Command="{Binding UploadKnossosConsole}">Upload Knossos Console</Button>
+							<Button Margin="5" Classes="Settings" Command="{Binding OpenLog}">View Knossos Logfile</Button>
+							<Button Margin="5" Classes="Settings" Command="{Binding OpenSettings}">View Knossos Settings File</Button>
+						</WrapPanel>
+					</StackPanel>
 					<TextBox Grid.Row="1" Text="{Binding UiConsoleOutput}" IsReadOnly="True"></TextBox>
 				</Grid>
 			</TabItem>
 		</TabControl>
-		<GridSplitter Grid.Row="1" Background="Black" ResizeDirection="Rows"/>
-		<v:TaskView Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" MaxHeight="350" Content="{Binding TaskView}"/>
+		<GridSplitter Grid.Row="2" Background="Black" ResizeDirection="Rows"/>
+		<v:TaskView Margin="0,0,0,10" Grid.Row="3" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" MaxHeight="350" Content="{Binding TaskView}"/>
 	</Grid>
 </Window>


### PR DESCRIPTION
Ok, this is probably my most extensive use of c# yet, so please review carefully.  What this does is use our general resources repo to load debug filters that adjust the fs2open.ini output.  I created a new window to save and load the options and have KNet save the choices to every TC.  It would be nice if this file were in Userdata so that we wouldn't have to save it over and over, but for the sake of backwards compatibility, we have to write it to each TC anyway.

This is tested and seems to work.

Fixes #165 