### PR TITLE
Fix installing compressed fso versions

### DIFF
--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -2972,7 +2972,7 @@ namespace Knossos.NET.ViewModels
                             try
                             {
                                 var fso = mod.GetDependency("FSO");
-                                if (fso != null && (fso.version == null || fso.version.Contains(">=") || SemanticVersion.Compare(fso.version.Replace(">=", "").Replace("<", "").Replace(">", "").Trim(), VPCompression.MinimumFSOVersion) > 0))
+                                if (fso != null && (fso.version == null || SemanticVersion.Compare(fso.version.Replace(">=", "").Replace("<", "").Replace(">", "").Trim(), VPCompression.MinimumFSOVersion) > 0))
                                     compressMod = true;
                             }
                             catch (Exception ex)

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -54,7 +54,7 @@
 						</WrapPanel>
 						<WrapPanel Margin="8,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
-							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space. 'Manual' means you will have to compress or decompress the files manually from mod settings. 'Always' means Knossos will compress all mods during install and 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum. This only works if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="Knossos can try to compress mod files in order to save disk space, and in some cases reduce loading times. 'Manual' means you will have to change a modpack's compression from mod settings or during installation. 'Always' means Knossos will compress all mods during install. 'Mod Support' means Knossos will compress the files only if the mod FSO engine dependency set by the mod is over the minimum, and if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 								<ComboBoxItem Tag="1">Manual</ComboBoxItem>
 								<ComboBoxItem Tag="2">Always</ComboBoxItem>


### PR DESCRIPTION
Mod compression support begins at 23.2 (specifically a 23.1 nightly), but we do have mods on nebula whose default build is 19.0, very different from 23.2. Allowing compression to take place for mods like this does not make sense, unless the user is in Manual or Always mode and knows that they will have to risk a newer build to correctly run the compressed modpack. So, remove the automatic compression approval if the mod just happens to have a ">=" in the build version.

Tested and this keeps mod compression from automatically happening when the required version is < the supported version.

Fixes #169 