### PR TITLE
Update Settings headings with some slight tuning

### DIFF
--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -27,7 +27,7 @@
 		<ScrollViewer Grid.Row="1">
 			<StackPanel>
 				<!--KNOSSOS SETTINGS-->
-				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18">Knossos</Label>
+				<Label Margin="5,10,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Settings that are specific to Knossos only. These settings do not affect the FSO engine.">Knossos</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Base Path -->
@@ -134,7 +134,7 @@
 					</StackPanel>
 				</Border>
 				<!--VIDEO SETTINGS-->
-				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">Video</Label>
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Video settings the FSO engine will use in-game.">Video</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Resolution -->
@@ -234,7 +234,7 @@
 				</Border>
 
 				<!--Audio SETTINGS-->
-				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">Audio</Label>
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Audio settings the FSO engine will use in-game.">Audio</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Playback -->
@@ -305,7 +305,7 @@
 				</Border>
 
 				<!--INPUT SETTINGS-->
-				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">Input</Label>
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Input settings where you can specify which of your plugged-in devices FSO can use in-game.">Input</Label>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
             <?ignore
@@ -351,7 +351,7 @@
 				</Border>
 		
 				<!--FSO ENGINE SETTINGS-->
-				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18">FSO Engine Settings</Label>
+				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Additional settings that affect how the FSO engine runs.">Specialized</Label>
 				<Border Margin="0,5,0,5" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- FS2 Lang -->

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -36,7 +36,7 @@
 		<!--Page2-->
 		<StackPanel IsVisible="{Binding Page2}" Grid.Row="0" >
 			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Setting up the library folder</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">First, you must set a library folder. Go to the "Settings" tab and under the "Knossos Settings" section click on the "Browse" button and choose or create a folder for Knossos to use. It is highly recommended to set this as an empty folder in a location with a large amount of available storage. Once you have set the folder be sure to click the "Save" button in the upper right corner of the "Settings" tab. </TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">First, you must set a library folder. Go to the "Settings" tab and under the "Knossos" section click on the "Browse" button and choose or create a folder for Knossos to use. It is highly recommended to set this as an empty folder in a location with a large amount of available storage. Once you have set the folder be sure to click the "Save" button in the upper right corner of the "Settings" tab. </TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The Knossos library folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>


### PR DESCRIPTION
Reporting some new testers questions, it was confusing to them that the last section had FSO Settings in the title, while none of the others did, even though they too were settings FSO uses. Thus, this PR adds tooltips to the Settings headings, and updates the name of the last item from `FSO Engine Settings` to `Specialized` (since all but one of the Settings headings are also FSO Settings).

Also I fixed a line in the `QuickSetup` that was not updated last time the Settings headings were updated.