### PR TITLE
Consider folder delete error during dev pkg deletion as non critical

### DIFF
--- a/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
@@ -675,7 +675,14 @@ namespace Knossos.NET.ViewModels
                     var resp = await MessageBox.Show(MainWindow.instance!, "This will delete the package: " + editorPackageItem.Package.name + " and ALL FILES on this folder: " + folderPath + " of the mod and version " + editor.ActiveVersion + "\n Do you really want to do this? This action cannot be undone.","Confirm package deletion",MessageBox.MessageBoxButtons.YesNo);
                     if(resp == MessageBox.MessageBoxResult.Yes)
                     {
-                        Directory.Delete(folderPath,true);
+                        try
+                        {
+                            Directory.Delete(folderPath, true);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Add(Log.LogSeverity.Warning, "DevModPkgMgrViewModel.DeletePkg()", ex);
+                        }
                         EditorPackageItems.Remove(editorPackageItem);
                     }
                 }


### PR DESCRIPTION
Do not consider folder deletion error during pkg delete from mod as critical. 

This avoid bing unable to delete a mod pkg if the folder dosent exist.