### PR TITLE
Support running Fred2 on Linux using Wine

### DIFF
--- a/Knossos.NET/Classes/Wine.cs
+++ b/Knossos.NET/Classes/Wine.cs
@@ -106,7 +106,9 @@ namespace Knossos.NET.Classes
                         var libraryPath = Knossos.GetKnossosLibraryPath();
                         if (libraryPath != null)
                         {
-                            Directory.CreateSymbolicLink(Path.Combine(winePrefix, "drive_c", "users", Environment.UserName, "Favourites", "KnossosLibrary"), libraryPath);
+                            var linkLocation = Path.Combine(winePrefix, "drive_c", "users", Environment.UserName, "Favourites", "KnossosLibrary");
+                            Directory.CreateDirectory(linkLocation);
+                            Directory.CreateSymbolicLink(linkLocation, libraryPath);
                         }
                     }
                     catch (Exception ex) 

--- a/Knossos.NET/Classes/Wine.cs
+++ b/Knossos.NET/Classes/Wine.cs
@@ -100,14 +100,18 @@ namespace Knossos.NET.Classes
                     wine.StartInfo.UseShellExecute = false;
                     wine.Start();
                     await wine.WaitForExitAsync();
-                    //Create a symlink to the Knossos library, this is not critical in case of error
+                    //Create a symlink to the Knossos library, this is not critical
                     try
                     {
                         var libraryPath = Knossos.GetKnossosLibraryPath();
                         if (libraryPath != null)
                         {
-                            var linkLocation = Path.Combine(winePrefix, "drive_c", "users", Environment.UserName, "Favourites", "KnossosLibrary");
-                            Directory.CreateDirectory(linkLocation);
+                            var linkLocation = Path.Combine(winePrefix, "drive_c", "users", Environment.UserName, "Favorites", "KnossosLibrary");
+                            if (Directory.Exists(linkLocation))
+                            {
+                                //Note: This only deletes the symlink not the library folder itself! I tested it.
+                                Directory.Delete(linkLocation);
+                            }
                             Directory.CreateSymbolicLink(linkLocation, libraryPath);
                         }
                     }

--- a/Knossos.NET/Classes/Wine.cs
+++ b/Knossos.NET/Classes/Wine.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Knossos.NET.Models;
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.IO;
+
+namespace Knossos.NET.Classes
+{
+    public struct WineResult
+    {
+        public bool IsSuccess;
+        public string ErrorMessage;
+
+        public WineResult(bool isSuccess, string errorMessage)
+        {
+            IsSuccess = isSuccess;
+            ErrorMessage = errorMessage;
+        }
+
+        public WineResult(bool isSuccess)
+        {
+            IsSuccess = isSuccess;
+            ErrorMessage = string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Small helper class to run Windows executables on Linux with Wine
+    /// </summary>
+    public static class Wine
+    {
+        public static async Task<WineResult> RunFred2(string exePath, string exeCmdLine, string? workingFolder, FsoExecArch fsoArch)
+        {
+            try
+            {
+                var wineArch = GetWineArch(fsoArch);
+                if (wineArch == null)
+                {
+                    return new WineResult(false, "Unsupported WINEARCH: " + fsoArch.ToString());
+                }
+
+                await SetWinePrefixFred2(wineArch);
+
+                using (var wine = new Process())
+                {
+                    wine.StartInfo.FileName = "wine";
+                    wine.StartInfo.Arguments = exePath + " " + exeCmdLine;
+                    if (workingFolder != null)
+                    {
+                        wine.StartInfo.WorkingDirectory = workingFolder;
+                    }
+                    wine.StartInfo.EnvironmentVariables["WINEPREFIX"] = GetWinePrefixPath();
+                    wine.StartInfo.EnvironmentVariables["WINEARCH"] = wineArch;
+                    wine.StartInfo.UseShellExecute = false;
+                    wine.Start();
+                    await wine.WaitForExitAsync();
+                }
+
+                return new WineResult(true);
+            }catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "Wine.RunFred2()", ex.ToString());
+                return new WineResult(false, ex.ToString());
+            }
+        }
+
+
+        /// <summary>
+        /// Sets the WinePrefix folder with the correct configuration for Fred2
+        /// </summary>
+        private static async Task SetWinePrefixFred2(string wineArch)
+        {
+            try
+            {
+                using (var wine = new Process())
+                {
+                    wine.StartInfo.FileName = "wine";
+                    wine.StartInfo.Arguments = "wineboot";
+                    wine.StartInfo.EnvironmentVariables["WINEPREFIX"] = GetWinePrefixPath();
+                    wine.StartInfo.EnvironmentVariables["WINEARCH"] = wineArch;
+                    wine.StartInfo.EnvironmentVariables["WINEDLLOVERRIDES"] = "mscoree=d";
+                    wine.StartInfo.UseShellExecute = false;
+                    wine.Start();
+                    await wine.WaitForExitAsync();
+                }
+            }catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "Wine.SetWinePrefixFred2()", ex.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Determine WINEARCH from FsoExecArch
+        /// </summary>
+        /// <param name="fsoArch"></param>
+        /// <returns>WineArch compatible string or null</returns>
+        private static string? GetWineArch(FsoExecArch fsoArch)
+        {
+            switch(fsoArch)
+            {
+                case FsoExecArch.x86:
+                case FsoExecArch.x86_avx:
+                case FsoExecArch.x86_avx2:
+                    return "win32";
+                case FsoExecArch.x64:
+                case FsoExecArch.x64_avx:
+                case FsoExecArch.x64_avx2:
+                    return "win64";
+                default: 
+                    return null;
+
+            }
+        }
+
+        /// <summary>
+        /// Get the WinePrefix directory, a "wine" directory inside Knet data folder
+        /// </summary>
+        /// <returns>WinePrefix string</returns>
+        private static string GetWinePrefixPath()
+        {
+            return Path.Combine(KnUtils.GetKnossosDataFolderPath(), "wine");
+        }
+    }
+}

--- a/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
@@ -94,7 +94,12 @@ namespace Knossos.NET.ViewModels
                         }
 
                         if (!BuildType.Contains(exe.type.ToString()))
-                            BuildType += exe.type.ToString() + "  ";
+                        {
+                            if(!exe.useWine)
+                                BuildType += exe.type.ToString() + "  ";
+                            else
+                                BuildType += exe.type.ToString() + " (Wine)  ";
+                        }
                     }
                 }
             }
@@ -263,6 +268,33 @@ namespace Knossos.NET.ViewModels
                                 if(!FsoBuild.IsEnviromentStringValidInstall(nebulaPkg.environment))
                                 {
                                     ckb.IsEnabled = false;
+                                    //Fred2 over Wine exception
+                                    try
+                                    {
+                                        if (nebulaPkg.executables != null && KnUtils.IsLinux && nebulaPkg.environment != null && nebulaPkg.environment.ToLower().Contains("windows"))
+                                        {
+                                            foreach (var exec in nebulaPkg.executables)
+                                            {
+                                                var label = FsoBuild.GetExecType(exec.label);
+                                                if (label == FsoExecType.Fred2 || label == FsoExecType.Fred2Debug)
+                                                {
+                                                    var props = FsoBuild.FillProperties(nebulaPkg.environment);
+                                                    var arch = FsoBuild.GetExecArch(props);
+                                                    var score = FsoBuild.DetermineScoreFromArch(arch);
+                                                    if (score > 0)
+                                                    {
+                                                        ToolTip.SetTip(ckb, "This pkg contains Fred2 that can run over Wine.");
+                                                        ckb.IsEnabled = true;
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    } 
+                                    catch (Exception ex) 
+                                    {
+                                        Log.Add(Log.LogSeverity.Error, "FsoBuildItemViewModel.LoadPkgData(Fred2 over wine)", ex);
+                                    }
                                 }
                                 BuildPkgs.Add(ckb);
                             }

--- a/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
@@ -98,7 +98,7 @@ namespace Knossos.NET.ViewModels
                             if(!exe.useWine)
                                 BuildType += exe.type.ToString() + "  ";
                             else
-                                BuildType += exe.type.ToString() + "(Wine)  ";
+                                BuildType += exe.type.ToString() + " (Wine)  ";
                         }
                     }
                 }

--- a/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
@@ -93,12 +93,12 @@ namespace Knossos.NET.ViewModels
                             case FsoExecArch.arm64: if (!CpuArch.Contains("ARM64")) CpuArch += "ARM64   "; break;
                         }
 
-                        if (!BuildType.Contains(exe.type.ToString()))
+                        if (!BuildType.Split(" ").Contains(exe.type.ToString()))
                         {
                             if(!exe.useWine)
                                 BuildType += exe.type.ToString() + "  ";
                             else
-                                BuildType += exe.type.ToString() + " (Wine)  ";
+                                BuildType += exe.type.ToString() + "(Wine)  ";
                         }
                     }
                 }


### PR DESCRIPTION
Support downloading and running Fred2 on Linux using Wine

-No default install, if someone wants to install Fred2 on Linux needs to "Modify" the FSO build and install the Windows Package.
-Arch limitation, Knet on linux will only consider executables of the same CPU arch as valid, that means, in X64 Linux, you cant download or run 32 bit Fred2.

![image](https://github.com/KnossosNET/Knossos.NET/assets/2444336/52091693-38df-4673-b9aa-0fdb26827667)
