### PR TITLE
Fix typo error causing a crash opening mod details with null screenshots

### DIFF
--- a/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/ModDetailsViewModel.cs
@@ -312,7 +312,7 @@ namespace Knossos.NET.ViewModels
             {
                 Screenshots.Clear();
                 //Add Videos
-                if(modVersions[selectedIndex].videos != null && modVersions[selectedIndex].screenshots!.Length > 0)
+                if(modVersions[selectedIndex].videos != null && modVersions[selectedIndex].videos!.Length > 0)
                 {
                     foreach (var vid in modVersions[selectedIndex].videos!)
                     {


### PR DESCRIPTION
This was creating a crash opening the details window for a newly created mod. copy & paste error.