### PR TITLE
Implement FSO builds autoupdate function

### DIFF
--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -65,6 +65,26 @@ namespace Knossos.NET.Models
             public uint height { get; set; }
         }
 
+        /// <summary>
+        /// Struc to save fso autoupdate settings
+        /// Note: "UpdateRC = true" should only update RC builds if they are newer than the newest avalible stable
+        /// </summary>
+        public struct AutoUpdateFsoBuilds
+        {
+            public bool UpdateStable { get; set; }
+            public bool UpdateRC { get; set; }
+            public bool UpdateNightly { get; set; }
+            public bool DeleteOlder { get; set; }
+
+            public AutoUpdateFsoBuilds(bool stable = false, bool rc = false, bool nightly = false, bool deleteOlder = false)
+            {
+                UpdateNightly = nightly;
+                UpdateStable = stable;
+                UpdateRC = rc;
+                DeleteOlder = deleteOlder;
+            }
+        }
+
         /* Knossos Settings */
         [JsonPropertyName("base_path")]
         public string? basePath { get; set; } = null;
@@ -96,6 +116,8 @@ namespace Knossos.NET.Models
         public Decompressor decompressor { get; set; } = Decompressor.Auto;
         [JsonPropertyName("dev_mod_sort")]
         public int devModSort { get; set; } = 0;
+        [JsonPropertyName("auto_update_fso_builds")]
+        public AutoUpdateFsoBuilds autoUpdateBuilds { get; set; } = new AutoUpdateFsoBuilds();
 
         /* FSO Settings that use the fs2_open.ini are json ignored */
 
@@ -571,6 +593,7 @@ namespace Knossos.NET.Models
                         deleteUploadedFiles = tempSettings.deleteUploadedFiles;
                         decompressor = tempSettings.decompressor;
                         devModSort = tempSettings.devModSort;
+                        autoUpdateBuilds = tempSettings.autoUpdateBuilds;
                         
                         if (MainWindowViewModel.Instance != null)
                             MainWindowViewModel.Instance.sharedSortType = tempSettings.sortType;

--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -87,7 +87,7 @@ namespace Knossos.NET.Models
         /// If user has saved credentials to Nebula, login and check private mods
         /// Displays mods updates to taskview (if any)
         /// </summary>
-        public static async void Trinity()
+        public static async Task Trinity()
         {
             try
             {

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -86,6 +86,14 @@ namespace Knossos.NET.ViewModels
         internal bool autoUpdate = false;
         [ObservableProperty]
         internal bool deleteUploadedFiles = true;
+        [ObservableProperty]
+        internal bool updateNightly = false;
+        [ObservableProperty]
+        internal bool updateStable = false;
+        [ObservableProperty]
+        internal bool updateRC = false;
+        [ObservableProperty]
+        internal bool deleteOlder = false;
 
         /*VIDEO*/
         [ObservableProperty]
@@ -269,6 +277,10 @@ namespace Knossos.NET.ViewModels
             CheckUpdates = Knossos.globalSettings.checkUpdate;
             AutoUpdate = Knossos.globalSettings.autoUpdate;
             DeleteUploadedFiles = Knossos.globalSettings.deleteUploadedFiles;
+            UpdateNightly = Knossos.globalSettings.autoUpdateBuilds.UpdateNightly;
+            UpdateRC = Knossos.globalSettings.autoUpdateBuilds.UpdateRC;
+            UpdateStable = Knossos.globalSettings.autoUpdateBuilds.UpdateStable;
+            DeleteOlder = Knossos.globalSettings.autoUpdateBuilds.DeleteOlder;
 
             /* VIDEO SETTINGS */
             //RESOLUTION
@@ -821,6 +833,7 @@ namespace Knossos.NET.ViewModels
                 AutoUpdate = false;
             }
             Knossos.globalSettings.autoUpdate = AutoUpdate;
+            Knossos.globalSettings.autoUpdateBuilds = new GlobalSettings.AutoUpdateFsoBuilds(UpdateStable, UpdateRC, UpdateNightly, DeleteOlder);
 
             /* VIDEO */
             //Resolution

--- a/Knossos.NET/ViewModels/TaskViewModel.cs
+++ b/Knossos.NET/ViewModels/TaskViewModel.cs
@@ -273,7 +273,7 @@ namespace Knossos.NET.ViewModels
         /// <param name="sender"></param>
         /// <param name="modJson"></param>
         /// <returns>FsoBuild class of the installed build or null if failed or cancelled</returns>
-        public async Task<FsoBuild?> InstallBuild(FsoBuild build, FsoBuildItemViewModel sender, Mod? modJson=null, List<ModPackage>? modifyPkgs = null)
+        public async Task<FsoBuild?> InstallBuild(FsoBuild build, FsoBuildItemViewModel sender, Mod? modJson=null, List<ModPackage>? modifyPkgs = null, bool cleanupOldVersions = false)
         {
             if(Knossos.GetKnossosLibraryPath() == null)
             {
@@ -289,7 +289,7 @@ namespace Knossos.NET.ViewModels
                 TaskList.Add(newTask);
                 taskQueue.Enqueue(newTask);
             });
-            return await newTask.InstallBuild(build, sender,sender.cancellationTokenSource,modJson, modifyPkgs).ConfigureAwait(false);
+            return await newTask.InstallBuild(build, sender,sender.cancellationTokenSource,modJson, modifyPkgs, cleanupOldVersions).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
@@ -165,7 +165,7 @@ namespace Knossos.NET.ViewModels
             IsDownloading = false;
         }
 
-        public async void DownloadBuildExternal(Mod  mod)
+        public async void DownloadBuildExternal(Mod  mod, bool cleanupOldVersions = false)
         {
             if (!IsDownloading && !IsInstalled)
             {
@@ -173,12 +173,13 @@ namespace Knossos.NET.ViewModels
                 cancellationTokenSource = new CancellationTokenSource();
                 await mod.LoadFulLNebulaData().ConfigureAwait(false);
                 await Dispatcher.UIThread.InvokeAsync(async () => { 
-                    FsoBuild? newBuild = await TaskViewModel.Instance?.InstallBuild(build!, this, mod)!;
+                    FsoBuild? newBuild = await TaskViewModel.Instance?.InstallBuild(build!, this, mod, null, cleanupOldVersions)!;
                     if (newBuild != null)
                     {
                         //Install completed
                         IsInstalled = true;
                         build = newBuild;
+                        UpdateDisplayData(newBuild, true);
                     }
                     IsDownloading = false;
                     cancellationTokenSource?.Dispose();

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -4122,7 +4122,7 @@ namespace Knossos.NET.ViewModels
                                                 }
                                                 if (inUse)
                                                 {
-                                                    Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.InstallMod()", "Cleanup: " + version + " is in use by these mods: " + inUseMods + ". Skipping.");
+                                                    Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.InstallBuild()", "Cleanup: " + version + " is in use by these mods: " + inUseMods + ". Skipping.");
                                                 }
                                                 else
                                                 {
@@ -4155,7 +4155,7 @@ namespace Knossos.NET.ViewModels
                                             }
                                             else
                                             {
-                                                Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.InstallMod()", "Cleanup: " + version + " is newer than " + build + ". Skipping.");
+                                                Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.InstallBuild()", "Cleanup: " + version + " is newer than " + build + ". Skipping.");
                                             }
                                         }
                                         MainWindowViewModel.Instance?.RunModStatusChecks();

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -3660,7 +3660,7 @@ namespace Knossos.NET.ViewModels
             }
         }
 
-        public async Task<FsoBuild?> InstallBuild(FsoBuild build, FsoBuildItemViewModel sender, CancellationTokenSource? cancelSource = null, Mod? modJson = null, List<ModPackage>? modifyPkgs = null)
+        public async Task<FsoBuild?> InstallBuild(FsoBuild build, FsoBuildItemViewModel sender, CancellationTokenSource? cancelSource = null, Mod? modJson = null, List<ModPackage>? modifyPkgs = null, bool cleanupOldVersions = false)
         {
             string? modPath = null;
             try
@@ -4082,6 +4082,101 @@ namespace Knossos.NET.ViewModels
 
                         //Re-run Dependencies checks 
                         MainWindowViewModel.Instance?.RunModStatusChecks();
+
+                        // Clean old versions
+                        if (cleanupOldVersions)
+                        {
+                            try
+                            {
+                                var versions = Knossos.GetInstalledBuildsList(build.id, build.stability);
+                                if (versions != null)
+                                {
+                                    versions.Remove(build);
+                                    if (versions.Any())
+                                    {
+                                        foreach (var version in versions.ToList())
+                                        {
+                                            //Check if it is inferior to the one we just installed
+                                            if (SemanticVersion.Compare(build.version, version.version) >= 1)
+                                            {
+                                                bool inUse = false;
+                                                string inUseMods = "";
+                                                foreach (var m in Knossos.GetInstalledModList(null))
+                                                {
+                                                    if (m != null && m.id != build.id)
+                                                    {
+                                                        var deps = m.GetModDependencyList();
+                                                        if (deps != null)
+                                                        {
+                                                            foreach (var dep in deps)
+                                                            {
+                                                                var depMod = dep.SelectBuild();
+                                                                if (depMod == version)
+                                                                {
+                                                                    inUse = true;
+                                                                    inUseMods += m + ", ";
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                                if (inUse)
+                                                {
+                                                    Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.InstallMod()", "Cleanup: " + version + " is in use by these mods: " + inUseMods + ". Skipping.");
+                                                }
+                                                else
+                                                {
+                                                    //Safe to delete
+                                                    FsoBuildItemViewModel? uiItem = null;
+                                                    switch(version.stability)
+                                                    {
+                                                        case FsoStability.Stable: uiItem = FsoBuildsViewModel.Instance!.StableItems.FirstOrDefault(x => x.build != null && x.build.version == version.version); break;
+                                                        case FsoStability.RC: uiItem = FsoBuildsViewModel.Instance!.RcItems.FirstOrDefault(x => x.build != null && x.build.version == version.version); break;
+                                                        case FsoStability.Nightly: uiItem = FsoBuildsViewModel.Instance!.NightlyItems.FirstOrDefault(x => x.build != null && x.build.version == version.version); break;
+                                                        case FsoStability.Custom: uiItem = FsoBuildsViewModel.Instance!.CustomItems.FirstOrDefault(x => x.build != null && x.build.version == version.version); break;
+                                                    }
+
+                                                    if (uiItem != null)
+                                                    {
+                                                        Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.InstallBuild()", "Cleanup: " + version + " is not in use, deleting...");
+                                                        var msgtask = new TaskItemViewModel();
+                                                        msgtask.ShowMsg("Cleanup: Deleting " + version.version, null);
+                                                        await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, msgtask));
+                                                        FsoBuildsViewModel.Instance!.DeleteBuild(version, uiItem, false);
+                                                        //If the build is custom and the dev editor is open and loaded this build id, reset it
+                                                        if(version.stability == FsoStability.Custom)
+                                                            await Dispatcher.UIThread.InvokeAsync(() => DeveloperModsViewModel.Instance!.ResetModEditor(version.id));
+                                                    }
+                                                    else
+                                                    {
+                                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", "Cleanup: Unable to find" + version + " in the UI items, we cant to auto delete.");
+                                                    }
+                                                }
+                                            }
+                                            else
+                                            {
+                                                Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.InstallMod()", "Cleanup: " + version + " is newer than " + build + ". Skipping.");
+                                            }
+                                        }
+                                        MainWindowViewModel.Instance?.RunModStatusChecks();
+                                    }
+                                    else
+                                    {
+                                        //Nothing to cleanup
+                                        var msgtask = new TaskItemViewModel();
+                                        msgtask.ShowMsg("Cleanup: Nothing to cleanup.", null);
+                                        await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, msgtask));
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                var msgtask = new TaskItemViewModel();
+                                msgtask.ShowMsg("Cleanup: An error has ocurred, check logs.", null);
+                                await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, msgtask));
+                                Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallMod()", ex);
+                            }
+                        }
 
                         /*
                             Always Dequeue, always check for check size and verify that the first is this TaskItemViewModel object

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -4149,7 +4149,7 @@ namespace Knossos.NET.ViewModels
                                                     }
                                                     else
                                                     {
-                                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", "Cleanup: Unable to find" + version + " in the UI items, we cant to auto delete.");
+                                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", "Cleanup: Unable to find" + version + " in the UI items, so we can't auto delete.");
                                                     }
                                                 }
                                             }

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -68,8 +68,15 @@
 							<CheckBox IsChecked="{Binding CheckUpdates}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will connect to the GitHub repo to check for available updates at the start."></CheckBox>
 						</WrapPanel>
                         <WrapPanel Margin="5,10,0,0">
-                            <Label Margin="0,5,0,0" Width="205">Auto Update</Label> 
+                            <Label Margin="0,5,0,0" Width="205">Auto Update Knet</Label> 
 							<CheckBox IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input."></CheckBox>
+						</WrapPanel>
+						<WrapPanel Margin="5,10,0,0">
+							<Label Margin="0,5,0,0" Width="205">Auto Update FSO Builds</Label>
+							<CheckBox Margin="5,0,0,0" IsChecked="{Binding UpdateStable}" ToolTip.Tip="Knet will check for newer Stable FSO builds at the start and automatically download them if one is available">Stable</CheckBox>
+							<CheckBox Margin="5,0,0,0" IsChecked="{Binding UpdateRC}" ToolTip.Tip="Knet will check for newer RCs (Release Candidate) FSO builds at the start and automatically download them if one is available. Note: RC are only downloaded if they are newer than the newerest available Stable.">RC</CheckBox>
+							<CheckBox Margin="5,0,0,0" IsChecked="{Binding UpdateNightly}" ToolTip.Tip="Knet will check for newer Nightly FSO builds at the start and automatically download them if one is available">Nightly</CheckBox>
+							<CheckBox Margin="5,0,0,0" IsChecked="{Binding DeleteOlder}" ToolTip.Tip="If this option is enabled, after an autoupdate Knet will delete older versions of installed FSO builds if they are not needed by any mod">Delete older versions</CheckBox>
 						</WrapPanel>
                         <WrapPanel Margin="5,10,0,0">
                             <Label Margin="0,5,0,0" Width="205">Delete Uploaded Mod Files</Label> 


### PR DESCRIPTION
This was far, far, FAR more extensive i would have imagined.

+Implement optional checking for newer FSO builds on launch
+Implement optional cleanup old versions (if not needed by mods) during FSO builds installs
+Fix an oversight on FsoBuildItemViewModel.DownloadBuildExternal(): Missing update display data

The logic goes like this:
If there is a newer stable, check the newer stable in nebula against the newer installed, if it is newer than the one installed or there is not installed stable, download and install whiout promt. If the delete old versions is also enabled all installed mods will be checked to see if they depend on older fso builds.

Same applyies to Nightlies. On RC an extra check is also added to make sure the RC is newer than the newer stable in nebula, so we dont download a RC that is older than the current stable.

I did testing, but i would like more testing on this one if possible.