### PR TITLE
Add option to skip SystemCMD generation

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -976,7 +976,7 @@ namespace Knossos.NET
             {
                 if (!mod.modSettings.ignoreGlobalCmd)
                 {
-                    if (modCmd != null && modCmd.Any())
+                    if (modCmd != null && modCmd.Any() && !globalSettings.noSystemCMD)
                     {
                         foreach(var flag in modCmd.ToList())
                         {
@@ -984,7 +984,8 @@ namespace Knossos.NET
                                 modCmd.Remove(flag);
                         }
                     }
-                    cmdline = KnUtils.CmdLineBuilder(cmdline, systemCmd);
+                    if (!globalSettings.noSystemCMD)
+                        cmdline = KnUtils.CmdLineBuilder(cmdline, systemCmd);
                     cmdline = KnUtils.CmdLineBuilder(cmdline, globalCmd);
                 }
                 cmdline = KnUtils.CmdLineBuilder(cmdline, modCmd?.ToArray());

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -576,7 +576,8 @@ namespace Knossos.NET.Models
                         decompressor = tempSettings.decompressor;
                         devModSort = tempSettings.devModSort;
                         noSystemCMD = tempSettings.noSystemCMD;
-                        
+                        showDevOptions = tempSettings.showDevOptions;
+
                         if (MainWindowViewModel.Instance != null)
                             MainWindowViewModel.Instance.sharedSortType = tempSettings.sortType;
 

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -96,6 +96,8 @@ namespace Knossos.NET.Models
         public Decompressor decompressor { get; set; } = Decompressor.Auto;
         [JsonPropertyName("dev_mod_sort")]
         public int devModSort { get; set; } = 0;
+        [JsonPropertyName("no_system_cmd")]
+        public bool noSystemCMD { get; set; } = false;
 
         /* FSO Settings that use the fs2_open.ini are json ignored */
 
@@ -571,6 +573,7 @@ namespace Knossos.NET.Models
                         deleteUploadedFiles = tempSettings.deleteUploadedFiles;
                         decompressor = tempSettings.decompressor;
                         devModSort = tempSettings.devModSort;
+                        noSystemCMD = tempSettings.noSystemCMD;
                         
                         if (MainWindowViewModel.Instance != null)
                             MainWindowViewModel.Instance.sharedSortType = tempSettings.sortType;

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -98,6 +98,8 @@ namespace Knossos.NET.Models
         public int devModSort { get; set; } = 0;
         [JsonPropertyName("no_system_cmd")]
         public bool noSystemCMD { get; set; } = false;
+        [JsonPropertyName("show_dev_options")]
+        public bool showDevOptions { get; set; } = false;
 
         /* FSO Settings that use the fs2_open.ini are json ignored */
 

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -192,8 +192,8 @@ namespace Knossos.NET.ViewModels
             set
             {
 
-                if (value.Contains("freespace2.com")){                  
-                    ShowDevOptions = true;
+                if (value.Contains("freespace2.com") && !ShowDevOptions){   
+                    ToggleDeveloperOptions();
                 }
 
                 SetProperty(ref globalCmd, value.Replace("freespace2.com", ""));
@@ -291,7 +291,7 @@ namespace Knossos.NET.ViewModels
             AutoUpdate = Knossos.globalSettings.autoUpdate;
             DeleteUploadedFiles = Knossos.globalSettings.deleteUploadedFiles;
             NoSystemCMD = Knossos.globalSettings.noSystemCMD;
-            ShowDevOptions = Knossos.globalSettings.showDevOptions;
+            ShowDevOptions = Knossos.globalSettings.showDevOptions || NoSystemCMD;
 
             /* VIDEO SETTINGS */
             //RESOLUTION

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -88,6 +88,8 @@ namespace Knossos.NET.ViewModels
         internal bool deleteUploadedFiles = true;
         [ObservableProperty]
         internal bool noSystemCMD = false;
+        [ObservableProperty]
+        internal bool showDevOptions = false;
 
         /*VIDEO*/
         [ObservableProperty]
@@ -168,7 +170,6 @@ namespace Knossos.NET.ViewModels
         internal int joy4SelectedIndex = -1;
 
         /* MOD / FS2 */
-        [ObservableProperty]
         internal string globalCmd = string.Empty;
         [ObservableProperty]
         internal int fs2LangSelectedIndex = 0;
@@ -180,6 +181,24 @@ namespace Knossos.NET.ViewModels
         internal uint joystickSensitivity = 9;
         [ObservableProperty]
         internal uint joystickDeadZone = 10;
+
+        // In order to have hidden dev options, we need a setter for globalCMD
+        public string GlobalCmd
+        {
+            get
+            {
+                return globalCmd;
+            }
+            set
+            {
+
+                if (value.Contains("freespace2.com")){                  
+                    ShowDevOptions = true;
+                }
+
+                SetProperty(ref globalCmd, value.Replace("freespace2.com", ""));
+            }
+        }
 
         public GlobalSettingsViewModel()
         {
@@ -272,6 +291,7 @@ namespace Knossos.NET.ViewModels
             AutoUpdate = Knossos.globalSettings.autoUpdate;
             DeleteUploadedFiles = Knossos.globalSettings.deleteUploadedFiles;
             NoSystemCMD = Knossos.globalSettings.noSystemCMD;
+            ShowDevOptions = Knossos.globalSettings.showDevOptions;
 
             /* VIDEO SETTINGS */
             //RESOLUTION
@@ -825,6 +845,7 @@ namespace Knossos.NET.ViewModels
             }
             Knossos.globalSettings.autoUpdate = AutoUpdate;
             Knossos.globalSettings.noSystemCMD = NoSystemCMD;
+            Knossos.globalSettings.showDevOptions = ShowDevOptions;
 
             /* VIDEO */
             //Resolution
@@ -1146,6 +1167,16 @@ namespace Knossos.NET.ViewModels
             var dialog = new Views.DebugFiltersView();
             dialog.DataContext = new DebugFiltersViewModel();
             await dialog.ShowDialog<DebugFiltersView?>(MainWindow.instance!);
+        }
+
+        internal void ToggleDeveloperOptions()
+        {
+            ShowDevOptions = !ShowDevOptions;
+
+            // if we are turning off dev options, we need to actually restore to default
+            if (!ShowDevOptions){
+                NoSystemCMD = false;
+            }
         }
 
     }

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -86,6 +86,8 @@ namespace Knossos.NET.ViewModels
         internal bool autoUpdate = false;
         [ObservableProperty]
         internal bool deleteUploadedFiles = true;
+        [ObservableProperty]
+        internal bool noSystemCMD = false;
 
         /*VIDEO*/
         [ObservableProperty]
@@ -269,6 +271,7 @@ namespace Knossos.NET.ViewModels
             CheckUpdates = Knossos.globalSettings.checkUpdate;
             AutoUpdate = Knossos.globalSettings.autoUpdate;
             DeleteUploadedFiles = Knossos.globalSettings.deleteUploadedFiles;
+            NoSystemCMD = Knossos.globalSettings.noSystemCMD;
 
             /* VIDEO SETTINGS */
             //RESOLUTION
@@ -821,6 +824,7 @@ namespace Knossos.NET.ViewModels
                 AutoUpdate = false;
             }
             Knossos.globalSettings.autoUpdate = AutoUpdate;
+            Knossos.globalSettings.noSystemCMD = NoSystemCMD;
 
             /* VIDEO */
             //Resolution

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -131,6 +131,11 @@
 								<ComboBoxItem Tag="2">Error</ComboBoxItem>
 							</ComboBox>
 						</WrapPanel>
+						<!-- NoSystemCMD -->
+						<WrapPanel Margin="5,10,0,0">
+							<Label Margin="0,5,0,0" Width="205">Don't Apply Graphics Settings</Label> 
+							<CheckBox IsChecked="{Binding NoSystemCMD}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will not pass the graphics settings configured to FSO."></CheckBox>
+						</WrapPanel>
 					</StackPanel>
 				</Border>
 				<!--VIDEO SETTINGS-->

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -131,8 +131,12 @@
 								<ComboBoxItem Tag="2">Error</ComboBoxItem>
 							</ComboBox>
 						</WrapPanel>
+						<!-- Developer Options Shutoff-->
+						<WrapPanel IsEnabled="{Binding ShowDevOptions}" Margin="5,10,0,0">
+							<Button IsEnabled="{Binding ShowDevOptions}" Content="Turn Off Developer Options" Command="{Binding ToggleDeveloperOptions}"></Button>
+						</WrapPanel>
 						<!-- NoSystemCMD -->
-						<WrapPanel Margin="5,10,0,0">
+						<WrapPanel IsEnabled="{Binding ShowDevOptions}" Margin="5,10,0,0">
 							<Label Margin="0,5,0,0" Width="205">Don't Apply Graphics Settings</Label> 
 							<CheckBox IsChecked="{Binding NoSystemCMD}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will not pass the graphics settings configured to FSO."></CheckBox>
 						</WrapPanel>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -131,15 +131,6 @@
 								<ComboBoxItem Tag="2">Error</ComboBoxItem>
 							</ComboBox>
 						</WrapPanel>
-						<!-- Developer Options Shutoff-->
-						<WrapPanel IsEnabled="{Binding ShowDevOptions}" Margin="5,10,0,0">
-							<Button IsEnabled="{Binding ShowDevOptions}" Content="Turn Off Developer Options" Command="{Binding ToggleDeveloperOptions}"></Button>
-						</WrapPanel>
-						<!-- NoSystemCMD -->
-						<WrapPanel IsEnabled="{Binding ShowDevOptions}" Margin="5,10,0,0">
-							<Label Margin="0,5,0,0" Width="205">Don't Apply Graphics Settings</Label> 
-							<CheckBox IsChecked="{Binding NoSystemCMD}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will not pass the graphics settings configured to FSO."></CheckBox>
-						</WrapPanel>
 					</StackPanel>
 				</Border>
 				<!--VIDEO SETTINGS-->
@@ -402,6 +393,22 @@
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="5">
 							<Button Content="Adjust Debug Filters" Command="{Binding OpenDebugFilterView}"></Button>
 						</Grid>
+					</StackPanel>
+				</Border>
+
+				<!--Developer Settings-->
+				<Label IsVisible="{Binding ShowDevOptions}" Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Advanced settings used by Hard-light devs.">Developer Options</Label>
+				<Border IsVisible="{Binding ShowDevOptions}" Margin="0,5,0,5" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
+					<StackPanel IsVisible="{Binding ShowDevOptions}" Margin="5">
+						<!-- Developer Options Shutoff-->
+						<WrapPanel IsVisible="{Binding ShowDevOptions}" Margin="5,10,0,0">
+							<Button Content="Turn Off Developer Options" ToolTip.Tip="Restore Dev Options to Default and Close Developer Section.  This should restore normal Knossos.NET operations." Command="{Binding ToggleDeveloperOptions}"></Button>
+						</WrapPanel>
+						<!-- NoSystemCMD -->
+						<WrapPanel IsVisible="{Binding ShowDevOptions}" IsEnabled="{Binding ShowDevOptions}" Margin="5,10,0,0">
+							<Label Margin="0,5,0,0" Width="205">Don't Apply Graphics Settings</Label> 
+							<CheckBox IsChecked="{Binding NoSystemCMD}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will not pass the graphics settings configured to FSO."></CheckBox>
+						</WrapPanel>
 					</StackPanel>
 				</Border>
 			</StackPanel>


### PR DESCRIPTION
Having the SystemCMD forced on every mod equally is a huuuuge issue to my workflow.
It's fairly often that I need to launch some mods in a non-fullscreen window (typically debug mods to attach debuggers and not lock up my whole desktop in the process), and some other mods in fullscreen (just to play), and then others like the VR mod in yet other configurations. In almost all of these cases, these changes are fix and per mod.
Having the option to toggle off the system cmd options allows a user to manually configure this per-mod in the command line, without the need to enable complex per-mod graphics options.