### PR TITLE
Fix engine and community tabs layout

### DIFF
--- a/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/FsoBuildItemViewModel.cs
@@ -42,8 +42,8 @@ namespace Knossos.NET.ViewModels
             IsValid = true;
             Title = "Test Build Title";
             Date = "19/12/20";
-            CpuArch = "x86";
-            BuildType = "Release, Fred2";
+            CpuArch = "Architecture: x86";
+            BuildType = "Builds: Release, Fred2";
         }
 
         public FsoBuildItemViewModel (FsoBuild build)
@@ -58,8 +58,8 @@ namespace Knossos.NET.ViewModels
             Date = build.date;
             IsInstalled = build.isInstalled;
             IsValid = false;
-            CpuArch = "";
-            BuildType = "";
+            CpuArch = "Architecture: ";
+            BuildType = "Builds: ";
             if (build.id == "FSO")
             {
                 //No detail button on official FSO builds

--- a/Knossos.NET/Views/CommunityView.axaml
+++ b/Knossos.NET/Views/CommunityView.axaml
@@ -14,37 +14,38 @@
 
 	<TabControl>
 		<TabItem Header="Resources">
-            <StackPanel Margin="40,20,20,10">
-                <Button Command="{Binding JoinHLPDiscord}" ToolTip.Tip="Hard Light Productions Discord - Permanent Invitation: https://discord.gg/cyhMBhMHzK"  Classes="CommunityLink">
-                    <WrapPanel Margin="10,5,15,5">
-                        <Image Margin="0,3,0,0" Height="64" Width="64" Source="/Assets/general/discordicon.png"/>
-                        <TextBlock FontSize="18" Margin="30,5,0,0" Width="800" TextWrapping="Wrap">Join our discord!  With more than two thousand members and the collective wisdom of the community's modders, mission designers and scripters, you'll have everything you need to bring your FSO vision to life!</TextBlock>
-                    </WrapPanel> 
-                </Button>
-                <Button Command="{Binding VisitHLPWiki}" ToolTip.Tip="Hard-Light Productions wiki https://wiki.hard-light.net/index.php/Main_Page"  Margin="0,20,0,0" Classes="CommunityLink">
-                    <WrapPanel Margin="10,5,15,10">
-                        <Image Height="64" Width="64" Source="/Assets/knossos-icon.ico"/>
-                        <TextBlock FontSize="18" Margin="30,15,0,0" Width="800" TextWrapping="Wrap">Our wiki has documentation for modding the game, additional resources for creating your own missions, and details about the Freespace canon.</TextBlock> 
-                    </WrapPanel>
-                </Button>
-                <Button Command="{Binding OpenFredTutorial}" ToolTip.Tip="Fred Tutorial Selection https://wiki.hard-light.net/index.php/FRED_tutorials"  Margin="0,15,0,0" Classes="CommunityLink">
-                    <WrapPanel Margin="10,10,15,10">
-                        <Image Height="64" Width="64" Source="/Assets/general/fred.png"/>
-                        <TextBlock FontSize="18" Margin="30,15,0,0" Width="800" TextWrapping="Wrap">Learn how to make your own custom missions for FSO with this tutorial for our mission editor, called FRED.</TextBlock>
-                    </WrapPanel>                     
-                </Button>
-                <Button Command="{Binding VisitScriptingRepo}" ToolTip.Tip="Scripting Repository https://github.com/FSO-Scripters/fso-scripts"  Margin="0,15,0,0" Classes="CommunityLink">
-                    <WrapPanel Margin="10,10,15,10">
-                        <Image Height="64" Width="64" Source="/Assets/general/fsolua.png"/>
-                        <TextBlock FontSize="18" Margin="30,15,0,0" Width="800" TextWrapping="Wrap">For advanced users, you can download custom scripts to use in your mods and missions that enable new features.</TextBlock> 
-                    </WrapPanel>
-                </Button>
-                
-            </StackPanel>
+            <ScrollViewer HorizontalScrollBarVisibility="Visible">
+                <StackPanel Margin="40,20,20,10">
+                    <Button Width="900" Command="{Binding JoinHLPDiscord}" ToolTip.Tip="Hard Light Productions Discord - Permanent Invitation: https://discord.gg/cyhMBhMHzK"  Classes="CommunityLink">                          
+                            <WrapPanel Margin="10,5,15,5">
+                                <Image Margin="0,3,0,0" Height="64" Width="64" Source="/Assets/general/discordicon.png"/>
+                                <TextBlock FontSize="18" Margin="30,5,0,0" TextWrapping="Wrap">Join our discord!  With more than two thousand members and the collective wisdom of the community's modders, mission designers and scripters, you'll have everything you need to bring your FSO vision to life!</TextBlock>
+                            </WrapPanel> 
+                    </Button>
+                    <Button Width="900" Command="{Binding VisitHLPWiki}" ToolTip.Tip="Hard-Light Productions wiki https://wiki.hard-light.net/index.php/Main_Page"  Margin="0,20,0,0" Classes="CommunityLink">
+                            <WrapPanel Margin="10,5,15,10">
+                                <Image Height="64" Width="64" Source="/Assets/knossos-icon.ico"/>
+                                <TextBlock FontSize="18" Margin="30,15,0,0" TextWrapping="Wrap">Our wiki has documentation for modding the game, additional resources for creating your own missions, and details about the Freespace canon.</TextBlock> 
+                            </WrapPanel>
+                    </Button>
+                    <Button Width="900" Command="{Binding OpenFredTutorial}" ToolTip.Tip="Fred Tutorial Selection https://wiki.hard-light.net/index.php/FRED_tutorials"  Margin="0,15,0,0" Classes="CommunityLink">
+                            <WrapPanel Margin="10,10,15,10">
+                                <Image Height="64" Width="64" Source="/Assets/general/fred.png"/>
+                                <TextBlock FontSize="18" Margin="30,15,0,0" TextWrapping="Wrap">Learn how to make your own custom missions for FSO with this tutorial for our mission editor, called FRED.</TextBlock>
+                            </WrapPanel>
+                    </Button>
+                    <Button Width="900" Command="{Binding VisitScriptingRepo}" ToolTip.Tip="Scripting Repository https://github.com/FSO-Scripters/fso-scripts"  Margin="0,15,0,0" Classes="CommunityLink">
+                            <WrapPanel Margin="10,10,15,10">
+                                <Image Height="64" Width="64" Source="/Assets/general/fsolua.png"/>
+                                <TextBlock FontSize="18" Margin="30,15,0,0" TextWrapping="Wrap">For advanced users, you can download custom scripts to use in your mods and missions that enable new features.</TextBlock> 
+                            </WrapPanel>
+                    </Button>
+                </StackPanel>
+            </ScrollViewer>
 		</TabItem>
 
 	    <TabItem Header="FAQ">
-            <ScrollViewer>
+            <ScrollViewer HorizontalScrollBarVisibility="Visible">
                 <StackPanel Margin="30,0,20,10">
                     <ItemsControl ItemsSource="{Binding Categories}">
                         <ItemsControl.ItemTemplate>
@@ -80,20 +81,22 @@
         </TabItem>
 
 		<TabItem Header="Bug Reporting">
-            <StackPanel Margin="40,20,20,10">
-                <Button Command="{Binding VisitFSOIssues}" ToolTip.Tip="https://github.com/scp-fs2open/fs2open.github.com/issues"  Margin="20,15,0,0" Classes="CommunityLink">
-                    <WrapPanel Margin="10,10,15,10">
-                        <Image Height="64" Width="64" Source="/Assets/general/github.png"/>
-                        <TextBlock FontSize="18" Margin="30,15,0,0" Width="350" TextWrapping="Wrap">Freespace 2 Open Github Issues</TextBlock> 
-                    </WrapPanel>
-                </Button>
-                <Button Command="{Binding VisitKnossosNETIssues}" ToolTip.Tip="https://github.com/KnossosNET/Knossos.NET/issues"  Margin="20,15,0,0" Classes="CommunityLink">
-                    <WrapPanel Margin="10,10,15,10">
-                        <Image Height="64" Width="64" Source="/Assets/general/github.png"/>
-                        <TextBlock FontSize="18" Margin="30,15,0,0" Width="350" TextWrapping="Wrap">KnossosNET Github Issues</TextBlock> 
-                    </WrapPanel>
-                </Button>
-            </StackPanel>
+            <ScrollViewer HorizontalScrollBarVisibility="Visible">
+                <StackPanel Margin="40,20,20,10">
+                    <Button Command="{Binding VisitFSOIssues}" ToolTip.Tip="https://github.com/scp-fs2open/fs2open.github.com/issues"  Margin="20,15,0,0" Classes="CommunityLink">
+                        <WrapPanel Margin="10,10,15,10">
+                            <Image Height="64" Width="64" Source="/Assets/general/github.png"/>
+                            <TextBlock FontSize="18" Margin="30,15,0,0" Width="350" TextWrapping="Wrap">Freespace 2 Open Github Issues</TextBlock> 
+                        </WrapPanel>
+                    </Button>
+                    <Button Command="{Binding VisitKnossosNETIssues}" ToolTip.Tip="https://github.com/KnossosNET/Knossos.NET/issues"  Margin="20,15,0,0" Classes="CommunityLink">
+                        <WrapPanel Margin="10,10,15,10">
+                            <Image Height="64" Width="64" Source="/Assets/general/github.png"/>
+                            <TextBlock FontSize="18" Margin="30,15,0,0" Width="350" TextWrapping="Wrap">KnossosNET Github Issues</TextBlock> 
+                        </WrapPanel>
+                    </Button>
+                </StackPanel>
+            </ScrollViewer>
 		</TabItem>
 	</TabControl>
 

--- a/Knossos.NET/Views/Templates/FsoBuildItemView.axaml
+++ b/Knossos.NET/Views/Templates/FsoBuildItemView.axaml
@@ -12,15 +12,21 @@
 		<vm:FsoBuildItemViewModel/>
 	</Design.DataContext>
 
-	<Grid Background="{StaticResource BackgroundColorTertiary}" ColumnDefinitions="Auto,Auto,Auto,Auto,*">
-		<Label FontWeight="Bold" Width="150" Grid.Column="0" Content="{Binding Date}" VerticalAlignment="Center"></Label>
-		<Label FontWeight="Bold" Width="350" Grid.Column="1" Content="{Binding Title, Converter={StaticResource escapeUnderscoresConverter}}" VerticalAlignment="Center"></Label>
-
-		<Label Grid.Column="2" IsVisible="{Binding IsValid}" Width="150" Foreground="{StaticResource TertiaryColor}" FontWeight="Bold" Content="{Binding CpuArch}" VerticalAlignment="Center"></Label>
-		<Label Grid.Column="3" IsVisible="{Binding IsValid}" Foreground="{StaticResource PrimaryColor}" FontWeight="Bold" Content="{Binding BuildType}" VerticalAlignment="Center"></Label>
-		<Label Grid.Column="4" Foreground="{StaticResource TertiaryColor}" IsVisible="{Binding !IsValid}" VerticalAlignment="Center" FontWeight="Bold">No valid or usable files were found in this build</Label>
-			
-		<WrapPanel IsEnabled="{Binding !IsDevMode}" IsVisible="{Binding !IsDownloading}" Grid.Column="5" HorizontalAlignment="Right">
+	<Grid Background="{StaticResource BackgroundColorTertiary}" ColumnDefinitions="Auto,Auto,Auto,*">
+		<StackPanel>
+			<WrapPanel HorizontalAlignment="Left">
+				<Label FontWeight="Bold" Grid.Column="0" Content="{Binding Date}" VerticalAlignment="Center"></Label>
+				<Label FontWeight="Bold" Grid.Column="1" Content="{Binding Title, Converter={StaticResource escapeUnderscoresConverter}}" VerticalAlignment="Center"></Label>
+				<Label Grid.Column="2" Foreground="{StaticResource TertiaryColor}" IsVisible="{Binding !IsValid}" VerticalAlignment="Center" FontWeight="Bold">No valid or usable files were found in this build</Label>
+			</WrapPanel>
+			<WrapPanel IsEnabled="{Binding IsInstalled}" IsVisible="{Binding IsInstalled}">
+				<Label Grid.Column="1" IsVisible="{Binding IsValid}" Foreground="{StaticResource PrimaryColor}" FontWeight="Bold" Content="{Binding BuildType}" VerticalAlignment="Center"></Label>
+			</WrapPanel>
+			<WrapPanel IsEnabled="{Binding IsInstalled}" IsVisible="{Binding IsInstalled}">
+				<Label Grid.Column="0" IsVisible="{Binding IsValid}" Foreground="{StaticResource TertiaryColor}" FontWeight="Bold" Content="{Binding CpuArch}" VerticalAlignment="Center"></Label>
+			</WrapPanel>
+		</StackPanel>
+		<WrapPanel IsEnabled="{Binding !IsDevMode}" IsVisible="{Binding !IsDownloading}" Grid.Column="4" HorizontalAlignment="Right">
 			<Button IsVisible="{Binding IsDetailsButtonVisible}" Classes="Settings" Margin="0,0,10,0" Width="100" Command="{Binding ViewBuildDetails}">Details</Button>
 			<WrapPanel IsVisible="{Binding IsInstalled}">
 				<Button IsVisible="{Binding !IsDevMode}" Width="100" Classes="Secondary" Margin="0,0,10,0" Command="{Binding LoadPkgData}" Content="Modify">


### PR DESCRIPTION
This fixes the new task view so that it doesn't completely block engine tab and community tab content.

Community view is fixed by adding a vertical/horizontal scrollbar, and the engine tab has some elements rearranged so that the buttons are visible, even when the window is much smaller than intended.

Fixes #207 