### PR TITLE
use specific Ubuntu version for docker (22.04-jammy)

### DIFF
--- a/ci/create_appimage.sh
+++ b/ci/create_appimage.sh
@@ -59,5 +59,5 @@ docker run --rm \
     -v "$REPO_ROOT":/repo \
     -v "$PUBLISH_DIR":/PublishDir \
     -v "$OUTPUT_DIR":/OutputDir \
-    -t $DOCKER_ARCH/ubuntu \
+    -t $DOCKER_ARCH/ubuntu:jammy \
     /bin/bash -xc "/repo/ci/bundle_appimage.sh"


### PR DESCRIPTION
Newest Ubuntu LTS release (24.04) includes a version of qemu-user-static which fails to run aarch64 binaries on x86_64 hardware. Forcing Docker to use an older version of Ubuntu should work around the problem until qemu-user-static is fixed upstream.