### PR TITLE
Allow setting environment variables and prefix commands

### DIFF
--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -260,8 +260,16 @@ namespace Knossos.NET.Models
                         }
                         else
                         {
-                            fso.StartInfo.FileName = Knossos.globalSettings.prefixCMD;
-                            fso.StartInfo.Arguments = execPath + " " + cmdline;
+                            var prefixCMD = Knossos.globalSettings.prefixCMD.Split(" ", 2);
+                            fso.StartInfo.FileName = prefixCMD[0];
+                            if (prefixCMD.Length > 1)
+                            {
+                                fso.StartInfo.Arguments = prefixCMD[1] + " " + execPath + " " + cmdline;
+                            }
+                            else
+                            {
+                                fso.StartInfo.Arguments = execPath + " " + cmdline;
+                            }
                         }
 
                         fso.StartInfo.UseShellExecute = false;

--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -253,11 +253,30 @@ namespace Knossos.NET.Models
 
                     using (var fso = new Process())
                     {
-                        fso.StartInfo.FileName = execPath;
-                        fso.StartInfo.Arguments = cmdline;
+                        if (Knossos.globalSettings.prefixCMD == "")
+                        {
+                            fso.StartInfo.FileName = execPath;
+                            fso.StartInfo.Arguments = cmdline;
+                        }
+                        else
+                        {
+                            fso.StartInfo.FileName = Knossos.globalSettings.prefixCMD;
+                            fso.StartInfo.Arguments = execPath + " " + cmdline;
+                        }
+
                         fso.StartInfo.UseShellExecute = false;
                         if (workingFolder != null)
                             fso.StartInfo.WorkingDirectory = workingFolder;
+                        if (Knossos.globalSettings.envVars != "")
+                        {
+                            foreach (var envVar in Knossos.globalSettings.envVars.Split(","))
+                            {
+                                var envVarComponents = envVar.Split("=");
+                                if (envVarComponents.Length != 2)
+                                    continue;
+                                fso.StartInfo.EnvironmentVariables.Add(envVarComponents[0], envVarComponents[1]);
+                            }
+                        }
                         fso.Start();
                         if (waitForExit)
                             await fso.WaitForExitAsync();

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -118,10 +118,6 @@ namespace Knossos.NET.Models
         public int devModSort { get; set; } = 0;
         [JsonPropertyName("auto_update_fso_builds")]
         public AutoUpdateFsoBuilds autoUpdateBuilds { get; set; } = new AutoUpdateFsoBuilds();
-        [JsonPropertyName("no_system_cmd")]
-        public bool noSystemCMD { get; set; } = false;
-        [JsonPropertyName("show_dev_options")]
-        public bool showDevOptions { get; set; } = false;
 
         /* FSO Settings that use the fs2_open.ini are json ignored */
 
@@ -221,6 +217,16 @@ namespace Knossos.NET.Models
         [JsonPropertyName("last_sort_type"), JsonConverter(typeof(JsonStringEnumConverter))]
         public MainWindowViewModel.SortType sortType { get; set; } = MainWindowViewModel.SortType.name;
 
+        /* Developer Settings */
+        [JsonPropertyName("no_system_cmd")]
+        public bool noSystemCMD { get; set; } = false;
+        [JsonPropertyName("prefix_cmd")]
+        public string prefixCMD { get; set; } = string.Empty;
+        [JsonPropertyName("env_vars")]
+        public string envVars { get; set; } = string.Empty;
+        [JsonPropertyName("show_dev_options")]
+        public bool showDevOptions { get; set; } = false;
+        
         [JsonIgnore]
         private FileSystemWatcher? iniWatcher = null;
 
@@ -599,6 +605,8 @@ namespace Knossos.NET.Models
                         devModSort = tempSettings.devModSort;
                         autoUpdateBuilds = tempSettings.autoUpdateBuilds;
                         noSystemCMD = tempSettings.noSystemCMD;
+                        prefixCMD = tempSettings.prefixCMD;
+                        envVars = tempSettings.envVars;
                         showDevOptions = tempSettings.showDevOptions;
 
                         if (MainWindowViewModel.Instance != null)

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -97,8 +97,6 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal bool deleteOlder = false;
         [ObservableProperty]
-        internal bool noSystemCMD = false;
-        [ObservableProperty]
         internal bool showDevOptions = false;
 
         /*VIDEO*/
@@ -191,6 +189,14 @@ namespace Knossos.NET.ViewModels
         internal uint joystickSensitivity = 9;
         [ObservableProperty]
         internal uint joystickDeadZone = 10;
+        
+        /* DEVELOPER */
+        [ObservableProperty]
+        internal bool noSystemCMD = false;
+        [ObservableProperty]
+        internal string prefixCMD = string.Empty;
+        [ObservableProperty]
+        internal string envVars = string.Empty;
 
         // In order to have hidden dev options, we need a setter for globalCMD
         public string GlobalCmd
@@ -309,6 +315,8 @@ namespace Knossos.NET.ViewModels
             UpdateStable = Knossos.globalSettings.autoUpdateBuilds.UpdateStable;
             DeleteOlder = Knossos.globalSettings.autoUpdateBuilds.DeleteOlder;
             NoSystemCMD = Knossos.globalSettings.noSystemCMD;
+            PrefixCMD = Knossos.globalSettings.prefixCMD;
+            EnvVars = Knossos.globalSettings.envVars;
             ShowDevOptions = Knossos.globalSettings.showDevOptions || NoSystemCMD;
 
             /* VIDEO SETTINGS */
@@ -869,6 +877,8 @@ namespace Knossos.NET.ViewModels
             Knossos.globalSettings.autoUpdate = AutoUpdate;
             Knossos.globalSettings.autoUpdateBuilds = new GlobalSettings.AutoUpdateFsoBuilds(UpdateStable, UpdateRC, UpdateNightly, DeleteOlder);
             Knossos.globalSettings.noSystemCMD = NoSystemCMD;
+            Knossos.globalSettings.prefixCMD = PrefixCMD;
+            Knossos.globalSettings.envVars = EnvVars;
             Knossos.globalSettings.showDevOptions = ShowDevOptions;
 
             /* VIDEO */

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -417,6 +417,16 @@
 							<Label Margin="0,5,0,0" Width="205">Don't Apply Graphics Settings</Label> 
 							<CheckBox IsChecked="{Binding NoSystemCMD}" Margin="5,0,0,0" ToolTip.Tip="Knossos.NET will not pass the graphics settings configured to FSO."></CheckBox>
 						</WrapPanel>
+						<!-- PrefixCMD -->
+						<WrapPanel IsVisible="{Binding ShowDevOptions}" IsEnabled="{Binding ShowDevOptions}" Margin="5,10,0,0">
+							<Label Margin="0,5,0,0" Width="205">Pass FSO launch command as argument to other command</Label> 
+							<TextBox Text="{Binding PrefixCMD}" Margin="5,0,0,0" ToolTip.Tip="This will be prepended to the launch command for FSO and FRED." Width="500"></TextBox>
+						</WrapPanel>
+						<!-- EnvVars -->
+						<WrapPanel IsVisible="{Binding ShowDevOptions}" IsEnabled="{Binding ShowDevOptions}" Margin="5,10,0,0">
+							<Label Margin="0,5,0,0" Width="205">Pass environment variables to FSO</Label> 
+							<TextBox Text="{Binding EnvVars}" Margin="5,0,0,0" ToolTip.Tip="Expects a comma-seperated list." Width="500"></TextBox>
+						</WrapPanel>
 					</StackPanel>
 				</Border>
 			</StackPanel>


### PR DESCRIPTION
These can be useful to advanced users in certain circumstances.
Use cases for environment variables include stuff like setting the SDL-Videodriver to wayland on linux if available.
Use cases for prefix commands are running FSO through wrapper programs, such as attaching the nsight debugger, recording tools, or other things.