### PR TITLE
Adapt loading animations for mod tile tabs

### DIFF
--- a/Knossos.NET/ViewModels/ModListViewModel.cs
+++ b/Knossos.NET/ViewModels/ModListViewModel.cs
@@ -15,6 +15,18 @@ namespace Knossos.NET.ViewModels
     public partial class ModListViewModel : ViewModelBase
     {
         /// <summary>
+        /// Is this tab in the middle of sorting or filtering mod tiles
+        /// </summary>
+        [ObservableProperty]
+        internal bool sorting = false;
+
+        /// <summary>
+        /// For the knossos Loading animation 
+        /// </summary>
+        [ObservableProperty]
+        internal LoadingIconViewModel loadingAnimation;
+
+        /// <summary>
         /// Current Sort Mode
         /// </summary>
         internal MainWindowViewModel.SortType sortType = MainWindowViewModel.SortType.unsorted;
@@ -54,6 +66,8 @@ namespace Knossos.NET.ViewModels
 
         public ModListViewModel()
         {
+            LoadingAnimation = new LoadingIconViewModel();
+
         }
 
 
@@ -120,6 +134,7 @@ namespace Knossos.NET.ViewModels
 
                 if (newSort != sortType)
                 {
+                    Sorting = true;
                     Dispatcher.UIThread.Invoke( () =>
                     {
                         var tempList = Mods.ToList();
@@ -133,10 +148,13 @@ namespace Knossos.NET.ViewModels
                             }
                         }
                         GC.Collect();
+                        Sorting = false;
                     },DispatcherPriority.Background);
+
                 }
             }catch(Exception ex)
             {
+                Sorting = false;
                 Log.Add(Log.LogSeverity.Error, "ModListViewModel.ChangeSort()", ex);
             }
         }

--- a/Knossos.NET/ViewModels/ModListViewModel.cs
+++ b/Knossos.NET/ViewModels/ModListViewModel.cs
@@ -134,6 +134,7 @@ namespace Knossos.NET.ViewModels
 
                 if (newSort != sortType)
                 {
+                    LoadingAnimation.Animate = 1;
                     Sorting = true;
                     Dispatcher.UIThread.Invoke( () =>
                     {
@@ -149,12 +150,14 @@ namespace Knossos.NET.ViewModels
                         }
                         GC.Collect();
                         Sorting = false;
+                        LoadingAnimation.Animate = 0;
                     },DispatcherPriority.Background);
 
                 }
             }catch(Exception ex)
             {
                 Sorting = false;
+                LoadingAnimation.Animate = 0;                
                 Log.Add(Log.LogSeverity.Error, "ModListViewModel.ChangeSort()", ex);
             }
         }

--- a/Knossos.NET/ViewModels/NebulaModListViewModel.cs
+++ b/Knossos.NET/ViewModels/NebulaModListViewModel.cs
@@ -32,16 +32,35 @@ namespace Knossos.NET.ViewModels
             get { return _isLoading; }
             set { 
                 _isLoading = value;
-                ShowTiles = !sorting && !isLoading;}
+                ShowTiles = !sorting && !isLoading;
+                if (ShowTiles)
+                {
+                    LoadingAnimation.Animate = 0;
+                } 
+                else  
+                {
+                    LoadingAnimation.Animate = 1;
+                }        
             }
+        }
 
         private bool _sorting = true;
         internal bool sorting {
             get { return _sorting; }
             set { 
                 _sorting = value;
-                ShowTiles = !sorting && !isLoading;}
+                ShowTiles = !sorting && !isLoading;
+
+                if (ShowTiles)
+                {
+                    LoadingAnimation.Animate = 0;                
+                } 
+                else  
+                {
+                    LoadingAnimation.Animate = 1;
+                }
             }
+        }
 
         /// <summary>
         /// For the UI to detmerine whether to show mod tiles.  It needs to check more than one property, so this gets updated when sorting or isLoading do.
@@ -62,6 +81,8 @@ namespace Knossos.NET.ViewModels
             set 
             {
                 sorting = true;
+                LoadingAnimation.Animate = 1;
+
                 if (value != Search){
                     this.SetProperty(ref search, value);
                     if (value.Trim() != string.Empty)
@@ -84,6 +105,7 @@ namespace Knossos.NET.ViewModels
                     }
                 }
                 sorting = false;
+                LoadingAnimation.Animate = 1;
             }
         }
 

--- a/Knossos.NET/ViewModels/Templates/LoadingIconViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/LoadingIconViewModel.cs
@@ -7,5 +7,6 @@ namespace Knossos.NET.ViewModels
 {
     public partial class LoadingIconViewModel : ViewModelBase
     {
+        public int Animate {get; set;} = 0;
     }
 }

--- a/Knossos.NET/ViewModels/Templates/LoadingIconViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/LoadingIconViewModel.cs
@@ -1,0 +1,37 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Knossos.NET.ViewModels
+{
+    public partial class LoadingIconViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        internal bool frame0 = true;
+        [ObservableProperty]
+        internal bool frame1 = false;
+
+        public LoadingIconViewModel() 
+        {
+            System.Timers.Timer timer = new System.Timers.Timer();
+            timer.Interval = 500;
+            timer.Elapsed += Animate;
+            timer.Start();
+        }
+
+        private void Animate(object? _, System.Timers.ElapsedEventArgs __)
+        {
+            if(Frame0)
+            {
+                Frame0 = false;
+                Frame1 = true;
+            }
+            else
+            {
+                Frame1 = false;
+                Frame0 = true;
+            }
+        }
+    }
+}

--- a/Knossos.NET/ViewModels/Templates/LoadingIconViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/LoadingIconViewModel.cs
@@ -7,31 +7,5 @@ namespace Knossos.NET.ViewModels
 {
     public partial class LoadingIconViewModel : ViewModelBase
     {
-        [ObservableProperty]
-        internal bool frame0 = true;
-        [ObservableProperty]
-        internal bool frame1 = false;
-
-        public LoadingIconViewModel() 
-        {
-            System.Timers.Timer timer = new System.Timers.Timer();
-            timer.Interval = 500;
-            timer.Elapsed += Animate;
-            timer.Start();
-        }
-
-        private void Animate(object? _, System.Timers.ElapsedEventArgs __)
-        {
-            if(Frame0)
-            {
-                Frame0 = false;
-                Frame1 = true;
-            }
-            else
-            {
-                Frame1 = false;
-                Frame0 = true;
-            }
-        }
     }
 }

--- a/Knossos.NET/Views/ModListView.axaml
+++ b/Knossos.NET/Views/ModListView.axaml
@@ -51,18 +51,24 @@
 			</WrapPanel>
 		</Grid>
 		<ScrollViewer Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-			<ItemsControl HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ItemsSource="{Binding Mods}">
-				<ItemsControl.ItemTemplate>
-					<DataTemplate>
-						<v:ModCardView Margin="5" Content="{Binding}"/>
-					</DataTemplate>
-				</ItemsControl.ItemTemplate>
-				<ItemsControl.ItemsPanel>
-					<ItemsPanelTemplate>
-						<WrapPanel />
-					</ItemsPanelTemplate>
-				</ItemsControl.ItemsPanel>
-			</ItemsControl>
+			<StackPanel>
+				<StackPanel>
+					<v:LoadingIconView IsEnabled="{Binding Sorting}" IsVisible="{Binding Sorting}" Width="80" Height="80" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="50,50,0,0" Content="{Binding LoadingAnimation}"/>
+					<Label FontWeight="Bold" FontSize="20" VerticalAlignment="Center" HorizontalAlignment="Center" IsVisible="{Binding Sorting}" Margin="60,0,0,0">Loading...</Label>
+				</StackPanel>
+				<ItemsControl IsEnabled="{Binding !Sorting}" IsVisible="{Binding !Sorting}"  HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ItemsSource="{Binding Mods}">
+					<ItemsControl.ItemTemplate>
+						<DataTemplate>
+							<v:ModCardView Margin="5" Content="{Binding}"/>
+						</DataTemplate>
+					</ItemsControl.ItemTemplate>
+					<ItemsControl.ItemsPanel>
+						<ItemsPanelTemplate>
+							<WrapPanel />
+						</ItemsPanelTemplate>
+					</ItemsControl.ItemsPanel>
+				</ItemsControl>
+			</StackPanel>
 		</ScrollViewer>
 	</Grid>
 </UserControl>

--- a/Knossos.NET/Views/NebulaModListView.axaml
+++ b/Knossos.NET/Views/NebulaModListView.axaml
@@ -36,20 +36,25 @@
 			</WrapPanel>
 		</Grid>
 		<ScrollViewer Grid.Row="1" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-			<ItemsControl HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ItemsSource="{Binding Mods}" IsVisible="{Binding !IsLoading}">
-				<ItemsControl.ItemTemplate>
-					<DataTemplate>
-						<v:NebulaModCardView Margin="5" Content="{Binding}"/>
-					</DataTemplate>
-				</ItemsControl.ItemTemplate>
-				<ItemsControl.ItemsPanel>
-					<ItemsPanelTemplate>
-						<WrapPanel />
-					</ItemsPanelTemplate>
-				</ItemsControl.ItemsPanel>
-			</ItemsControl>
+			<StackPanel>
+				<StackPanel>
+					<v:LoadingIconView IsEnabled="{Binding !ShowTiles}" IsVisible="{Binding !ShowTiles}" Width="80" Height="80" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="50,50,0,0" Content="{Binding LoadingAnimation}"/>
+					<Label FontWeight="Bold" FontSize="20" VerticalAlignment="Center" HorizontalAlignment="Center" IsVisible="{Binding !ShowTiles}" Margin="60,0,0,0">Loading...</Label>
+				</StackPanel>
+				<ItemsControl IsEnabled="{Binding ShowTiles}" IsVisible="{Binding ShowTiles}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ItemsSource="{Binding Mods}">
+					<ItemsControl.ItemTemplate>
+						<DataTemplate>
+							<v:NebulaModCardView Margin="5" Content="{Binding}"/>
+						</DataTemplate>
+					</ItemsControl.ItemTemplate>
+					<ItemsControl.ItemsPanel>
+						<ItemsPanelTemplate>
+							<WrapPanel />
+						</ItemsPanelTemplate>
+					</ItemsControl.ItemsPanel>
+				</ItemsControl>
+			</StackPanel>
 		</ScrollViewer>
-		<Label Grid.Row="1" FontWeight="Bold" FontSize="24" VerticalAlignment="Center" HorizontalAlignment="Center" IsVisible="{Binding IsLoading}">Loading...</Label>
 	</Grid>
 
 </UserControl>

--- a/Knossos.NET/Views/Templates/LoadingIconView.axaml
+++ b/Knossos.NET/Views/Templates/LoadingIconView.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="40" d:DesignHeight="40"
+             x:Class="Knossos.NET.Views.LoadingIconView"
+	         xmlns:v="using:Knossos.NET.Views"
+	         xmlns:vm="using:Knossos.NET.ViewModels"
+	         x:DataType="vm:LoadingIconViewModel">
+	
+    <Grid>
+        <Image IsVisible="{Binding Frame0}" VerticalAlignment="Center" Height="35" Width="35" ToolTip.Tip="Loading ..." Source="/Assets/general/kns-frame-0.png" />
+        <Image IsVisible="{Binding Frame1}" VerticalAlignment="Center" Height="35" Width="35" ToolTip.Tip="Loading ..." Source="/Assets/general/kns-frame-1.png" />
+    </Grid>
+</UserControl>

--- a/Knossos.NET/Views/Templates/LoadingIconView.axaml
+++ b/Knossos.NET/Views/Templates/LoadingIconView.axaml
@@ -10,7 +10,7 @@
 	         x:DataType="vm:LoadingIconViewModel">
 	
     <Grid>
-        <Image Width="62" Stretch="UniformToFill" anim:ImageBehavior.AnimatedSource="avares://Knossos.NET/Assets/general/knossos-1.gif" />
-	    <Image Width="60" Stretch="UniformToFill" anim:ImageBehavior.AnimatedSource="avares://Knossos.NET/Assets/general/knossos-2.gif" />    
+        <Image Width="62" Stretch="UniformToFill" anim:ImageBehavior.SpeedRatio="{Binding Animate}" anim:ImageBehavior.AnimatedSource="avares://Knossos.NET/Assets/general/knossos-1.gif" />
+	    <Image Width="60" Stretch="UniformToFill" anim:ImageBehavior.SpeedRatio="{Binding Animate}" anim:ImageBehavior.AnimatedSource="avares://Knossos.NET/Assets/general/knossos-2.gif" />    
     </Grid>
 </UserControl>

--- a/Knossos.NET/Views/Templates/LoadingIconView.axaml
+++ b/Knossos.NET/Views/Templates/LoadingIconView.axaml
@@ -2,14 +2,15 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="40" d:DesignHeight="40"
+             mc:Ignorable="d" d:DesignWidth="40" d:DesignHeight="40"             
+                xmlns:anim="https://github.com/whistyun/AnimatedImage.Avalonia"
              x:Class="Knossos.NET.Views.LoadingIconView"
 	         xmlns:v="using:Knossos.NET.Views"
 	         xmlns:vm="using:Knossos.NET.ViewModels"
 	         x:DataType="vm:LoadingIconViewModel">
 	
     <Grid>
-        <Image IsVisible="{Binding Frame0}" VerticalAlignment="Center" Height="35" Width="35" ToolTip.Tip="Loading ..." Source="/Assets/general/kns-frame-0.png" />
-        <Image IsVisible="{Binding Frame1}" VerticalAlignment="Center" Height="35" Width="35" ToolTip.Tip="Loading ..." Source="/Assets/general/kns-frame-1.png" />
+        <Image Width="62" Stretch="UniformToFill" anim:ImageBehavior.AnimatedSource="avares://Knossos.NET/Assets/general/knossos-1.gif" />
+	    <Image Width="60" Stretch="UniformToFill" anim:ImageBehavior.AnimatedSource="avares://Knossos.NET/Assets/general/knossos-2.gif" />    
     </Grid>
 </UserControl>

--- a/Knossos.NET/Views/Templates/LoadingIconView.axaml.cs
+++ b/Knossos.NET/Views/Templates/LoadingIconView.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Knossos.NET.Views;
+
+public partial class LoadingIconView : UserControl
+{
+    public LoadingIconView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
This ameliorates the loading time for mod tiles when populating by showing our knossos animation and a loading label to the mod and nebula tabs when they are sorting, populating or filtering.

There is still approximately 10 seconds before the nebula mod tiles are loaded at least on my machine, so improvements are still possible.