### PR TITLE
Warn about bad library folder

### DIFF
--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -782,12 +782,27 @@ namespace Knossos.NET.ViewModels
 
                 var result = await MainWindow.instance.StorageProvider.OpenFolderPickerAsync(options);
 
-                if (result != null && result.Count > 0)
+                try {
+                    if (result != null && result.Count > 0)
+                    {
+                        
+                        // Test if we can write to the new library directory
+                        using (StreamWriter writer = new StreamWriter(result[0].Path + Path.DirectorySeparatorChar + "test.txt"))
+                        {
+                            writer.WriteLine("test");
+                        }
+                        File.Delete(KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "test.txt");
+                    
+                        Knossos.globalSettings.basePath = result[0].Path.LocalPath.ToString();
+                        Knossos.globalSettings.Save();
+                        Knossos.ResetBasePath();
+                        LoadData();
+                    }
+                } 
+                catch (Exception Ex) 
                 {
-                    Knossos.globalSettings.basePath = result[0].Path.LocalPath.ToString();
-                    Knossos.globalSettings.Save();
-                    Knossos.ResetBasePath();
-                    LoadData();
+                    Log.Add(Log.LogSeverity.Error, "GlobalSettings.BrowseFolderCommand() - test read/write was not successful: ", ex);
+
                 }
             }
         }

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -787,11 +787,11 @@ namespace Knossos.NET.ViewModels
                     {
                         
                         // Test if we can write to the new library directory
-                        using (StreamWriter writer = new StreamWriter(result[0].Path + Path.DirectorySeparatorChar + "test.txt"))
+                        using (StreamWriter writer = new StreamWriter(Path.Combine(result[0].Path, Path.DirectorySeparatorChar, "test.txt")))
                         {
                             writer.WriteLine("test");
                         }
-                        File.Delete(KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "test.txt");
+                        File.Delete(Path.Combine(result[0].Path, Path.DirectorySeparatorChar, "test.txt"));
                     
                         Knossos.globalSettings.basePath = result[0].Path.LocalPath.ToString();
                         Knossos.globalSettings.Save();
@@ -803,7 +803,7 @@ namespace Knossos.NET.ViewModels
                 {
                     Log.Add(Log.LogSeverity.Error, "GlobalSettings.BrowseFolderCommand() - test read/write was not successful: ", ex);
                     await Dispatcher.UIThread.Invoke(async () => {
-                        result = await MessageBox.Show(null, null, "Knossos was not able to write to this folder.  Please select another library folder.", MessageBox.MessageBoxButtons.Ok);
+                        result = await MessageBox.Show(null, null, "Knossos was not able to write to this folder.  Please select another library folder.", MessageBox.MessageBoxButtons.OK);
                     }).ConfigureAwait(false);
                 }
             }

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -787,11 +787,11 @@ namespace Knossos.NET.ViewModels
                     {
                         
                         // Test if we can write to the new library directory
-                        using (StreamWriter writer = new StreamWriter(Path.Combine(result[0].Path, Path.DirectorySeparatorChar, "test.txt")))
+                        using (StreamWriter writer = new StreamWriter(result[0].Path.AbsolutePath.ToString() + Path.DirectorySeparatorChar + "test.txt"))
                         {
                             writer.WriteLine("test");
                         }
-                        File.Delete(Path.Combine(result[0].Path, Path.DirectorySeparatorChar, "test.txt"));
+                        File.Delete(Path.Combine(result[0].Path.AbsolutePath.ToString() + Path.DirectorySeparatorChar + "test.txt"));
                     
                         Knossos.globalSettings.basePath = result[0].Path.LocalPath.ToString();
                         Knossos.globalSettings.Save();
@@ -803,7 +803,7 @@ namespace Knossos.NET.ViewModels
                 {
                     Log.Add(Log.LogSeverity.Error, "GlobalSettings.BrowseFolderCommand() - test read/write was not successful: ", ex);
                     await Dispatcher.UIThread.Invoke(async () => {
-                        result = await MessageBox.Show(null, null, "Knossos was not able to write to this folder.  Please select another library folder.", MessageBox.MessageBoxButtons.OK);
+                        await MessageBox.Show(null, "Knossos was not able to write to this folder.  Please select another library folder.", "Cannot Select Folder", MessageBox.MessageBoxButtons.OK);
                     }).ConfigureAwait(false);
                 }
             }

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -799,10 +799,12 @@ namespace Knossos.NET.ViewModels
                         LoadData();
                     }
                 } 
-                catch (Exception Ex) 
+                catch (Exception ex) 
                 {
                     Log.Add(Log.LogSeverity.Error, "GlobalSettings.BrowseFolderCommand() - test read/write was not successful: ", ex);
-
+                    await Dispatcher.UIThread.Invoke(async () => {
+                        result = await MessageBox.Show(null, null, "Knossos was not able to write to this folder.  Please select another library folder.", MessageBox.MessageBoxButtons.Ok);
+                    }).ConfigureAwait(false);
                 }
             }
         }


### PR DESCRIPTION
This keeps the user from selecting library folders that Knossos has insufficient write permissions to use, like Program Files.

Fixes #214 