### PR TITLE
Use Local instead of Absolute path

### DIFF
--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -787,11 +787,11 @@ namespace Knossos.NET.ViewModels
                     {
                         
                         // Test if we can write to the new library directory
-                        using (StreamWriter writer = new StreamWriter(result[0].Path.AbsolutePath.ToString() + Path.DirectorySeparatorChar + "test.txt"))
+                        using (StreamWriter writer = new StreamWriter(result[0].Path.LocalPath.ToString() + Path.DirectorySeparatorChar + "test.txt"))
                         {
                             writer.WriteLine("test");
                         }
-                        File.Delete(Path.Combine(result[0].Path.AbsolutePath.ToString() + Path.DirectorySeparatorChar + "test.txt"));
+                        File.Delete(Path.Combine(result[0].Path.LocalPath.ToString() + Path.DirectorySeparatorChar + "test.txt"));
                     
                         Knossos.globalSettings.basePath = result[0].Path.LocalPath.ToString();
                         Knossos.globalSettings.Save();


### PR DESCRIPTION
This allows spaces in the Library folder.  I also tested special characters, just in case.