### PR TITLE
Add CRC check during mod upload

### DIFF
--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -105,7 +105,7 @@ namespace Knossos.NET.Models
         [JsonPropertyName("mod_compression")]
         public CompressionSettings modCompression { get; set; } = CompressionSettings.Manual;
         [JsonPropertyName("compression_max_parallelism")]
-        public int compressionMaxParallelism { get; set; } = 4;
+        public int compressionMaxParallelism { get; set; } = 2;
         [JsonPropertyName("auto_update")]
         public bool autoUpdate { get; set; } = false;
         [JsonPropertyName("check_updates")]

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -81,7 +81,7 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal CompressionSettings modCompression = CompressionSettings.Manual;
         [ObservableProperty]
-        internal int compressionMaxParallelism = 4;
+        internal int compressionMaxParallelism = 2;
         [ObservableProperty]
         internal bool checkUpdates = true;
         [ObservableProperty]

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -1215,6 +1215,7 @@ namespace Knossos.NET.ViewModels
                     IsTextTask = false;
                     IsFileDownloadTask = false;
                     Name = "Prepare Pkg: " + pkg.name;
+                    var maxCrcAttempts = 5; //How many times try to compress a pkg with 7z in case of CRC error
 
                     if (cancelSource != null)
                         cancellationTokenSource = cancelSource;
@@ -1292,11 +1293,35 @@ namespace Knossos.NET.ViewModels
                             ProgressCurrent = 0;
                             using (var compressor = new SevenZipConsoleWrapper(sevenZipCallback, cancellationTokenSource))
                             {
-                                if (!await compressor.CompressFile(vpPath, modFullPath + Path.DirectorySeparatorChar + "kn_upload" + Path.DirectorySeparatorChar + "vps", zipPath, true))
-                                {
-                                    Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "Error while compressing the package");
-                                    throw new TaskCanceledException();
-                                }
+                                var crcAttempt = 0;
+                                var crcResult = false;
+                                do {
+                                    if (!await compressor.CompressFile(vpPath, modFullPath + Path.DirectorySeparatorChar + "kn_upload" + Path.DirectorySeparatorChar + "vps", zipPath, true))
+                                    {
+                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "Error while compressing the package");
+                                        throw new TaskCanceledException();
+                                    }
+                                    //CRC CHECK
+                                    crcResult = await compressor.VerifyFile(zipPath);
+                                    if(!crcResult)
+                                    {
+                                        if(crcAttempt >= maxCrcAttempts)
+                                        {
+                                            Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Max attempts reached, cancelling upload...");
+                                            throw new TaskCanceledException();
+                                        }
+                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Retrying...");
+                                        ProgressBarMax = 100;
+                                        ProgressCurrent = 0;
+                                        Info = "Retry: Compressing (7z)";
+                                        if (File.Exists(zipPath))
+                                        {
+                                            File.Delete(zipPath);
+                                        }
+                                        crcAttempt++;
+                                    }
+                                } while (!crcResult);
+                                Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.PrepareModPkg()", "CRC Verify OK on File: " + zipPath);
                             }
                             var fl = new ModFilelist();
                             fl.archive = pkg.folder + ".7z";
@@ -1343,22 +1368,71 @@ namespace Knossos.NET.ViewModels
                             if (pkg.environment != null && pkg.environment.ToLower().Contains("macos"))
                             {
                                 Info = "Compressing (.tar.gz)";
-                                if (!await compressor.CompressFolderTarGz(modFullPath + Path.DirectorySeparatorChar + pkg.folder, zipPath))
+                                var crcAttempt = 0;
+                                var crcResult = false;
+                                do
                                 {
-                                    Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "Error while compressing the package");
-                                    throw new TaskCanceledException();
-                                }
+                                    if (!await compressor.CompressFolderTarGz(modFullPath + Path.DirectorySeparatorChar + pkg.folder, zipPath))
+                                    {
+                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "Error while compressing the package");
+                                        throw new TaskCanceledException();
+                                    }
+                                    //CRC CHECK
+                                    crcResult = await compressor.VerifyFile(zipPath);
+                                    if (!crcResult)
+                                    {
+                                        if (crcAttempt >= maxCrcAttempts)
+                                        {
+                                            Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Max attempts reached, cancelling upload...");
+                                            throw new TaskCanceledException();
+                                        }
+                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Retrying...");
+                                        ProgressBarMax = 100;
+                                        ProgressCurrent = 0;
+                                        Info = "Retry: Compressing (.tar.gz)";
+                                        if (File.Exists(zipPath))
+                                        {
+                                            File.Delete(zipPath);
+                                        }
+                                        crcAttempt++;
+                                    }
+                                } while (!crcResult);
                                 zipPath += ".tar.gz";
                             }
                             else
                             {
                                 Info = "Compressing (7z)";
-                                if (!await compressor.CompressFolder(modFullPath + Path.DirectorySeparatorChar + pkg.folder, zipPath))
+                                var crcAttempt = 0;
+                                var crcResult = false;
+                                do
                                 {
-                                    Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "Error while compressing the package");
-                                    throw new TaskCanceledException();
-                                }
+                                    if (!await compressor.CompressFolder(modFullPath + Path.DirectorySeparatorChar + pkg.folder, zipPath))
+                                    {
+                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "Error while compressing the package");
+                                        throw new TaskCanceledException();
+                                    }
+                                    //CRC CHECK
+                                    crcResult = await compressor.VerifyFile(zipPath);
+                                    if (!crcResult)
+                                    {
+                                        if (crcAttempt >= maxCrcAttempts)
+                                        {
+                                            Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Max attempts reached, cancelling upload...");
+                                            throw new TaskCanceledException();
+                                        }
+                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Retrying...");
+                                        ProgressBarMax = 100;
+                                        ProgressCurrent = 0;
+                                        Info = "Retry: Compressing (7z)";
+                                        if (File.Exists(zipPath))
+                                        {
+                                            File.Delete(zipPath);
+                                        }
+                                        crcAttempt++;
+                                    }
+                                } while (!crcResult);
                             }
+                            Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.PrepareModPkg()", "CRC Verify OK on File: " + zipPath);
                         }
                     }
 
@@ -1530,7 +1604,7 @@ namespace Knossos.NET.ViewModels
                             Info = "Prepare Packages";
                             Directory.CreateDirectory(mod.fullPath + Path.DirectorySeparatorChar + "kn_upload");
                             //Prepare packages, update data on mod
-                            await Parallel.ForEachAsync(mod.packages, new ParallelOptions { MaxDegreeOfParallelism = 4 }, async (pkg, token) =>
+                            await Parallel.ForEachAsync(mod.packages, new ParallelOptions { MaxDegreeOfParallelism = Knossos.globalSettings.compressionMaxParallelism }, async (pkg, token) =>
                             {
                                 if (mod.type != ModType.mod && mod.type != ModType.tc) //Just to be sure
                                     pkg.isVp = false;

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -1378,15 +1378,15 @@ namespace Knossos.NET.ViewModels
                                         throw new TaskCanceledException();
                                     }
                                     //CRC CHECK
-                                    crcResult = await compressor.VerifyFile(zipPath);
+                                    crcResult = await compressor.VerifyFile(zipPath + ".tar.gz");
                                     if (!crcResult)
                                     {
                                         if (crcAttempt >= maxCrcAttempts)
                                         {
-                                            Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Max attempts reached, cancelling upload...");
+                                            Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ".tar.gz. Max attempts reached, cancelling upload...");
                                             throw new TaskCanceledException();
                                         }
-                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ". Retrying...");
+                                        Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.PrepareModPkg()", "CRC error on file: " + zipPath + ".tar.gz. Retrying...");
                                         ProgressBarMax = 100;
                                         ProgressCurrent = 0;
                                         Info = "Retry: Compressing (.tar.gz)";

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -1302,6 +1302,7 @@ namespace Knossos.NET.ViewModels
                                         throw new TaskCanceledException();
                                     }
                                     //CRC CHECK
+                                    Info = "CRC Check";
                                     crcResult = await compressor.VerifyFile(zipPath);
                                     if(!crcResult)
                                     {
@@ -1378,6 +1379,7 @@ namespace Knossos.NET.ViewModels
                                         throw new TaskCanceledException();
                                     }
                                     //CRC CHECK
+                                    Info = "CRC Check";
                                     crcResult = await compressor.VerifyFile(zipPath + ".tar.gz");
                                     if (!crcResult)
                                     {
@@ -1412,6 +1414,7 @@ namespace Knossos.NET.ViewModels
                                         throw new TaskCanceledException();
                                     }
                                     //CRC CHECK
+                                    Info = "CRC Check";
                                     crcResult = await compressor.VerifyFile(zipPath);
                                     if (!crcResult)
                                     {


### PR DESCRIPTION
This is in response to bta mod owners reporting packages being uploaded on a mod update that werent changed, that on futher investigation it was determinated that those packages had a different sha256 hash because they had a single random changed byte, corrupting the file and preventing at least one file from being decompressed correctly.

-Add a CRC check after compressing a mod pkg, to make sure we arent uploading a corrupted file to nebula. 
-If the file fails the CRC check up to 5 attempts at recompressing the pkg are done before giving up and cancelling the upload. 
-Now knossos will use the "max compression parallelism" value to determine how many mod pkgs will be compressed at the same time, previuosly this number was hardcoded to 4. 
-Lower the default max compression paralelism value from 4 to 2.