### PR TITLE
Refresh dev fso build list during builds install/delete and add reload depedency button

### DIFF
--- a/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
+++ b/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
@@ -203,6 +203,14 @@ namespace Knossos.NET.ViewModels
         }
 
         /// <summary>
+        /// If the mod editor is open this will refresh the listed build options in the Fso Settings tabs
+        /// </summary>
+        public void UpdateListedFsoBuildVersionsInEditor()
+        {
+            ModEditor?.UpdateFsoSettingsComboBox();
+        }
+
+        /// <summary>
         /// Resets the mod editor
         /// Reloads the currently loaded mod in editor if it matches the passed id, null for always
         /// </summary>

--- a/Knossos.NET/ViewModels/FsoBuildsViewModel.cs
+++ b/Knossos.NET/ViewModels/FsoBuildsViewModel.cs
@@ -319,6 +319,7 @@ namespace Knossos.NET.ViewModels
                     }
                 }
                 Knossos.RemoveBuild(build);
+                DeveloperModsViewModel.Instance?.UpdateListedFsoBuildVersionsInEditor();
                 if (runModstatusChecks)
                 {
                     MainWindowViewModel.Instance?.RunModStatusChecks();

--- a/Knossos.NET/ViewModels/Templates/DevModEditorViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModEditorViewModel.cs
@@ -344,5 +344,16 @@ namespace Knossos.NET.ViewModels
             if(VersionsView != null && (modid == null || ActiveVersion.id == modid) )
                 VersionsView?.HackUpdateModList();
         }
+
+        /// <summary>
+        /// If the mod editor is open this will refresh the listed build options in the Fso Settings tabs
+        /// </summary>
+        public void UpdateFsoSettingsComboBox()
+        {
+            if (FsoSettingsView != null)
+            {
+                FsoSettingsView.UpdateFsoPicker();
+            }
+        }
     }
 }

--- a/Knossos.NET/ViewModels/Templates/DevModFsoSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModFsoSettingsViewModel.cs
@@ -26,40 +26,48 @@ namespace Knossos.NET.ViewModels
         public DevModFsoSettingsViewModel(DevModEditorViewModel devModEditorViewModel)
         {
             editor = devModEditorViewModel;
-            if (editor.ActiveVersion.modSettings.customBuildId == null)
+            LoadFsoPicker();
+        }
+
+        private void LoadFsoPicker()
+        {
+            if (editor != null)
             {
-                fsoPicker = new FsoBuildPickerViewModel(null);
-            }
-            else
-            {
-                if (editor.ActiveVersion.modSettings.customBuildExec != null)
+                if (editor.ActiveVersion.modSettings.customBuildId == null)
                 {
-                    fsoPicker = new FsoBuildPickerViewModel(new FsoBuild(editor.ActiveVersion.modSettings.customBuildExec));
+                    FsoPicker = new FsoBuildPickerViewModel(null);
                 }
                 else
                 {
-                    var matchingBuilds = Knossos.GetInstalledBuildsList(editor.ActiveVersion.modSettings.customBuildId);
-                    if (matchingBuilds.Any())
+                    if (editor.ActiveVersion.modSettings.customBuildExec != null)
                     {
-                        var theBuild = matchingBuilds.FirstOrDefault(build => build.version == editor.ActiveVersion.modSettings.customBuildVersion);
-                        if (theBuild != null)
-                        {
-                            fsoPicker = new FsoBuildPickerViewModel(theBuild);
-                        }
-                        else
-                        {
-                            Log.Add(Log.LogSeverity.Warning, "DevModFsoSettingsViewModel.Constructor()", "Missing user-saved build version for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId + " and version: " + editor.ActiveVersion.modSettings.customBuildVersion);
-                            fsoPicker = new FsoBuildPickerViewModel(null);
-                        }
+                        FsoPicker = new FsoBuildPickerViewModel(new FsoBuild(editor.ActiveVersion.modSettings.customBuildExec));
                     }
                     else
                     {
-                        Log.Add(Log.LogSeverity.Warning, "DevModFsoSettingsViewModel.Constructor()", "Missing user-saved build id for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId);
-                        fsoPicker = new FsoBuildPickerViewModel(null);
+                        var matchingBuilds = Knossos.GetInstalledBuildsList(editor.ActiveVersion.modSettings.customBuildId);
+                        if (matchingBuilds.Any())
+                        {
+                            var theBuild = matchingBuilds.FirstOrDefault(build => build.version == editor.ActiveVersion.modSettings.customBuildVersion);
+                            if (theBuild != null)
+                            {
+                                FsoPicker = new FsoBuildPickerViewModel(theBuild);
+                            }
+                            else
+                            {
+                                Log.Add(Log.LogSeverity.Warning, "DevModFsoSettingsViewModel.Constructor()", "Missing user-saved build version for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId + " and version: " + editor.ActiveVersion.modSettings.customBuildVersion);
+                                FsoPicker = new FsoBuildPickerViewModel(null);
+                            }
+                        }
+                        else
+                        {
+                            Log.Add(Log.LogSeverity.Warning, "DevModFsoSettingsViewModel.Constructor()", "Missing user-saved build id for mod: " + editor.ActiveVersion.tile + " - " + editor.ActiveVersion.version + " requested build id: " + editor.ActiveVersion.modSettings.customBuildId);
+                            FsoPicker = new FsoBuildPickerViewModel(null);
+                        }
                     }
                 }
+                CmdLine = editor.ActiveVersion.cmdline;
             }
-            CmdLine = editor.ActiveVersion.cmdline; 
         }
 
         internal void ConfigureBuild()
@@ -147,6 +155,16 @@ namespace Knossos.NET.ViewModels
                 editor.ActiveVersion.modSettings.Save();
                 editor.ActiveVersion.SaveJson();
             }
+        }
+
+        /// <summary>
+        /// Updates the FSO picker combobox to display changes to installed fso builds
+        /// Note: it actually destroys the current fso picker and it replaces it with a new one.
+        /// </summary>
+        public void UpdateFsoPicker()
+        {
+            //Run from UI thread
+            Dispatcher.UIThread.Invoke(()=> { LoadFsoPicker(); });
         }
     }
 }

--- a/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
@@ -457,9 +457,9 @@ namespace Knossos.NET.ViewModels
                         if (PkgMgr.editor != null && oldIndex <= DependencyItems.Count())
                             DependencyItems.Insert(oldIndex, new EditorDependencyItem(dependency.Dependency, this, PkgMgr.editor.ActiveVersion.id, PkgMgr.editor.ActiveVersion.parent));
                     }
-                    catch
+                    catch (Exception ex)
                     {
-
+                        Log.Add(Log.LogSeverity.Error, "EditorModPackageItem.ReloadDependency()", ex);
                     }
                 }
                 else

--- a/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
@@ -280,6 +280,11 @@ namespace Knossos.NET.ViewModels
                 EditorPackageItem.DeleteDependency(this);
             }
 
+            internal void ReloadDependency()
+            {
+                EditorPackageItem.ReloadDependency(this);
+            }
+
             public ModDependency? GetDependency()
             {
                 try
@@ -439,6 +444,29 @@ namespace Knossos.NET.ViewModels
                 {
                     Log.Add(Log.LogSeverity.Error, "EditorModPackageItem.DeleteDependency()", ex);
                 }
+            }
+
+            public void ReloadDependency(EditorDependencyItem dependency)
+            {
+                int oldIndex = DependencyItems.IndexOf(dependency);
+                if (oldIndex != -1)
+                {
+                    DeleteDependency(dependency);
+                    try
+                    {
+                        if (PkgMgr.editor != null && oldIndex <= DependencyItems.Count())
+                            DependencyItems.Insert(oldIndex, new EditorDependencyItem(dependency.Dependency, this, PkgMgr.editor.ActiveVersion.id, PkgMgr.editor.ActiveVersion.parent));
+                    }
+                    catch
+                    {
+
+                    }
+                }
+                else
+                {
+                    Log.Add(Log.LogSeverity.Error, "EditorModPackageItem.ReloadDependency()", "Got -1 on DeprendencyItems.IndexOf(dependency) for some reason.");
+                }
+
             }
 
             internal void DeleteModPkg()

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -4401,7 +4401,9 @@ namespace Knossos.NET.ViewModels
                         FsoBuild newBuild = new FsoBuild(modJson);
                         if (modifyPkgs == null)
                         {
+                            //New Build
                             Knossos.AddBuild(newBuild);
+                            DeveloperModsViewModel.Instance?.UpdateListedFsoBuildVersionsInEditor();
                         }
                         if (modJson.devMode)
                         {

--- a/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
+++ b/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
@@ -71,7 +71,7 @@
 							<ItemsControl.ItemTemplate>
 								<DataTemplate>
 									<!--Pkg Dependency Item-->
-									<Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto">
+									<Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto,Auto,Auto">
 										<Label Margin="30,0,0,0" Grid.Column="0" FontSize="18" HorizontalContentAlignment="Center" VerticalContentAlignment="Center">&#x21B3;</Label>
 										<ComboBox SelectedIndex="{Binding ModSelectedIndex}" ItemsSource="{Binding ModItems}" Grid.Column="1" HorizontalAlignment="Stretch" Margin="5,2,2,2" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black"></ComboBox>
 										<ComboBox SelectedIndex="{Binding VersionTypeIndex}" Grid.Column="2" MinWidth="60" Margin="2" FontWeight="Bold" FontSize="16" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black">
@@ -97,7 +97,10 @@
 											</Button.Flyout>
 										</Button>
 										<!--End Packages-->
-										<Button Command="{Binding DeleteDependency}" Grid.Column="5" Margin="10,0,0,0" Classes="Cancel" ToolTip.Tip="Remove this dependency">									
+										<Button Command="{Binding ReloadDependency}" Grid.Column="5" Margin="10,0,0,0" Classes="Secondary" ToolTip.Tip="Reload Dependency versions. If you just downloaded a new version and it is not listed, use this to refresh the version list">
+											<Image Height="14" Width="14" Source="/Assets/general/refresh.png"></Image>
+										</Button>
+										<Button Command="{Binding DeleteDependency}" Grid.Column="6" Margin="10,0,0,0" Classes="Cancel" ToolTip.Tip="Remove this dependency">									
 											<Image Height="14" Width="14" Source="/Assets/general/x.png"></Image>
 										</Button>
 									</Grid>


### PR DESCRIPTION
-The first auto updates the fso build list on the developer fso tab to account for new build install and delete.

-The second adds a reload depedency button to the mod pkg manager, this is to reload the listed versions for a depedency id so it can be updated after installing a new mod/build without reloading the entire mod editor.