### PR TITLE
Advanced mod upload

### DIFF
--- a/Knossos.NET/App.axaml
+++ b/Knossos.NET/App.axaml
@@ -15,6 +15,7 @@
     <Application.Styles>
 		<StyleInclude Source="/AppStyles.axaml" />
         <FluentTheme />
+		<StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
     </Application.Styles>
 
     <Application.Resources>

--- a/Knossos.NET/Knossos.NET.csproj
+++ b/Knossos.NET/Knossos.NET.csproj
@@ -70,6 +70,7 @@
   <ItemGroup>
     <PackageReference Include="AnimatedImage.Avalonia" Version="1.0.7" />
     <PackageReference Include="Avalonia" Version="11.0.5" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.5" />
     <PackageReference Include="Avalonia.Desktop" Version="11.0.5" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.5" />
@@ -89,6 +90,9 @@
     </Compile>
     <Compile Update="Views\DeveloperModsView.axaml.cs">
       <DependentUpon>DeveloperModsView.axaml</DependentUpon>
+    </Compile>
+    <Compile Update="Views\Windows\DevModAdvancedUploadView.axaml.cs">
+      <DependentUpon>DevModAdvancedUploadView.axaml</DependentUpon>
     </Compile>
     <Compile Update="Views\Windows\MessageBox.axaml.cs">
       <DependentUpon>MessageBox.axaml</DependentUpon>

--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -779,6 +779,7 @@ namespace Knossos.NET.Models
 
         /// <summary>
         /// To use with the List .Sort()
+        /// Retuns a list that is sort from older to newer
         /// </summary>
         /// <param name="mod1"></param>
         /// <param name="mod2"></param>
@@ -786,6 +787,18 @@ namespace Knossos.NET.Models
         {
             //inverted
             return SemanticVersion.Compare(mod1.version, mod2.version);
+        }
+
+        /// <summary>
+        /// To use with the List .Sort()
+        /// Retuns a list that is sort from newer to older
+        /// </summary>
+        /// <param name="mod1"></param>
+        /// <param name="mod2"></param>
+        public static int CompareVersionNewerToOlder(Mod mod1, Mod mod2)
+        {
+            //inverted
+            return SemanticVersion.Compare(mod2.version, mod1.version);
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/TaskViewModel.cs
+++ b/Knossos.NET/ViewModels/TaskViewModel.cs
@@ -436,7 +436,10 @@ namespace Knossos.NET.ViewModels
         /// <param name="mod"></param>
         /// <param name="isNewMod"></param>
         /// <param name="metadataonly"></param>
-        public async void UploadModVersion(Mod mod, bool isNewMod, bool metadataonly = false)
+        /// <param name="advData"></param>
+        /// <param name="parallelCompression"></param>
+        /// <param name="parallelUploads"></param>
+        public async void UploadModVersion(Mod mod, bool isNewMod, bool metadataonly = false, int parallelCompression = 1, int parallelUploads = 1, List<DevModAdvancedUploadData>? advData = null )
         {
             using (var cancelSource = new CancellationTokenSource())
             {
@@ -446,7 +449,7 @@ namespace Knossos.NET.ViewModels
                     TaskList.Add(newTask);
                     taskQueue.Enqueue(newTask);
                 });
-                await newTask.UploadModVersion(mod, isNewMod, metadataonly, cancelSource).ConfigureAwait(false);
+                await newTask.UploadModVersion(mod, isNewMod, metadataonly, cancelSource, parallelCompression, parallelUploads, advData).ConfigureAwait(false);
             }
         }
 

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -228,7 +228,7 @@ namespace Knossos.NET.ViewModels
                     if (mod.type == ModType.mod || mod.type == ModType.tc)
                     {
                         var dialog = new DevModAdvancedUploadView();
-                        dialog.DataContext = new DevModAdvancedUploadViewModel(mod, dialog);
+                        dialog.DataContext = new DevModAdvancedUploadViewModel(mod, dialog, this);
                         await dialog.ShowDialog<DevModAdvancedUploadView?>(MainWindow.instance!);
                     }
                     else
@@ -243,12 +243,19 @@ namespace Knossos.NET.ViewModels
             }
         }
 
+        //For UI button
         internal async void UploadMod()
         {
             await UploadProcess();
         }
 
-        internal async Task UploadProcess()
+        //for the advanced upload window
+        public void AdvancedUpload(List<DevModAdvancedUploadData> advData, int parallelCompression, int parallelUploads)
+        {
+            _ = UploadProcess(advData, parallelCompression, parallelUploads);
+        }
+
+        private async Task UploadProcess(List<DevModAdvancedUploadData>? advData = null, int parallelCompression = 1, int parallelUploads = 1)
         {
             /* 
              *  Pre-Upload Checks:
@@ -533,7 +540,7 @@ namespace Knossos.NET.ViewModels
 
                         //Basic check finish, create task
                         ButtonsEnabled = true;
-                        TaskViewModel.Instance!.UploadModVersion(mod, isNewMod, metaUpdOnly);
+                        TaskViewModel.Instance!.UploadModVersion(mod, isNewMod, metaUpdOnly, parallelCompression, parallelUploads, advData);
                     }
                 }
                 catch(Exception ex)

--- a/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModVersionsViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Knossos.NET.ViewModels
 {
@@ -217,7 +218,37 @@ namespace Knossos.NET.ViewModels
             Mods = Mods.ToList();
         }
 
+        internal async void UploadModAdvanced()
+        {
+            var mod = editor?.ActiveVersion;
+            if (mod != null)
+            {
+                if (!mod.inNebula)
+                {
+                    if (mod.type == ModType.mod || mod.type == ModType.tc)
+                    {
+                        var dialog = new DevModAdvancedUploadView();
+                        dialog.DataContext = new DevModAdvancedUploadViewModel(mod, dialog);
+                        await dialog.ShowDialog<DevModAdvancedUploadView?>(MainWindow.instance!);
+                    }
+                    else
+                    {
+                        _ = MessageBox.Show(MainWindow.instance!, "Advanced uploading is only available for Mods and TCs.", "Unsupported for type: " + mod.type, MessageBox.MessageBoxButtons.OK);
+                    }
+                }
+                else
+                {
+                    _ = MessageBox.Show(MainWindow.instance!, "This mod version is already uploaded to nebula, if you want to update the metadata use the basic upload", "Mod already uploaded", MessageBox.MessageBoxButtons.OK);
+                }
+            }
+        }
+
         internal async void UploadMod()
+        {
+            await UploadProcess();
+        }
+
+        internal async Task UploadProcess()
         {
             /* 
              *  Pre-Upload Checks:

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -1613,21 +1613,25 @@ namespace Knossos.NET.ViewModels
                                 //We should skip this?
                                 if(advData != null)
                                 {
-                                    var uploadedPkg = advData.FirstOrDefault(p => p.packageInNebula!.name == pkg.name)?.packageInNebula;
-                                    if (uploadedPkg != null)
+                                    var advDataPkg = advData.FirstOrDefault(p => p.packageInNebula != null && p.packageInNebula!.name == pkg.name);
+                                    if (advDataPkg != null && !advDataPkg.Upload)
                                     {
-                                        pkg.notes = uploadedPkg.notes;
-                                        pkg.isVp = uploadedPkg.isVp;
-                                        pkg.status = uploadedPkg.status;
-                                        pkg.filelist = uploadedPkg.filelist;
-                                        pkg.files = uploadedPkg.files;
-                                        pkg.dependencies = uploadedPkg.dependencies;
-                                        pkg.environment = uploadedPkg.environment;
-                                        pkg.executables = uploadedPkg.executables;
-                                        pkg.folder = uploadedPkg.folder;
-                                        pkg.checkNotes = uploadedPkg.checkNotes;
-                                        pkg.files?.ForEach(f => f.urls = null); //Cant send urls to Nebula or it gets rejected
-                                        skipPkg = true;
+                                        var uploadedPkg = advDataPkg.packageInNebula;
+                                        if (uploadedPkg != null)
+                                        {
+                                            pkg.notes = uploadedPkg.notes;
+                                            pkg.isVp = uploadedPkg.isVp;
+                                            pkg.status = uploadedPkg.status;
+                                            pkg.filelist = uploadedPkg.filelist;
+                                            pkg.files = uploadedPkg.files;
+                                            pkg.dependencies = uploadedPkg.dependencies;
+                                            pkg.environment = uploadedPkg.environment;
+                                            pkg.executables = uploadedPkg.executables;
+                                            pkg.folder = uploadedPkg.folder;
+                                            pkg.checkNotes = uploadedPkg.checkNotes;
+                                            pkg.files?.ForEach(f => f.urls = null); //Cant send urls to Nebula or it gets rejected
+                                            skipPkg = true;
+                                        }
                                     }
                                 }
                                 if (!skipPkg)
@@ -1649,7 +1653,7 @@ namespace Knossos.NET.ViewModels
                             {
                                 bool skipPkg = false;
                                 //We should skip this?
-                                if (advData != null && advData.FirstOrDefault(p => p.packageInNebula!.name == pkg.name) != null)
+                                if (advData != null && advData.FirstOrDefault(p => p.packageInNebula != null && p.packageInNebula!.name == pkg.name) != null && !advData.FirstOrDefault(p => p.packageInNebula != null && p.packageInNebula!.name == pkg.name)!.Upload)
                                 {
                                     skipPkg = true;
                                 }

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -1522,7 +1522,7 @@ namespace Knossos.NET.ViewModels
             }
         }
 
-        public async Task<bool> UploadModVersion(Mod mod, bool isNewMod, bool metaOnly, CancellationTokenSource? cancelSource = null)
+        public async Task<bool> UploadModVersion(Mod mod, bool isNewMod, bool metaOnly, CancellationTokenSource? cancelSource = null, int parallelCompression = 1, int parallelUploads = 1, List<DevModAdvancedUploadData>? advData = null )
         {
             try
             {
@@ -1607,13 +1607,37 @@ namespace Knossos.NET.ViewModels
                             Info = "Prepare Packages";
                             Directory.CreateDirectory(mod.fullPath + Path.DirectorySeparatorChar + "kn_upload");
                             //Prepare packages, update data on mod
-                            await Parallel.ForEachAsync(mod.packages, new ParallelOptions { MaxDegreeOfParallelism = Knossos.globalSettings.compressionMaxParallelism }, async (pkg, token) =>
+                            await Parallel.ForEachAsync(mod.packages, new ParallelOptions { MaxDegreeOfParallelism = parallelCompression }, async (pkg, token) =>
                             {
-                                if (mod.type != ModType.mod && mod.type != ModType.tc) //Just to be sure
-                                    pkg.isVp = false;
-                                var newTask = new TaskItemViewModel();
-                                await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, newTask));
-                                await newTask.PrepareModPkg(pkg, mod.fullPath, cancellationTokenSource);
+                                bool skipPkg = false;
+                                //We should skip this?
+                                if(advData != null)
+                                {
+                                    var uploadedPkg = advData.FirstOrDefault(p => p.packageInNebula!.name == pkg.name)?.packageInNebula;
+                                    if (uploadedPkg != null)
+                                    {
+                                        pkg.notes = uploadedPkg.notes;
+                                        pkg.isVp = uploadedPkg.isVp;
+                                        pkg.status = uploadedPkg.status;
+                                        pkg.filelist = uploadedPkg.filelist;
+                                        pkg.files = uploadedPkg.files;
+                                        pkg.dependencies = uploadedPkg.dependencies;
+                                        pkg.environment = uploadedPkg.environment;
+                                        pkg.executables = uploadedPkg.executables;
+                                        pkg.folder = uploadedPkg.folder;
+                                        pkg.checkNotes = uploadedPkg.checkNotes;
+                                        pkg.files?.ForEach(f => f.urls = null); //Cant send urls to Nebula or it gets rejected
+                                        skipPkg = true;
+                                    }
+                                }
+                                if (!skipPkg)
+                                {
+                                    if (mod.type != ModType.mod && mod.type != ModType.tc) //Just to be sure
+                                        pkg.isVp = false;
+                                    var newTask = new TaskItemViewModel();
+                                    await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, newTask));
+                                    await newTask.PrepareModPkg(pkg, mod.fullPath, cancellationTokenSource);
+                                }
                                 ProgressCurrent++;
                                 if (cancellationTokenSource.IsCancellationRequested)
                                     throw new TaskCanceledException();
@@ -1621,11 +1645,20 @@ namespace Knossos.NET.ViewModels
 
                             Info = "Upload Packages";
                             //Upload Packages
-                            await Parallel.ForEachAsync(mod.packages, new ParallelOptions { MaxDegreeOfParallelism = 1 }, async (pkg, token) =>
+                            await Parallel.ForEachAsync(mod.packages, new ParallelOptions { MaxDegreeOfParallelism = parallelUploads }, async (pkg, token) =>
                             {
-                                var newTask = new TaskItemViewModel();
-                                await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, newTask));
-                                await newTask.UploadModPkg(pkg, mod.fullPath, cancellationTokenSource);
+                                bool skipPkg = false;
+                                //We should skip this?
+                                if (advData != null && advData.FirstOrDefault(p => p.packageInNebula!.name == pkg.name) != null)
+                                {
+                                    skipPkg = true;
+                                }
+                                if (!skipPkg)
+                                {
+                                    var newTask = new TaskItemViewModel();
+                                    await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, newTask));
+                                    await newTask.UploadModPkg(pkg, mod.fullPath, cancellationTokenSource);
+                                }
                                 ProgressCurrent++;
                                 if (cancellationTokenSource.IsCancellationRequested)
                                     throw new TaskCanceledException();

--- a/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/TaskItemViewModel.cs
@@ -1631,6 +1631,7 @@ namespace Knossos.NET.ViewModels
                                             pkg.checkNotes = uploadedPkg.checkNotes;
                                             pkg.files?.ForEach(f => f.urls = null); //Cant send urls to Nebula or it gets rejected
                                             skipPkg = true;
+                                            Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.UploadModVersion()", "Skipping package preparation for :" + pkg.name + ". Data was loaded from Nebula.");
                                         }
                                     }
                                 }
@@ -1653,9 +1654,18 @@ namespace Knossos.NET.ViewModels
                             {
                                 bool skipPkg = false;
                                 //We should skip this?
-                                if (advData != null && advData.FirstOrDefault(p => p.packageInNebula != null && p.packageInNebula!.name == pkg.name) != null && !advData.FirstOrDefault(p => p.packageInNebula != null && p.packageInNebula!.name == pkg.name)!.Upload)
+                                if (advData != null)
                                 {
-                                    skipPkg = true;
+                                    var advDataPkg = advData.FirstOrDefault(p => p.packageInNebula != null && p.packageInNebula!.name == pkg.name);
+                                    if (advDataPkg != null && !advDataPkg.Upload)
+                                    {
+                                        var uploadedPkg = advDataPkg.packageInNebula;
+                                        if (uploadedPkg != null)
+                                        {
+                                            skipPkg = true;
+                                            Log.Add(Log.LogSeverity.Information, "TaskItemViewModel.UploadModVersion()", "Skipping package upload for :" + pkg.name + ". Used the one in Nebula instead, file hash: " + advDataPkg.CustomHash );
+                                        }
+                                    }
                                 }
                                 if (!skipPkg)
                                 {

--- a/Knossos.NET/ViewModels/Windows/DevModAdvancedUploadViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/DevModAdvancedUploadViewModel.cs
@@ -249,8 +249,8 @@ namespace Knossos.NET.ViewModels
                 }
             }
 
-            //Check with nebula
-            //Disabled, moved to PerPackage
+            //Check with nebula if the file is uploaded
+            //Disabled, no need since we are getting the file hash from nebula the file HAS to be uploaded.
             /*
             foreach (var data in ModPackagesData)
             {

--- a/Knossos.NET/ViewModels/Windows/DevModAdvancedUploadViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/DevModAdvancedUploadViewModel.cs
@@ -210,6 +210,7 @@ namespace Knossos.NET.ViewModels
             if (uploadMod != null && uploadMod.packages != null)
             {
                 var allVersionsOfThisMod = await Nebula.GetAllModsWithID(uploadMod.id);
+                allVersionsOfThisMod.Sort(Mod.CompareVersionNewerToOlder);
                 foreach (var package in uploadMod.packages)
                 {
                     Dispatcher.UIThread.Invoke(() =>

--- a/Knossos.NET/ViewModels/Windows/DevModAdvancedUploadViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/DevModAdvancedUploadViewModel.cs
@@ -1,0 +1,251 @@
+﻿using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Knossos.NET.Models;
+using Knossos.NET.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Knossos.NET.ViewModels
+{
+    public partial class DevModAdvancedUploadData : ObservableObject
+    {
+        [ObservableProperty]
+        internal List<ComboBoxItem> otherVersions = new List<ComboBoxItem>();
+
+        internal int otherVersionsSelectedIndex = 0;
+        internal int OtherVersionsSelectedIndex
+        {
+            get { return otherVersionsSelectedIndex; }
+            set
+            {
+                if (otherVersionsSelectedIndex != value)
+                {
+                    this.SetProperty(ref otherVersionsSelectedIndex, value);
+                    if (value <= 1 ) //Manual Input // Auto
+                    {
+                        CustomHash = "";
+                    }
+                    else
+                    {
+                        try
+                        {
+                            //Mod class is saved in the datacontext for each version
+                            if (OtherVersions[value].DataContext != null)
+                            {
+                                var modPackage = (ModPackage)OtherVersions[value].DataContext!;
+                                if (modPackage != null && modPackage.files != null)
+                                {
+                                    CustomHash = modPackage.files.FirstOrDefault()!.checksum![1].ToString();
+                                }
+                                else
+                                {
+                                    CustomHash = "Error getting hash";
+                                }
+                            }
+                            else
+                            {
+                                CustomHash = "Error getting hash";
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            CustomHash = "Error getting hash";
+                            Log.Add(Log.LogSeverity.Error, "DevModAdvancedUploadData(OtherVersionsSelectedIndex.Setter)", ex);
+                        }
+                    }
+                }
+            }
+        }
+
+        internal bool upload = true;
+        internal bool Upload
+        {
+            get { return upload; }
+            set
+            {
+                if (upload != value)
+                {
+                    this.SetProperty(ref upload, value);
+                    try
+                    {
+                        if (value == false)
+                        {
+                            //Enable all Versions listed in the combobox
+                            OtherVersions.ForEach(o => o.IsEnabled = true);
+                            OtherVersions[0].IsEnabled = false; // Disable "auto"
+                            CustomHash = "";
+                            //Select what should be the latest version of a mod id
+                            OtherVersionsSelectedIndex = OtherVersions.Count() - 1;
+                        }
+                        else
+                        {
+                            //Disable all versions listed in the combobox
+                            OtherVersions.ForEach(o => o.IsEnabled = false);
+                            OtherVersions[0].IsEnabled = true; //Enable Auto
+                            //Select Auto
+                            OtherVersionsSelectedIndex = 0;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Add(Log.LogSeverity.Error, "DevModAdvancedUploadData(Upload.Setter)", ex);
+                    }
+                }
+            }
+        }
+        
+        [ObservableProperty]
+        internal string customHash = "";
+
+        public ModPackage? package;
+        public string PackageName
+        {
+            get
+            {
+                if (package != null)
+                    return package.name;
+                else
+                    return "package is null";
+            }
+        }
+
+
+        public DevModAdvancedUploadData(ModPackage package, Mod mod)
+        {
+            this.package = package;
+
+            //Fill Get Hash Combobox
+            var auto = new ComboBoxItem();
+            auto.Content = "Auto";
+            auto.IsEnabled = true;
+            OtherVersions.Add(auto);
+
+            var manual = new ComboBoxItem();
+            manual.Content = "Manual Input";
+            manual.IsEnabled = false;
+            OtherVersions.Add(manual);
+
+            //Get all local versions of this ID that are uploaded to nebula, that devmode is enabled and contains this package name
+            var versions = Knossos.GetInstalledModList(mod.id).Where( m => m.devMode && m.inNebula && m.packages != null && m.packages.FirstOrDefault(p => p.name == package.name) != null);
+
+            if (versions != null)
+            {
+                //Reload json data to get the hashes
+                versions.ForEach(m => m.ReLoadJson());
+                foreach (var o in versions)
+                {
+                    if (o != mod)
+                    {
+                        try
+                        {
+                            //List version in the combobox
+                            var p = o.packages.FirstOrDefault(p => p.name == package.name);
+                            if (p != null && p.files != null && p.files.Any() && p.files.FirstOrDefault()?.checksum?.Length > 0)
+                            {
+                                var item = new ComboBoxItem();
+                                item.DataContext = p;
+                                item.Content = o.version.ToString();
+                                item.IsEnabled = false;
+                                item.Foreground = o.isPrivate ? Brushes.Red : Brushes.Cyan;
+                                OtherVersions.Add(item);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Add(Log.LogSeverity.Error, "DevModAdvancedUploadData(contructor)", ex);
+                        }
+                    }
+                }
+            }
+            OtherVersionsSelectedIndex = 0;
+        }
+    }
+
+    /********************************************************************************/
+
+    public partial class DevModAdvancedUploadViewModel : ViewModelBase
+    {
+        [ObservableProperty]
+        internal string title = string.Empty;
+        [ObservableProperty]
+        internal bool loading = true;
+        [ObservableProperty]
+        internal int parallelCompressing = 1;
+        [ObservableProperty]
+        internal int parallelUploads = 1;
+        [ObservableProperty]
+        internal List<DevModAdvancedUploadData> modPackagesData  = new List<DevModAdvancedUploadData>();
+
+        private Mod? uploadMod = null;
+        private DevModAdvancedUploadView? dialog = null;
+
+        public DevModAdvancedUploadViewModel() 
+        {
+        }
+
+        public DevModAdvancedUploadViewModel(Mod mod, DevModAdvancedUploadView dialog)
+        {
+            this.dialog = dialog;
+            Title = "Advanced Nebula Upload: " + mod;
+            uploadMod = mod;
+            _ = Task.Run(() => { LazyLoading(); });
+        }
+
+        private void LazyLoading()
+        {
+            if (uploadMod != null && uploadMod.packages != null)
+            {
+                foreach (var package in uploadMod.packages)
+                {
+                    Dispatcher.UIThread.Invoke(() =>
+                    {
+                        var data = new DevModAdvancedUploadData(package, uploadMod);
+                        ModPackagesData.Add(data);
+                    });
+                }
+            }
+            Loading = false;
+        }
+
+        internal async void UploadMod()
+        {
+            //We have to check that all packages we arent going to upload has a valid sha256 and that they had been uploaded to nebula
+            //Basic check
+            foreach (var data in ModPackagesData)
+            {
+                if (!data.upload)
+                {
+                    if (String.IsNullOrWhiteSpace(data.CustomHash) || data.CustomHash.Length == 0)
+                    {
+                        _ = MessageBox.Show(MainWindow.instance!, "Package: " + data.PackageName + " is not set to upload but it lacks a defined sha256. Operation cancelled.", "Missing hash data", MessageBox.MessageBoxButtons.OK);
+                        return;
+                    }
+                    else
+                    {
+                        //ensure it is in lowercase
+                        data.CustomHash = data.CustomHash.ToLower();
+                    }
+                }
+            }
+
+            //Check with nebula
+            foreach (var data in ModPackagesData)
+            {
+                if (!data.upload)
+                {
+                    if(await Nebula.IsFileUploaded(data.CustomHash) == false)
+                    {
+                        _ = MessageBox.Show(MainWindow.instance!, "The provided sha256 hash for package: " + data.PackageName + " is not valid or not uploaded to Nebula, operation cancelled. Passed hash:" + data.CustomHash, "File hash is not uploaded to nebula (or it is incorrect)", MessageBox.MessageBoxButtons.OK);
+                        Log.Add(Log.LogSeverity.Error,"DevModAdvancedUploadViewModel.UploadMod", "The provided sha256 hash for package: " + data.PackageName + " is not valid or not uploaded to Nebula, operation cancelled. Passed hash:"+data.CustomHash);
+                    }
+                    await Task.Delay(1000);
+                }
+            }
+        }
+    }
+}

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -48,9 +48,10 @@
 				</ListBox.ItemTemplate>
 			</ListBox>
 		</Grid>
-		<Label Grid.Row="1" Margin="0,5,0,0" HorizontalAlignment="Center">Actions for Active Version</Label>
+		<Label Grid.Row="1" Margin="0,0,0,0" HorizontalAlignment="Center">Actions for Active Version</Label>
 		<WrapPanel Grid.Row="2" Margin="0,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-			<Button Width="146" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Settings">Upload to Nebula</Button>
+			<Button Width="146" Margin="0,0,20,0" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Settings">Upload to Nebula</Button>
+			<Button Width="146" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadModAdvanced}" Classes="Secondary">Advanced Upload</Button>
 			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Settings" Margin="24,0,0,0"/>
 		</WrapPanel>
 		<WrapPanel Grid.Row="3" Margin="0,8,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">

--- a/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml
+++ b/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml
@@ -20,6 +20,7 @@
 
 	<ScrollViewer Background="{StaticResource BackgroundColorPrimary}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalScrollBarVisibility="Visible">
 		<Grid RowDefinitions="Auto, Auto, *, Auto" >
+			<Label Margin="0,-3,0,0" HorizontalAlignment="Center" Foreground="Yellow">Advanced Mod Upload is still a experimental feature, use with caution. Ask on Discord if you have questions.</Label>
 			<Label IsVisible="{Binding Loading}" Grid.Row="0" FontWeight="Bold" FontSize="18" Padding="60,130,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">LOADING...</Label>
 			<v:LoadingIconView Grid.Row="0" IsVisible="{Binding Loading}" Width="80" Height="80" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="50,50,0,0" />
 

--- a/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml
+++ b/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml
@@ -1,0 +1,66 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="1100" d:DesignHeight="700"
+        x:Class="Knossos.NET.Views.DevModAdvancedUploadView"
+		xmlns:v="using:Knossos.NET.Views"
+		Icon="/Assets/knossos-icon.ico"
+		xmlns:vm="using:Knossos.NET.ViewModels"
+		x:DataType="vm:DevModAdvancedUploadViewModel"
+		Width="1100"
+		Height="700"
+		WindowStartupLocation="CenterOwner"
+		Title="{Binding Title}"
+		CanResize="True">
+
+  	<Design.DataContext>
+		<vm:DevModAdvancedUploadViewModel/>
+	</Design.DataContext>
+
+	<ScrollViewer Background="{StaticResource BackgroundColorPrimary}" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" HorizontalScrollBarVisibility="Visible">
+		<Grid RowDefinitions="Auto, Auto, *, Auto" >
+			<Label IsVisible="{Binding Loading}" Grid.Row="0" FontWeight="Bold" FontSize="18" Padding="60,130,0,0" HorizontalAlignment="Center" VerticalAlignment="Center">LOADING...</Label>
+			<v:LoadingIconView Grid.Row="0" IsVisible="{Binding Loading}" Width="80" Height="80" HorizontalAlignment="Center" VerticalAlignment="Center" Margin="50,50,0,0" />
+
+			<WrapPanel Grid.Row="0">
+				<WrapPanel IsVisible="{Binding !Loading}" HorizontalAlignment="Left" ToolTip.Tip="Number of simultanous mod package compression. Recommended: 1 or 2. Warning: Very heavy cpu and ram usage.">
+					<Label FontSize="14" VerticalContentAlignment="Center" Margin="20">Parallel Compression Tasks</Label>
+					<NumericUpDown Background="{StaticResource BackgroundColorPrimary}" Increment="1" Width="110" Value="{Binding ParallelCompressing}" Minimum="1" Maximum="6" VerticalContentAlignment="Center" Margin="20"></NumericUpDown>
+				</WrapPanel>
+		
+				<WrapPanel IsVisible="{Binding !Loading}" HorizontalAlignment="Right" ToolTip.Tip="Number of simultanous mod packages uploads to Nebula. Recommended: 1">
+					<Label FontSize="14" VerticalContentAlignment="Center" Margin="20">Parallel Upload Tasks</Label>
+					<NumericUpDown Background="{StaticResource BackgroundColorPrimary}" Increment="1" Width="110" Value="{Binding ParallelUploads}" Minimum="1" Maximum="2" VerticalContentAlignment="Center" Margin="20"></NumericUpDown>
+				</WrapPanel>
+			</WrapPanel>
+
+			<Label IsVisible="{Binding !Loading}" FontSize="14" Grid.Row="2" Margin="0,-5,0,0" HorizontalAlignment="Center">Package Selection</Label>
+			<DataGrid IsVisible="{Binding !Loading}" ItemsSource="{Binding ModPackagesData}" Grid.Row="2" Margin="20" CanUserResizeColumns="True" CanUserSortColumns="False" GridLinesVisibility="All" BorderThickness="1" BorderBrush="White">
+				<DataGrid.Columns>
+					<DataGridTextColumn IsReadOnly="True" MinWidth="200" Header="Package" Binding="{Binding PackageName}" />
+
+					<DataGridTemplateColumn MinWidth="85" MaxWidth="85" Header="Upload" IsReadOnly="False">
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<CheckBox Margin="32,0,0,0" ToolTip.Tip="This package will be compressed and uploaded to nebula, the hash will be calculated after compression. You can disable uploading this package if it dosent have changes from the previous version and provide a file hash from an older version that will be used instead." VerticalContentAlignment="Center" HorizontalContentAlignment="Center" IsChecked="{Binding Upload}"/>
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					
+					<DataGridTemplateColumn Header="Get Hash" MinWidth="100" IsReadOnly="False">
+						<DataGridTemplateColumn.CellTemplate>
+							<DataTemplate>
+								<ComboBox HorizontalAlignment="Stretch" VerticalAlignment="Stretch" SelectedIndex="{Binding OtherVersionsSelectedIndex}" ItemsSource="{Binding OtherVersions}"/>
+							</DataTemplate>
+						</DataGridTemplateColumn.CellTemplate>
+					</DataGridTemplateColumn>
+					
+					<DataGridTextColumn Header="File Hash" MinWidth="150" Width="680" Binding="{Binding CustomHash}"/>
+				</DataGrid.Columns>
+			</DataGrid>
+
+			<Button Grid.Row="3" Width="146" Margin="20" HorizontalAlignment="Center" IsVisible="{Binding !Loading}" Command="{Binding UploadMod}" Classes="Settings">Upload to Nebula</Button>
+		</Grid>
+	</ScrollViewer>
+</Window>

--- a/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml
+++ b/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml
@@ -56,7 +56,7 @@
 						</DataGridTemplateColumn.CellTemplate>
 					</DataGridTemplateColumn>
 					
-					<DataGridTextColumn Header="File Hash" MinWidth="150" Width="680" Binding="{Binding CustomHash}"/>
+					<DataGridTextColumn Header="File Hash" MinWidth="150" Width="680" IsReadOnly="True" Binding="{Binding CustomHash}"/>
 				</DataGrid.Columns>
 			</DataGrid>
 

--- a/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml.cs
+++ b/Knossos.NET/Views/Windows/DevModAdvancedUploadView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Knossos.NET.Views;
+
+public partial class DevModAdvancedUploadView : Window
+{
+    public DevModAdvancedUploadView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
The advanced mod upload windows allows mod uploaders on mod release to pick an older version of a package, this would skip package compression and package upload enterely and instead the package data of the one that is already uploaded will be used.

![image](https://github.com/user-attachments/assets/8d0c4af5-5034-4306-8fdb-40f3026eb10c)
