### PR TITLE
Add warning for the new FSO 24.2 settings system

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.Linq;
 using Avalonia.Platform;
 using VP.NET;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Knossos.NET
 {

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using Avalonia.Platform;
 using VP.NET;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace Knossos.NET
 {
@@ -1161,6 +1162,40 @@ namespace Knossos.NET
             }
 
             Log.Add(Log.LogSeverity.Information, "Knossos.PlayMod()", "Used cmdLine : " + cmdline);
+
+            if (MainWindow.instance != null && globalSettings.warnNewSettingsSystem)
+            {
+                try
+                {
+                    var fsoVersion = new SemanticVersion(fsoBuild.version);
+                    var newSettingsVersion = new SemanticVersion("24.2.0-RC");
+                    if(fsoVersion >= newSettingsVersion)
+                    {
+                        await Dispatcher.UIThread.InvokeAsync(async () => {
+                            try
+                            {
+                                var res = await MessageBox.Show(MainWindow.instance, "Starting from FSO version 24.2.0 a new in-game settings system was implemented,\n" +
+                                    "Launcher settings, like video, audio or input, and cmdline arguments of those categories not longer have an effect.\n" +
+                                    "Settings must be changed ingame by going to 'Options' and then pressing the F3 key.", "New FSO settings system", MessageBox.MessageBoxButtons.DontWarnAgainOK);
+
+                                if (res == MessageBox.MessageBoxResult.DontWarnAgain)
+                                {
+                                    globalSettings.warnNewSettingsSystem = false;
+                                    globalSettings.Save();
+                                }
+                            }
+                            catch
+                            {
+                                //fail silently, this is not important
+                            }
+                        });
+                    }
+                }
+                catch 
+                {
+                    //fail silently, this is not important
+                }
+            }
 
             //Launch FSO!!!
             var fsoResult = await fsoBuild.RunFSO(fsoExecType, cmdline, rootPath, false);

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1173,9 +1173,9 @@ namespace Knossos.NET
                         await Dispatcher.UIThread.InvokeAsync(async () => {
                             try
                             {
-                                var res = await MessageBox.Show(MainWindow.instance, "Starting from FSO version 24.2.0 a new in-game settings system was implemented,\n" +
-                                    "Launcher settings, like video, audio or input, and cmdline arguments of those categories not longer have an effect.\n" +
-                                    "Settings must be changed ingame by going to 'Options' and then pressing the F3 key.", "New FSO settings system", MessageBox.MessageBoxButtons.DontWarnAgainOK);
+                                var res = await MessageBox.Show(MainWindow.instance, "Starting from FSO version 24.2.0 a new in-game settings system was implemented.\n" +
+                                    "Launcher settings, such as video, audio or input, and Command Line arguments of those categories no longer have an effect by default.\n" +
+                                    "Settings for most mods using FSO version 24.2.0 or higher must be now changed in-game by going to the 'Options' menu, where you will see additional methods for accessing and setting these new in-game options.", "New FSO settings system", MessageBox.MessageBoxButtons.DontWarnAgainOK);
 
                                 if (res == MessageBox.MessageBoxResult.DontWarnAgain)
                                 {

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -118,6 +118,8 @@ namespace Knossos.NET.Models
         public int devModSort { get; set; } = 0;
         [JsonPropertyName("auto_update_fso_builds")]
         public AutoUpdateFsoBuilds autoUpdateBuilds { get; set; } = new AutoUpdateFsoBuilds();
+        [JsonPropertyName("warn_new_settings_system")]
+        public bool warnNewSettingsSystem { get; set; } = true;
 
         /* FSO Settings that use the fs2_open.ini are json ignored */
 
@@ -608,6 +610,7 @@ namespace Knossos.NET.Models
                         prefixCMD = tempSettings.prefixCMD;
                         envVars = tempSettings.envVars;
                         showDevOptions = tempSettings.showDevOptions;
+                        warnNewSettingsSystem = tempSettings.warnNewSettingsSystem;
 
                         if (MainWindowViewModel.Instance != null)
                             MainWindowViewModel.Instance.sharedSortType = tempSettings.sortType;

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -143,6 +143,7 @@
 				</Border>
 				<!--VIDEO SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Video settings the FSO engine will use in-game.">Video</Label>
+				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">As of FSO version 24.2 video settings not longer have any effect and is only intended to use with old versions. On 24.2 or newer you can change settings ingame by going to "Options" and pressing F3 to display all settings.</TextBox>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Resolution -->
@@ -243,6 +244,7 @@
 
 				<!--Audio SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Audio settings the FSO engine will use in-game.">Audio</Label>
+				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">As of FSO version 24.2 audio settings not longer have any effect and is only intended to use with old versions. On 24.2 or newer you can change settings ingame by going to "Options" and pressing F3 to display all settings.</TextBox>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Playback -->
@@ -314,6 +316,7 @@
 
 				<!--INPUT SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Input settings where you can specify which of your plugged-in devices FSO can use in-game.">Input</Label>
+				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">As of FSO version 24.2 input settings not longer have any effect and is only intended to use with old versions. On 24.2 or newer you can change settings ingame by going to "Options" and pressing F3 to display all settings.</TextBox>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
             <?ignore

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -143,7 +143,7 @@
 				</Border>
 				<!--VIDEO SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Video settings the FSO engine will use in-game.">Video</Label>
-				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">As of FSO version 24.2 video settings not longer have any effect and is only intended to use with old versions. On 24.2 or newer you can change settings ingame by going to "Options" and pressing F3 to display all settings.</TextBox>
+				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">Note, video settings for most mods using FSO version 24.2.0 or higher will need to be changed in-game by default. You can change in-game settings by going to "Options" menu of the mod you are playing.</TextBox>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Resolution -->
@@ -244,7 +244,7 @@
 
 				<!--Audio SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Audio settings the FSO engine will use in-game.">Audio</Label>
-				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">As of FSO version 24.2 audio settings not longer have any effect and is only intended to use with old versions. On 24.2 or newer you can change settings ingame by going to "Options" and pressing F3 to display all settings.</TextBox>
+				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">Note, audio settings for most mods using FSO version 24.2.0 or higher will need to be changed in-game by default. You can change in-game settings by going to "Options" menu of the mod you are playing..</TextBox>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
 						<!-- Playback -->
@@ -316,7 +316,7 @@
 
 				<!--INPUT SETTINGS-->
 				<Label Margin="5,15,0,0" FontWeight="Bold" FontSize="18" ToolTip.Tip="Input settings where you can specify which of your plugged-in devices FSO can use in-game.">Input</Label>
-				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">As of FSO version 24.2 input settings not longer have any effect and is only intended to use with old versions. On 24.2 or newer you can change settings ingame by going to "Options" and pressing F3 to display all settings.</TextBox>
+				<TextBox BorderBrush="Transparent" IsReadOnly="True" TextWrapping="Wrap" Margin="5,0,5,0" Foreground="Yellow">Note, input settings for most mods using FSO version 24.2.0 or higher will need to be changed in-game by default. You can change in-game settings by going to "Options" menu of the mod you are playing.</TextBox>
 				<Border Margin="0,5,0,0" BorderBrush="Black" BorderThickness="5" CornerRadius="2">
 					<StackPanel Margin="5">
             <?ignore

--- a/Knossos.NET/Views/Windows/MessageBox.axaml.cs
+++ b/Knossos.NET/Views/Windows/MessageBox.axaml.cs
@@ -17,7 +17,8 @@ namespace Knossos.NET.Views
             ContinueCancel,
             Details,
             DetailsOKCancel,
-            DetailsContinueCancel
+            DetailsContinueCancel,
+            DontWarnAgainOK
         }
 
         public enum MessageBoxResult
@@ -27,7 +28,8 @@ namespace Knossos.NET.Views
             Yes,
             No,
             Continue,
-            Details
+            Details,
+            DontWarnAgain
         }
 
         public MessageBox()
@@ -49,7 +51,7 @@ namespace Knossos.NET.Views
 
             var result = MessageBoxResult.OK;
 
-            void AddButton(string caption, MessageBoxResult r, bool def = false, string classes = "")
+            void AddButton(string caption, MessageBoxResult r, bool def = false, string classes = "", int buttonWidth = -1)
             {                
                 var button = new Button { Content = caption, Width = 100};
                 button.Click += (_, __) => {
@@ -59,6 +61,10 @@ namespace Knossos.NET.Views
                 if(classes != "")
                 {
                     button.Classes.Add(classes);
+                }
+                if (buttonWidth != -1)
+                {
+                    button.Width = buttonWidth;
                 }
                 buttonPanel.Children.Add(button);
                 if (def)
@@ -91,6 +97,12 @@ namespace Knossos.NET.Views
             if (buttons == MessageBoxButtons.Details || buttons == MessageBoxButtons.DetailsOKCancel || buttons == MessageBoxButtons.DetailsContinueCancel)
             {
                 AddButton("Details", MessageBoxResult.Details, false, "Option");
+            }
+
+            if (buttons == MessageBoxButtons.DontWarnAgainOK)
+            {
+                AddButton("OK", MessageBoxResult.OK, true, "Accept");
+                AddButton("Don't warn again", MessageBoxResult.DontWarnAgain, false, "Option", 150);
             }
 
             var tcs = new TaskCompletionSource<MessageBoxResult>();


### PR DESCRIPTION
Add visual warning on the settings tab and a messagebox warning if launching a mod that uses fso version newer than 24.2 to warn about the new settings system.