### PR TITLE
Implement portable mode

### DIFF
--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -351,7 +351,7 @@ namespace Knossos.NET.Models
                     cmd.StartInfo.WorkingDirectory = folderPath;
                     if (Knossos.inPortableMode)
                     {
-                        cmd.StartInfo.EnvironmentVariables.Add("FSO_PREFERENCES_PATH", Path.Combine(KnUtils.KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen"));
+                        cmd.StartInfo.EnvironmentVariables.Add("FSO_PREFERENCES_PATH", Path.Combine(KnUtils.KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen") + Path.DirectorySeparatorChar);
                     }
                     cmd.Start();
                     string result = cmd.StandardOutput.ReadToEnd();

--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -275,6 +275,12 @@ namespace Knossos.NET.Models
                         fso.StartInfo.UseShellExecute = false;
                         if (workingFolder != null)
                             fso.StartInfo.WorkingDirectory = workingFolder;
+                        if(Knossos.inPortableMode)
+                        {
+                            var prefPath = Path.Combine(KnUtils.KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen") + Path.DirectorySeparatorChar;
+                            Log.Add(Log.LogSeverity.Information, "FsoBuild.RunFSO()", "Used preferences path: " + prefPath);
+                            fso.StartInfo.EnvironmentVariables.Add("FSO_PREFERENCES_PATH", prefPath);
+                        }
                         if (Knossos.globalSettings.envVars != "")
                         {
                             foreach (var envVar in Knossos.globalSettings.envVars.Split(","))
@@ -343,6 +349,10 @@ namespace Knossos.NET.Models
                     cmd.StartInfo.RedirectStandardInput = true;
                     cmd.StartInfo.StandardOutputEncoding = new UTF8Encoding(false);
                     cmd.StartInfo.WorkingDirectory = folderPath;
+                    if (Knossos.inPortableMode)
+                    {
+                        cmd.StartInfo.EnvironmentVariables.Add("FSO_PREFERENCES_PATH", Path.Combine(KnUtils.KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen"));
+                    }
                     cmd.Start();
                     string result = cmd.StandardOutput.ReadToEnd();
                     output = result;

--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -275,7 +275,7 @@ namespace Knossos.NET.Models
                         fso.StartInfo.UseShellExecute = false;
                         if (workingFolder != null)
                             fso.StartInfo.WorkingDirectory = workingFolder;
-                        if(Knossos.inPortableMode)
+                        if(Knossos.inPortableMode && Knossos.globalSettings.portableFsoPreferences)
                         {
                             var prefPath = Path.Combine(KnUtils.KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen") + Path.DirectorySeparatorChar;
                             Log.Add(Log.LogSeverity.Information, "FsoBuild.RunFSO()", "Used preferences path: " + prefPath);
@@ -349,7 +349,7 @@ namespace Knossos.NET.Models
                     cmd.StartInfo.RedirectStandardInput = true;
                     cmd.StartInfo.StandardOutputEncoding = new UTF8Encoding(false);
                     cmd.StartInfo.WorkingDirectory = folderPath;
-                    if (Knossos.inPortableMode)
+                    if (Knossos.inPortableMode && Knossos.globalSettings.portableFsoPreferences)
                     {
                         cmd.StartInfo.EnvironmentVariables.Add("FSO_PREFERENCES_PATH", Path.Combine(KnUtils.KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen") + Path.DirectorySeparatorChar);
                     }

--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -88,6 +88,13 @@ namespace Knossos.NET
                 {
                     return Path.GetDirectoryName(KnUtils.AppImagePath);
                 }
+                else if (IsMacOS && WasInstallerUsed())
+                {
+                    var execFullPath = Environment.ProcessPath;
+                    var cutOff = execFullPath!.IndexOf(".app") + 4;
+                    var realName = execFullPath![..cutOff];
+                    return Path.GetDirectoryName(realName);
+                }
                 else
                 {
                     return AppDomain.CurrentDomain.BaseDirectory;

--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -112,7 +112,14 @@ namespace Knossos.NET
         /// <returns>fullpath as a string</returns>
         public static string GetKnossosDataFolderPath()
         {
-            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create), "KnossosNET");
+            if (!Knossos.inPortableMode)
+            {
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create), "KnossosNET");
+            }
+            else
+            {
+                return Path.Combine(KnetFolderPath!, "kn_portable", "KnossosNET"); //If inPortableMode = true, KnetFolderPath is not null
+            }
         }
 
         /// <summary>
@@ -124,20 +131,28 @@ namespace Knossos.NET
         /// <returns>fullpath as string</returns>
         public static string GetFSODataFolderPath()
         {
-            if (!string.IsNullOrEmpty(fsoPrefPath))
+            if (Knossos.inPortableMode)
             {
-                return fsoPrefPath;
+                return Path.Combine(KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen"); //If inPortableMode = true, KnetFolderPath is not null
             }
             else
             {
-                if (KnUtils.isMacOS){
-                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "HardLightProductions", "FreeSpaceOpen");
-                }
-                if(IsLinux)
+                if (!string.IsNullOrEmpty(fsoPrefPath))
                 {
-                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "HardLightProductions", "FreeSpaceOpen");
+                    return fsoPrefPath;
                 }
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create), "HardLightProductions", "FreeSpaceOpen");
+                else
+                {
+                    if (KnUtils.isMacOS)
+                    {
+                        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library", "Application Support", "HardLightProductions", "FreeSpaceOpen");
+                    }
+                    if (IsLinux)
+                    {
+                        return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "HardLightProductions", "FreeSpaceOpen");
+                    }
+                    return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create), "HardLightProductions", "FreeSpaceOpen");
+                }
             }
 
         }

--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -131,7 +131,7 @@ namespace Knossos.NET
         /// <returns>fullpath as string</returns>
         public static string GetFSODataFolderPath()
         {
-            if (Knossos.inPortableMode)
+            if (Knossos.inPortableMode && Knossos.globalSettings.portableFsoPreferences)
             {
                 return Path.Combine(KnetFolderPath!, "kn_portable", "HardLightProductions", "FreeSpaceOpen"); //If inPortableMode = true, KnetFolderPath is not null
             }

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1240,7 +1240,7 @@ namespace Knossos.NET
                 try
                 {
                     var fsoVersion = new SemanticVersion(fsoBuild.version);
-                    var newPortableModeVersion = new SemanticVersion("24.2.1");
+                    var newPortableModeVersion = new SemanticVersion("25.0.0");
                     if (fsoVersion < newPortableModeVersion)
                     {
                         cmdline = "-portable_mode " + cmdline;

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1244,15 +1244,8 @@ namespace Knossos.NET
                     if (fsoVersion < newPortableModeVersion)
                     {
                         cmdline = "-portable_mode " + cmdline;
-                        try
-                        {
-                            //older portable mode uses working path to pickup the .ini and store pilots
-                            globalSettings.WriteFS2IniValues(Path.Combine(rootPath, "fs2_open.ini"));
-                        } 
-                        catch (Exception ex) 
-                        {
-                            Log.Add(Log.LogSeverity.Error, "Knossos.PlayMod()", ex);
-                        }
+                        //older portable mode uses working path to pickup the .ini and store pilots
+                        globalSettings.WriteFS2IniValues(Path.Combine(rootPath, "fs2_open.ini"));
                     }
                 }
                 catch(Exception ex)

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1235,7 +1235,7 @@ namespace Knossos.NET
             }
 
             //Portable mode and limitations in unsupported fso versions
-            if (inPortableMode)
+            if (inPortableMode && globalSettings.portableFsoPreferences)
             {
                 try
                 {

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1240,7 +1240,7 @@ namespace Knossos.NET
                 try
                 {
                     var fsoVersion = new SemanticVersion(fsoBuild.version);
-                    var newPortableModeVersion = new SemanticVersion("25.0.0");
+                    var newPortableModeVersion = new SemanticVersion("24.3.0-20241211");
                     if (fsoVersion < newPortableModeVersion)
                     {
                         cmdline = "-portable_mode " + cmdline;

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -684,13 +684,19 @@ namespace Knossos.NET.Models
             {
                 Log.Add(Log.LogSeverity.Error, "GlobalSettings.Load()", ex);
             }
+            if(Knossos.inPortableMode)
+            {
+                basePath = Path.Combine(KnUtils.KnetFolderPath!, "kn_portable", "Library");
+            }
         }
 
         /// <summary>
         /// Save setting data to the fs2_open.ini
         /// Stops the ini-watcher if it was enabled and re-enables it to avoid triggering a read
+        /// Optional: Specific path to write the .ini to, need to be FULL PATH
         /// </summary>
-        public void WriteFS2IniValues()
+        /// <param name="customPath"></param>
+        public void WriteFS2IniValues(string? customFullPath = null)
         {
             try
             {
@@ -850,10 +856,20 @@ namespace Knossos.NET.Models
                     wasWatchingIni = iniWatcher.EnableRaisingEvents;
                     iniWatcher.EnableRaisingEvents = false;
                 }
-                parser.WriteFile(KnUtils.GetFSODataFolderPath() + Path.DirectorySeparatorChar + "fs2_open.ini", data, new UTF8Encoding(false));
-                if(iniWatcher!= null && wasWatchingIni)
+                if (customFullPath == null)
+                {
+                    parser.WriteFile(KnUtils.GetFSODataFolderPath() + Path.DirectorySeparatorChar + "fs2_open.ini", data, new UTF8Encoding(false));
+                    Log.Add(Log.LogSeverity.Information, "GlobalSettings.WriteFS2IniValues", "Writen ini: " + KnUtils.GetFSODataFolderPath() + Path.DirectorySeparatorChar + "fs2_open.ini");
+                }
+                else
+                {
+
+                    parser.WriteFile(customFullPath, data, new UTF8Encoding(false));
+                    Log.Add(Log.LogSeverity.Information, "GlobalSettings.WriteFS2IniValues", "Writen ini: " + customFullPath);
+                }
+
+                if (iniWatcher!= null && wasWatchingIni)
                     iniWatcher.EnableRaisingEvents = true;
-                Log.Add(Log.LogSeverity.Information, "GlobalSettings.WriteFS2IniValues","Writen ini: "+ KnUtils.GetFSODataFolderPath() + Path.DirectorySeparatorChar + "fs2_open.ini");
             }
             catch (Exception ex)
             {

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -261,6 +261,8 @@ namespace Knossos.NET.Models
         public string pxoLogin { get; set; } = "";
         [JsonIgnore]
         public string pxoPassword { get; set; } = "";
+        [JsonPropertyName("portable_fso_preferences")]
+        public bool portableFsoPreferences { get; set; } = true;
 
         /* Developer Settings */
         [JsonPropertyName("no_system_cmd")]
@@ -667,6 +669,7 @@ namespace Knossos.NET.Models
                         warnNewSettingsSystem = tempSettings.warnNewSettingsSystem;
                         mainMenuOpen = tempSettings.mainMenuOpen;
                         sortType = tempSettings.sortType;
+                        portableFsoPreferences = tempSettings.portableFsoPreferences;
 
                         ReadFS2IniValues();
                         Log.Add(Log.LogSeverity.Information, "GlobalSettings.Load()", "Global settings have been loaded");

--- a/Knossos.NET/Models/Log.cs
+++ b/Knossos.NET/Models/Log.cs
@@ -37,10 +37,13 @@ namespace Knossos.NET
                 Task.Run(async () => {
                     try
                     {
-                        await WaitForFileAccess(LogFilePath);
-                        using (var writer = new StreamWriter(LogFilePath, true))
+                        if (!Knossos.isKnDataFolderReadOnly)
                         {
-                            writer.WriteLine(logString, Encoding.UTF8);
+                            await WaitForFileAccess(LogFilePath);
+                            using (var writer = new StreamWriter(LogFilePath, true))
+                            {
+                                writer.WriteLine(logString, Encoding.UTF8);
+                            }
                         }
                     }
                     catch (Exception ex)

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -36,7 +36,8 @@ namespace Knossos.NET.ViewModels
         private const long speed10MB = 170000000;
 
         /* For display only */
-
+		[ObservableProperty]
+        internal bool isPortableMode = false;
         [ObservableProperty]
         internal bool flagDataLoaded = false;
         [ObservableProperty]
@@ -61,7 +62,6 @@ namespace Knossos.NET.ViewModels
         internal bool isAVX2 = false;
 
         /* Knossos Settings */
-
         [ObservableProperty]
         internal string basePath = string.Empty; //When this is changed settings are saved immediately.
 
@@ -522,6 +522,7 @@ namespace Knossos.NET.ViewModels
 
         public GlobalSettingsViewModel()
         {
+            isPortableMode = Knossos.inPortableMode;
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -500,6 +500,14 @@ namespace Knossos.NET.ViewModels
             set { if (envVars != value) { this.SetProperty(ref envVars, value); UnCommitedChanges = true; } }
         }
 
+        /* MISC */
+        private bool portableFsoPreferences = true;
+        internal bool PortableFsoPreferences
+        {
+            get { return portableFsoPreferences; }
+            set { if (portableFsoPreferences != value) { this.SetProperty(ref portableFsoPreferences, value); UnCommitedChanges = true; } }
+        }
+
         internal string globalCmd = string.Empty;
         // In order to have hidden dev options, we need a setter for globalCMD
         public string GlobalCmd
@@ -1038,6 +1046,9 @@ namespace Knossos.NET.ViewModels
             //Multi Port
             MultiPort = Knossos.globalSettings.multiPort;
 
+            //MISC
+            PortableFsoPreferences = Knossos.globalSettings.portableFsoPreferences;
+
             UnCommitedChanges = false;
         }
 
@@ -1364,6 +1375,9 @@ namespace Knossos.NET.ViewModels
 
             //Multi port
             Knossos.globalSettings.multiPort = MultiPort;
+
+            //MISC
+            Knossos.globalSettings.portableFsoPreferences = PortableFsoPreferences;
 
             Knossos.globalSettings.Save();
             UnCommitedChanges = false;

--- a/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
@@ -24,6 +24,9 @@ namespace Knossos.NET.ViewModels
         internal bool lastPage = false;
 
         [ObservableProperty]
+        internal bool isPortableMode = false;
+
+        [ObservableProperty]
         internal string? libraryPath = null;
 
         [ObservableProperty]
@@ -49,12 +52,14 @@ namespace Knossos.NET.ViewModels
         public static QuickSetupViewModel? Instance;
 
         public QuickSetupViewModel() 
-        { 
+        {
+            isPortableMode = Knossos.inPortableMode;
         }
 
         public QuickSetupViewModel(Window dialog) 
         {
             this.dialog = dialog;
+            isPortableMode = Knossos.inPortableMode;
             Instance = this;
             UpdateBuildName(MainWindowViewModel.Instance!.LatestStable);
             TrackRepoStatus();

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -369,6 +369,11 @@
 								<ComboBoxItem>Polish</ComboBoxItem>
 							</ComboBox>
 						</Grid>
+						<!-- Portable FSO Preferences -->
+						<WrapPanel IsVisible="{Binding IsPortableMode}">
+							<Label Margin="4,5,0,0" Width="200" ToolTip.Tip="Store FSO pilots and settings in a portable location. Only if the launcher is in portable mode">Portable FSO Data</Label>
+							<ToggleSwitch Margin="11,0,0,0" IsChecked="{Binding PortableFsoPreferences}"></ToggleSwitch>
+						</WrapPanel>
 						<!-- Sys Info -->
 						<WrapPanel Margin="9,0,0,0">
 							<TextBlock VerticalAlignment="Center" Width="201">Detected Build Settings </TextBlock>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -28,7 +28,7 @@
 						<Grid ColumnDefinitions="Auto,Auto,Auto" Margin="7,10,0,0">
 							<TextBlock Grid.Column="0" VerticalAlignment="Center" Width="200">Library Folder </TextBlock>
 							<TextBox Text="{Binding BasePath}" Margin="10,0,0,0" Grid.Column="1" IsReadOnly="True" Width="500"></TextBox>
-							<Button Margin="5,0,0,0" Grid.Column="2" Classes="Quaternary" Command="{Binding BrowseFolderCommand}">Browse</Button>
+							<Button IsVisible="{Binding !IsPortableMode}" Margin="5,0,0,0" Grid.Column="2" Classes="Quaternary" Command="{Binding BrowseFolderCommand}">Browse</Button>
 						</Grid>
 						<!-- Lib Info -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="6,10,0,0">

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -35,12 +35,21 @@
 		
 		<!--Page2-->
 		<StackPanel IsVisible="{Binding Page2}" Grid.Row="0" >
-			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Setting up the library folder</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">First, you must set a library folder. Go to the "Settings" tab and under the "Knossos" section click on the "Browse" button and choose or create a folder for Knossos to use. It is highly recommended to set this as an empty folder in a location with a large amount of available storage. Once you have set the folder be sure to click the "Save" button in the upper right corner of the "Settings" tab. </TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The Knossos library folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>
-			<TextBlock IsVisible="{Binding !CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Go to the "Settings" tab and set the library folder to continue.</TextBlock>
+			<StackPanel IsVisible="{Binding !IsPortableMode}">
+				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Setting up the library folder</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">First, you must set a library folder. Go to the "Settings" tab and under the "Knossos" section click on the "Browse" button and choose or create a folder for Knossos to use. It is highly recommended to set this as an empty folder in a location with a large amount of available storage. Once you have set the folder be sure to click the "Save" button in the upper right corner of the "Settings" tab. </TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The Knossos library folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>
+				<TextBlock IsVisible="{Binding !CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Go to the "Settings" tab and set the library folder to continue.</TextBlock>
+			</StackPanel>
+			<StackPanel IsVisible="{Binding IsPortableMode}">
+				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Knet is running in portable mode</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">This means Knet settings and FSO pilots, settings and data are saved inside the 'kn_portable' folder, you can not set a library folder in this mode. </TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">If you ever need to stop using the portable mode move, rename or delete the 'kn_portable' folder</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>
+			</StackPanel>
 		</StackPanel>
 		
 		<!--Page3-->


### PR DESCRIPTION
Add portable mode, to enable this mode create a "kn_portable" folder in the same folder as were the Knet executable is in.

Then Fso prefereces (if supported) will be at:
\kn_portable\HardLightProductions\FreeSpaceOpen\

Knet data folder
\kn_portable\KnossosNET\

Knossos Library path:
\kn_portable\Library\

In portable mode you cant change the library path.



The FSO preferences path is passed via a env variable, im attaching a FSO build that support this
-removed- use a nightly build newer than 24.3.0-20241211


https://github.com/scp-fs2open/fs2open.github.com/pull/6387

If the FSO version dosent support the changing the preferences path, "-portable_mode" will be passed instead, and settings and pilots will be saved to the working folder.

I only tested it in Windows, this needs more testing, specially on other OS and ill need to update the readme as well.