### PR TITLE
sort mod titles without articles

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Security.Cryptography;
@@ -949,6 +950,20 @@ namespace Knossos.NET
             }
 
             return text.Replace("_", "__");
+        }
+
+        /// <summary>
+        /// Gets rid of 'A', 'An', and 'The' at the beginning of a string, case-insensitively
+        /// </summary>
+        /// <param name="text">A string</param>
+        /// <returns>The string with any articles removed from the beginning</returns>
+        public static string RemoveArticles(string title)
+        {
+            var match = Regex.Match(title, "((A)|(An)|(The))\\s+", RegexOptions.IgnoreCase);
+            if (match.Index == 0 && match.Length > 0)
+                return title.Substring(match.Length);
+            else
+                return title;
         }
 
         /// <summary>

--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -779,19 +779,18 @@ namespace Knossos.NET.Models
 
         /// <summary>
         /// To use with the List .Sort()
-        /// Retuns a list that is sort from older to newer
+        /// Orders the two mods from older to newer
         /// </summary>
         /// <param name="mod1"></param>
         /// <param name="mod2"></param>
         public static int CompareVersion(Mod mod1, Mod mod2)
         {
-            //inverted
             return SemanticVersion.Compare(mod1.version, mod2.version);
         }
 
         /// <summary>
         /// To use with the List .Sort()
-        /// Retuns a list that is sort from newer to older
+        /// Orders the two mods from newer to older
         /// </summary>
         /// <param name="mod1"></param>
         /// <param name="mod2"></param>
@@ -799,6 +798,17 @@ namespace Knossos.NET.Models
         {
             //inverted
             return SemanticVersion.Compare(mod2.version, mod1.version);
+        }
+
+        /// <summary>
+        /// To use with the List .Sort()
+        /// Orders the two titles using a regular case-insensitive string comparison, but ignoring any leading 'A', 'An', or 'The' articles
+        /// </summary>
+        /// <param name="title1"></param>
+        /// <param name="title2"></param>
+        public static int CompareTitles(string title1, string title2)
+        {
+            return String.Compare(KnUtils.RemoveArticles(title1), KnUtils.RemoveArticles(title2), StringComparison.CurrentCultureIgnoreCase);
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/ModListViewModel.cs
+++ b/Knossos.NET/ViewModels/ModListViewModel.cs
@@ -177,7 +177,7 @@ namespace Knossos.NET.ViewModels
                 switch (sortType)
                 {
                     case MainWindowViewModel.SortType.name:
-                        return CompareTitles(modA.title, modB.title);
+                        return Mod.CompareTitles(modA.title, modB.title);
                     case MainWindowViewModel.SortType.release:
                         if (modA.firstRelease == modB.firstRelease)
                             return 0;
@@ -219,11 +219,6 @@ namespace Knossos.NET.ViewModels
                 Log.Add(Log.LogSeverity.Warning, "ModListViewModel.CompareMods()",ex.Message);
                 return 0; 
             }
-        }
-
-        private int CompareTitles(string title1, string title2)
-        {
-            return String.Compare(KnUtils.RemoveArticles(title1), KnUtils.RemoveArticles(title2));
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/ModListViewModel.cs
+++ b/Knossos.NET/ViewModels/ModListViewModel.cs
@@ -177,7 +177,7 @@ namespace Knossos.NET.ViewModels
                 switch (sortType)
                 {
                     case MainWindowViewModel.SortType.name:
-                        return String.Compare(modA.title, modB.title);
+                        return CompareTitles(modA.title, modB.title);
                     case MainWindowViewModel.SortType.release:
                         if (modA.firstRelease == modB.firstRelease)
                             return 0;
@@ -219,6 +219,11 @@ namespace Knossos.NET.ViewModels
                 Log.Add(Log.LogSeverity.Warning, "ModListViewModel.CompareMods()",ex.Message);
                 return 0; 
             }
+        }
+
+        private int CompareTitles(string title1, string title2)
+        {
+            return String.Compare(KnUtils.RemoveArticles(title1), KnUtils.RemoveArticles(title2));
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/NebulaModListViewModel.cs
+++ b/Knossos.NET/ViewModels/NebulaModListViewModel.cs
@@ -327,7 +327,7 @@ namespace Knossos.NET.ViewModels
                 switch (sortType)
                 {
                     case MainWindowViewModel.SortType.name:
-                        return CompareTitles(modA.title, modB.title);
+                        return Mod.CompareTitles(modA.title, modB.title);
                     case MainWindowViewModel.SortType.release:
                         if (modA.firstRelease == modB.firstRelease)
                             return 0;
@@ -369,11 +369,6 @@ namespace Knossos.NET.ViewModels
                 Log.Add(Log.LogSeverity.Warning, "NebulaModListViewModel.CompareMods()",ex.Message);
                 return 0; 
             }
-        }
-
-        private int CompareTitles(string title1, string title2)
-        {
-            return String.Compare(KnUtils.RemoveArticles(title1), KnUtils.RemoveArticles(title2));
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/NebulaModListViewModel.cs
+++ b/Knossos.NET/ViewModels/NebulaModListViewModel.cs
@@ -327,7 +327,7 @@ namespace Knossos.NET.ViewModels
                 switch (sortType)
                 {
                     case MainWindowViewModel.SortType.name:
-                        return String.Compare(modA.title, modB.title);
+                        return CompareTitles(modA.title, modB.title);
                     case MainWindowViewModel.SortType.release:
                         if (modA.firstRelease == modB.firstRelease)
                             return 0;
@@ -370,7 +370,12 @@ namespace Knossos.NET.ViewModels
                 return 0; 
             }
         }
-        
+
+        private int CompareTitles(string title1, string title2)
+        {
+            return String.Compare(KnUtils.RemoveArticles(title1), KnUtils.RemoveArticles(title2));
+        }
+
         /// <summary>
         /// Changes a modcard to "installing" mode
         /// </summary>


### PR DESCRIPTION
Remove 'A', 'An', and 'The' from the beginning of mod titles before sorting them.  Should fix #251.

I can't actually build and test this at the moment, so this PR is in draft until it can be tested.