### PR TITLE
Net 8.0

### DIFF
--- a/IonKiwi.lz4/IonKiwi.lz4.csproj
+++ b/IonKiwi.lz4/IonKiwi.lz4.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net60</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<PackageId>IonKiwi.lz4.managed</PackageId>
 		<Version>1.0.7</Version>

--- a/Knossos.NET/Knossos.NET.csproj
+++ b/Knossos.NET/Knossos.NET.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <!--Avalonia doesen't support TrimMode=link currently,but we are working on that https://github.com/AvaloniaUI/Avalonia/issues/6892 -->
     <TrimMode>copyused</TrimMode>

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On KnossosNET there are multiples sources of Command Line arguments that are eve
 <br /><br />
 ## **Dev Environment:**<br />
 - MSVC 2022<br />
-- .NET 6.0.406 SDK https://dotnet.microsoft.com/en-us/download/dotnet/6.0<br />
+- .NET 8.0.403 SDK https://dotnet.microsoft.com/en-us/download/dotnet/8.0<br />
 - Avalonia Extension for Visual Studio https://marketplace.visualstudio.com/items?itemName=AvaloniaTeam.AvaloniaVS<br />
 
 <br /><br />

--- a/VP.NET/VP.NET.csproj
+++ b/VP.NET/VP.NET.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
.NET 6.0 is going EOL this November 12, updating the SDK to 8.0 should not do much in our case. But will hold on merging this for a few days.

After this is merged ill try to update avalonia to the newerest version to see if it works properly and not like last time that crashed on the dev mod editor.