### PR TITLE
Do not start the UI when using the "-playmod" cmdline argument

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -248,10 +248,13 @@ namespace Knossos.NET
                 Log.Add(Log.LogSeverity.Error, "Knossos.QuickLaunch", "Quick launch was used but the modid was not detected.");
             }
             await Task.Delay(2000);
-            Dispatcher.UIThread.Invoke(() =>
+            if (MainWindow.instance != null)
             {
-                MainWindow.instance?.Close();
-            });
+                Dispatcher.UIThread.Invoke(() =>
+                {
+                    MainWindow.instance.Close();
+                });
+            }
         }
 
         /// <summary>

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -250,7 +250,7 @@ namespace Knossos.NET
             await Task.Delay(2000);
             Dispatcher.UIThread.Invoke(() =>
             {
-                MainWindow.instance!.Close();
+                MainWindow.instance?.Close();
             });
         }
 
@@ -740,7 +740,7 @@ namespace Knossos.NET
         /// <param name="standalonePort"></param>
         public static async void PlayMod(Mod mod, FsoExecType fsoExecType, bool standaloneServer = false, int standalonePort = 0)
         {
-            if (TaskViewModel.Instance!.IsSafeState() == false)
+            if (TaskViewModel.Instance?.IsSafeState() == false)
             {
                 var result = await MessageBox.Show(MainWindow.instance!, "Other important tasks are running, it is recommended that you wait until they finish before launching the game because it may cause them to fail.\nIf you are absolutely sure those tasks cannot interfere you can continue.", "Tasks are running", MessageBox.MessageBoxButtons.ContinueCancel);
                 if(result != MessageBox.MessageBoxResult.Continue)
@@ -1064,15 +1064,17 @@ namespace Knossos.NET
             if (fsoBuild == null)
             {
                 Log.Add(Log.LogSeverity.Error, "Knossos.PlayMod()", "Unable to find a valid FSO build for this mod!");
-                if(hasBuildDependency)
+                if (MainWindow.instance != null)
                 {
-                    await MessageBox.Show(MainWindow.instance!, "Unable to find a valid FSO build for this mod!", "Error launching mod", MessageBox.MessageBoxButtons.OK);
+                    if (hasBuildDependency)
+                    {
+                        await MessageBox.Show(MainWindow.instance!, "Unable to find a valid FSO build for this mod!", "Error launching mod", MessageBox.MessageBoxButtons.OK);
+                    }
+                    else
+                    {
+                        await MessageBox.Show(MainWindow.instance!, "This mod does not especifies a engine build to use, you should select one in the mod settings.", "Error launching mod", MessageBox.MessageBoxButtons.OK);
+                    }
                 }
-                else
-                {
-                    await MessageBox.Show(MainWindow.instance!, "This mod does not especifies a engine build to use, you should select one in the mod settings.", "Error launching mod", MessageBox.MessageBoxButtons.OK);
-                }
-
                 return;
             }
             else
@@ -1084,9 +1086,12 @@ namespace Knossos.NET
                     {
                         if (mod.modSettings.isCompressed)
                         {
-                            var result = await MessageBox.Show(MainWindow.instance!, "This mod currently resolves to FSO build: " + fsoBuild.version + " and it is compressed, the minimum to fully support all compression features is: " + VPCompression.MinimumFSOVersion + ".\n23.0.0 may work if the mod do not have loose files, older versions are not going to work. Use a newer FSO version or uncompress this mod.", "FSO Version below minimum for compression", MessageBox.MessageBoxButtons.ContinueCancel);
-                            if (result != MessageBox.MessageBoxResult.Continue)
-                                return;
+                            if (MainWindow.instance != null)
+                            {
+                                var result = await MessageBox.Show(MainWindow.instance!, "This mod currently resolves to FSO build: " + fsoBuild.version + " and it is compressed, the minimum to fully support all compression features is: " + VPCompression.MinimumFSOVersion + ".\n23.0.0 may work if the mod do not have loose files, older versions are not going to work. Use a newer FSO version or uncompress this mod.", "FSO Version below minimum for compression", MessageBox.MessageBoxButtons.ContinueCancel);
+                                if (result != MessageBox.MessageBoxResult.Continue)
+                                    return;
+                            }
                         }
                         else
                         {
@@ -1113,9 +1118,12 @@ namespace Knossos.NET
                             }
                             if (compressedMods != string.Empty)
                             {
-                                var result = await MessageBox.Show(MainWindow.instance!, "This mod currently resolves to FSO build: " + fsoBuild.version + " and depends on mods: " + compressedMods + " that are currently compressed, the minimum to fully support all compression features is: " + VPCompression.MinimumFSOVersion + ".\n23.0.0 may work if the mod do not have loose files, older versions are not going to work. Use a newer FSO version or uncompress those mods.", "FSO Version below minimum for compression", MessageBox.MessageBoxButtons.ContinueCancel);
-                                if (result != MessageBox.MessageBoxResult.Continue)
-                                    return;
+                                if (MainWindow.instance != null)
+                                {
+                                    var result = await MessageBox.Show(MainWindow.instance!, "This mod currently resolves to FSO build: " + fsoBuild.version + " and depends on mods: " + compressedMods + " that are currently compressed, the minimum to fully support all compression features is: " + VPCompression.MinimumFSOVersion + ".\n23.0.0 may work if the mod do not have loose files, older versions are not going to work. Use a newer FSO version or uncompress those mods.", "FSO Version below minimum for compression", MessageBox.MessageBoxButtons.ContinueCancel);
+                                    if (result != MessageBox.MessageBoxResult.Continue)
+                                        return;
+                                }
                             }
                         }
                     }
@@ -1344,9 +1352,9 @@ namespace Knossos.NET
                                     await Dispatcher.UIThread.InvokeAsync(() => FsoBuildsViewModel.Instance?.AddBuildToUi(build), DispatcherPriority.Background);
                                 break;
                         }
-                        if(modJson.devMode)
+                        if(modJson.devMode && !isQuickLaunch)
                         {
-                            await Dispatcher.UIThread.InvokeAsync(() => MainWindowViewModel.Instance!.AddDevMod(modJson), DispatcherPriority.Background);
+                            await Dispatcher.UIThread.InvokeAsync(() => MainWindowViewModel.Instance?.AddDevMod(modJson), DispatcherPriority.Background);
                         }
                     }
                     catch (Exception ex)

--- a/Knossos.NET/Program.cs
+++ b/Knossos.NET/Program.cs
@@ -13,6 +13,7 @@ namespace Knossos.NET
         public static void Main(string[] args)
         {
             bool softwareRendering = false;
+            bool isQuickLaunch = false;
 
             //Check app args
             foreach (var arg in args)
@@ -21,24 +22,36 @@ namespace Knossos.NET
                 {
                     softwareRendering = true;
                 }
+                if (arg.ToLower() == "-playmod")
+                {
+                    isQuickLaunch = true;
+                }
             }
 
-            //Check enviroment variables
-            var renderMode = KnUtils.GetEnvironmentVariable("KNET_RENDER_MODE");
 
-            if (renderMode != null && renderMode.ToLower() == "software")
+            if (isQuickLaunch)
             {
-                softwareRendering = true;
-            }
-
-            //Start App
-            if (softwareRendering)
-            {
-                BuildAvaloniaAppSoftware().StartWithClassicDesktopLifetime(args);
+                Knossos.StartUp(true, false);
             }
             else
             {
-                BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+                //Check enviroment variables
+                var renderMode = KnUtils.GetEnvironmentVariable("KNET_RENDER_MODE");
+
+                if (renderMode != null && renderMode.ToLower() == "software")
+                {
+                    softwareRendering = true;
+                }
+
+                //Start App
+                if (softwareRendering)
+                {
+                    BuildAvaloniaAppSoftware().StartWithClassicDesktopLifetime(args);
+                }
+                else
+                {
+                    BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+                }
             }
         }
 


### PR DESCRIPTION
Call Knossos.StartUp() early and do not init the avalonia library. In this way the quicklaunch function is faster and dosent shows the UI for a second before closing.

The con is no message can be displayed if something is wrong, but it will still be printed to the log, what seems fair.