### PR TITLE
Update default values

### DIFF
--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -195,7 +195,7 @@ namespace Knossos.NET.Models
         [JsonIgnore]
         public bool enableDeferredLighting { get; set; } = true;
         [JsonIgnore]
-        public int windowMode { get; set; } = 2;
+        public int windowMode { get; set; } = 0;
         [JsonIgnore]
         public bool vsync { get; set; } = true;
         [JsonIgnore]
@@ -219,7 +219,7 @@ namespace Knossos.NET.Models
         [JsonIgnore]
         public bool enableEfx { get; set; } = false;
         [JsonPropertyName("enable_tts")]
-        public bool enableTts { get; set; } = true;
+        public bool enableTts { get; set; } = false;
         [JsonIgnore]
         public int? ttsVoice { get; set; } = null;
         public string? ttsVoiceName { get; set; } = null;


### PR DESCRIPTION
Very small PR that changes 2 default settings.

1) Makes the default Window Mode `Windowed` instead of `Fullscreen`. The help text already recommends putting it at `Windowed` mode so it makes more sense to make that the default.

2) Turns off TTS by default to better match the newer defaults of this setting in FSO. Happy to discuss alternatives if desired, such as keeping TTS mode enabled by default but having the specific settings only have it on in-mission by default, or something else. Overall, it's just very strange to new players to startup the game and have things being read to them right away as they navigate around the techroom and mission briefings, etc.