### PR TITLE
Make Settings Tab always consistent

### DIFF
--- a/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
@@ -221,7 +221,7 @@ namespace Knossos.NET.ViewModels
 
                 if (CustomLauncher.MenuDisplayGlobalSettingsEntry && GlobalSettingsView != null)
                 {
-                    MenuItems.Add(new MainViewMenuItem(GlobalSettingsView, "avares://Knossos.NET/Assets/general/menu_settings.png", "Options", "Change launcher and FSO engine settings"));
+                    MenuItems.Add(new MainViewMenuItem(GlobalSettingsView, "avares://Knossos.NET/Assets/general/menu_settings.png", "Settings", "Change launcher and FSO engine settings"));
                 }
 
                 if (CustomLauncher.MenuDisplayDebugEntry && DebugView != null)

--- a/Knossos.NET/Views/CustomHomeView.axaml
+++ b/Knossos.NET/Views/CustomHomeView.axaml
@@ -137,7 +137,7 @@
 							<Button Content="Details" Name="ButtonDetails" Classes="Option" CommandParameter="details"
 									Width="86" Command="{Binding HardcodedButtonCommand}">
 							</Button>
-							<Button Margin="5,0,0,0" Name="ButtonSettings" Classes="Settings" Content="Settings" CommandParameter="settings"
+							<Button Margin="5,0,0,0" Name="ButtonSettings" Classes="Settings" Content="Advanced" CommandParameter="settings"
 									Width="86" Command="{Binding HardcodedButtonCommand}">
 							</Button>
 						</WrapPanel>

--- a/Knossos.NET/Views/CustomHomeView.axaml.cs
+++ b/Knossos.NET/Views/CustomHomeView.axaml.cs
@@ -73,7 +73,7 @@ public partial class CustomHomeView : UserControl
             Log.Add(Log.LogSeverity.Error, "CustomHomeView.Constructor()", ex);
         }
 
-        //Home Buttons Custimizations
+        //Home Buttons Customizations
         try
         {
             if (CustomLauncher.HomeButtonConfigs != null && CustomLauncher.HomeButtonConfigs.Any())


### PR DESCRIPTION
Following user testing, in instructions throughout FSO websites and discussions, the `Settings` tab in Knossos is commonly referred to. The standalone TC mode changes that name to `Options` which was b/c the name `Settings` was already used in the mod `Settings` button on the Home Screen. That button is more of an `Advanced` settings especially for TC mode, so this PR proposes changing keeping the global `Settings` tab as `Settings` so that users will always understand instructions from community members and the QuickStart Guide regarding which tab controls global settings. 

This PR also proposes changing the default name of the `Settings` button on the TC mode home screen to `Advanced` by default, but of course mods can set this text to whatever they want since TC mode exposes that option. 

Would be happy to discuss if useful, too, thanks!