### PR TITLE
Allow TC Mode to alter Nebula text regarding 'Download' and 'Up-to-Date' messages

### DIFF
--- a/Knossos.NET/Models/CustomLauncher.cs
+++ b/Knossos.NET/Models/CustomLauncher.cs
@@ -72,6 +72,24 @@ namespace Knossos.NET.Models
         public static string WindowTitle { get; private set; } = "Knet Launcher";
 
         /// <summary>
+        /// Custom text for the message that states when Nebula is downloading the repo_minimal.json on the Home Screen.
+        /// By default this is "Nebula: repo_minimal.json is up to date!"
+        /// </summary>
+        public static string NebulaTextDownloading { get; private set; } = "Downloading repo_minimal.json";
+
+        /// <summary>
+        /// Custom text for the message that states when Nebula is up-to-date for the repo_minimal.json on the Home Screen.
+        /// By default this is "Nebula: repo_minimal.json is up to date!"
+        /// </summary>
+        public static string NebulaTextUpToDate { get; private set; } = "Nebula: repo_minimal.json is up to date!";
+
+        /// <summary>
+        /// Custom text for the tool tip that shows when hovering over the Nebula status on the Home Screen.
+        /// By default this is "The repo_minimal.json file contains info on all the mods available in Nebula, without this you will not be able to install new mods or engine builds"
+        /// </summary>
+        public static string NebulaTextToolTip { get; private set; } = "The repo_minimal.json file contains info on all the mods available in Nebula, without this you will not be able to install new mods or engine builds";
+
+        /// <summary>
         /// Starting width size of the launcher window
         /// This is also the min width
         /// null for auto
@@ -250,6 +268,15 @@ namespace Knossos.NET.Models
                     if (customData.WindowTitle != null)
                         WindowTitle = customData.WindowTitle;
 
+                    if (customData.NebulaTextDownloading != null)
+                        NebulaTextDownloading = customData.NebulaTextDownloading;
+
+                    if (customData.NebulaTextUpToDate != null)
+                        NebulaTextUpToDate = customData.NebulaTextUpToDate;
+
+                    if (customData.NebulaTextToolTip != null)
+                        NebulaTextToolTip = customData.NebulaTextToolTip;
+
                     if (customData.WindowWidth != null)
                         WindowWidth = customData.WindowWidth;
 
@@ -318,6 +345,9 @@ namespace Knossos.NET.Models
             public bool? UseCustomFSODataFolder { get; set; }
             public bool? AllowLauncherUpdates { get; set; }
             public string? WindowTitle { get; set; }
+            public string? NebulaTextDownloading { get; set; }
+            public string? NebulaTextUpToDate { get; set; }
+            public string? NebulaTextToolTip { get; set; }
             public int? WindowWidth { get; set; }
             public int? WindowHeight { get; set; }
             public bool? MenuTaskButtonAtTheEnd { get; set; }

--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -127,12 +127,15 @@ namespace Knossos.NET.Models
             {
                 bool displayUpdates = settings.NewerModsVersions.Any() && !CustomLauncher.IsCustomMode ? true : false;
                 var webEtag = await KnUtils.GetUrlFileEtag(repoUrl).ConfigureAwait(false);
+                var neb_text_downloading = CustomLauncher.IsCustomMode ? CustomLauncher.NebulaTextDownloading : "Downloading repo_minimal.json";
+                var neb_text_uptodate = CustomLauncher.IsCustomMode ? CustomLauncher.NebulaTextUpToDate : "Nebula: repo_minimal.json is up to date!";
+                var neb_text_tooltip = CustomLauncher.IsCustomMode ? CustomLauncher.NebulaTextToolTip : "The repo_minimal.json file contains info on all the mods available in Nebula, without this you will not be able to install new mods or engine builds";
                 if (!File.Exists(KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "repo_minimal.json") || settings.etag != webEtag)
                 {
                     //Download the repo_minimal.json
                     if (TaskViewModel.Instance != null)
                     {
-                        var result = await Dispatcher.UIThread.InvokeAsync(async()=>await TaskViewModel.Instance.AddFileDownloadTask(repoUrl, KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "repo_minimal_temp.json", "Downloading repo_minimal.json", true, "The repo_minimal.json file contains info on all the mods available in Nebula, without this you will not be able to install new mods or engine builds"), DispatcherPriority.Background).ConfigureAwait(false);
+                        var result = await Dispatcher.UIThread.InvokeAsync(async()=>await TaskViewModel.Instance.AddFileDownloadTask(repoUrl, KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "repo_minimal_temp.json", neb_text_downloading, true, neb_text_tooltip), DispatcherPriority.Background).ConfigureAwait(false);
 
                         if (cancellationToken!.IsCancellationRequested)
                         {
@@ -162,7 +165,7 @@ namespace Knossos.NET.Models
                 else
                 {
                     //No update is needed
-                    Dispatcher.UIThread.Invoke(() => TaskViewModel.Instance?.AddMessageTask("Nebula: repo_minimal.json is up to date!"), DispatcherPriority.Background);
+                    Dispatcher.UIThread.Invoke(() => TaskViewModel.Instance?.AddMessageTask(neb_text_uptodate, neb_text_tooltip), DispatcherPriority.Background);
                     Log.Add(Log.LogSeverity.Information, "Nebula.Trinity()", "repo_minimal.json is up to date!");
                     displayUpdates = false;
                     repoLoaded = true;
@@ -880,7 +883,7 @@ namespace Knossos.NET.Models
                     }
                     else
                     {
-                        Log.Add(Log.LogSeverity.Error, "Nebula.UploadLog", "Error uploading log to nebula, reason: " + reply.Value.reason);
+                        Log.Add(Log.LogSeverity.Error, "Nebula.UploadLog", "Error uploading log to Nebula, reason: " + reply.Value.reason);
                     }
                 }
             }
@@ -1248,7 +1251,7 @@ namespace Knossos.NET.Models
                             {
                                 members += item.user + "(" + item.role.ToString() + ") ";
                             }
-                            Log.Add(Log.LogSeverity.Information, "Nebula.GetTeamMembers", "Mod id: " + modid + " members: " + members);
+                            Log.Add(Log.LogSeverity.Information, "Nebula.GetTeamMembers", "Mod ID: " + modid + " members: " + members);
                         }
                     }
                     else

--- a/Knossos.NET/ViewModels/Windows/DevModCreateNewViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/DevModCreateNewViewModel.cs
@@ -122,22 +122,22 @@ namespace Knossos.NET.ViewModels
             //ID
             if (ModId.Replace(" ", "").Length <= 2)
             {
-                await MessageBox.Show(MainWindow.instance, "Mod id cant be empty or be less than 3 characters: " + ModId, "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance, "Mod ID cant be empty or be less than 3 characters: " + ModId, "Validation error", MessageBox.MessageBoxButtons.OK);
                 return false;
             }
             if (ModId.ToLower() == "tools" || ModId.ToLower() == "fso")
             {
-                await MessageBox.Show(MainWindow.instance, "Mod id: " + ModId+" is a reserved value", "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance, "Mod ID: " + ModId+" is a reserved value", "Validation error", MessageBox.MessageBoxButtons.OK);
                 return false;
             }
             if (await Nebula.IsModIdInNebula(ModId))
             {
-                await MessageBox.Show(MainWindow.instance, "Mod id already exist in Nebula: " + ModId, "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance, "Mod ID already exist in Nebula: " + ModId, "Validation error", MessageBox.MessageBoxButtons.OK);
                 return false;
             }
             if (Knossos.GetInstalledModList(ModId).Any() || Knossos.GetInstalledBuildsList(ModId).Any())
             {
-                await MessageBox.Show(MainWindow.instance, "Mod id already exist locally: " + ModId, "Validation error", MessageBox.MessageBoxButtons.OK);
+                await MessageBox.Show(MainWindow.instance, "Mod ID already exist locally: " + ModId, "Validation error", MessageBox.MessageBoxButtons.OK);
                 return false;
             }
             //If modtype = Mod it has to have a parent mod

--- a/Knossos.NET/Views/CustomHomeView.axaml
+++ b/Knossos.NET/Views/CustomHomeView.axaml
@@ -105,7 +105,7 @@
 									Margin="0,2,0,0" Height="50" Width="150" FontSize="24" 
 									IsVisible="{Binding !Installing}" IsEnabled="{Binding NebulaServices}"></Button>
 							<Button Command="{Binding HardcodedButtonCommand}" Name="ButtonInfo" CommandParameter="details"
-									Content="More info" Classes="Quaternary" HorizontalAlignment="Center"
+									Content="More Info" Classes="Quaternary" HorizontalAlignment="Center"
 									Margin="0,2,0,0" Height="30" Width="150"
 									IsVisible="{Binding !Installing}" IsEnabled="{Binding NebulaServices}"></Button>
 							<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="cancel"


### PR DESCRIPTION
The current TC mode options are great and really allow for a massive customization of almost everything about the home screen and launcher, except for the Nebula messages. This PR allows TC modders to set the main nebula message texts that are usually seen on the home screen, which really helps make the home screen feel fully integrated with the other customization options.

This PR also updates a few public facing capitalizations to be more consistent with other wording capitalizations.

Everything was tested and works as expected.

Happy to discuss and refine however might be requested, thanks!