### PR TITLE
Add mouse over configuration options for custom home view and add more button ids

### DIFF
--- a/Knossos.NET/Models/CustomLauncher.cs
+++ b/Knossos.NET/Models/CustomLauncher.cs
@@ -30,10 +30,10 @@ namespace Knossos.NET.Models
         public int? FontSize { get; set; } = null;
         public string? BackgroundHexColor { get; set; } = null; //#CD3632 hex color value
         public string? ForegroundHexColor { get; set; } = null; //#CD3632 hex color value
-        public string? BorderHexColer { get; set; } = null; //#CD3632 hex color value
+        public string? BorderHexColor { get; set; } = null; //#CD3632 hex color value
         public string? MouseOverBackgroundHexColor { get; set; } = null; //#CD3632 hex color value
         public string? MouseOverForegroundHexColor { get; set; } = null; //#CD3632 hex color value
-        public string? MouseOverBorderHexColer { get; set; } = null; //#CD3632 hex color value
+        public string? MouseOverBorderHexColor { get; set; } = null; //#CD3632 hex color value
     }
 
     public struct CustomMenuButton

--- a/Knossos.NET/Models/CustomLauncher.cs
+++ b/Knossos.NET/Models/CustomLauncher.cs
@@ -20,13 +20,20 @@ namespace Knossos.NET.Models
         {
         }
 
-        public string? ButtonID { get; set; } = null; //ButtonLaunch, ButtonModify, ButtonUpdate, ButtonInstall, ButtonInfo, ButtonDetails, ButtonSettings
+        /// <summary>
+        /// ButtonLaunch, ButtonModify, ButtonUpdate, ButtonInstall, ButtonInfo, ButtonDetails, ButtonSettings, ButtonLaunchAdvanced
+        /// ButtonPlayVR, ButtonFred2, ButtonQtFred, ButtonDebug, ButtonFred2Debug, ButtonQtFredDebug, ButtonLogFile
+        /// </summary>
+        public string? ButtonID { get; set; } = null;
         public string? DisplayText { get; set; } = null;
         public string? ToolTip { get; set; } = null;
         public int? FontSize { get; set; } = null;
         public string? BackgroundHexColor { get; set; } = null; //#CD3632 hex color value
         public string? ForegroundHexColor { get; set; } = null; //#CD3632 hex color value
         public string? BorderHexColer { get; set; } = null; //#CD3632 hex color value
+        public string? MouseOverBackgroundHexColor { get; set; } = null; //#CD3632 hex color value
+        public string? MouseOverForegroundHexColor { get; set; } = null; //#CD3632 hex color value
+        public string? MouseOverBorderHexColer { get; set; } = null; //#CD3632 hex color value
     }
 
     public struct CustomMenuButton

--- a/Knossos.NET/Views/CustomHomeView.axaml
+++ b/Knossos.NET/Views/CustomHomeView.axaml
@@ -68,19 +68,19 @@
 						<!-- Installed -->
 						<StackPanel IsVisible="{Binding Installed}" Grid.Column="2" Margin="20" VerticalAlignment="Center">
 							<WrapPanel Margin="5" HorizontalAlignment="Right">
-								<Button Grid.Column="0" HorizontalAlignment="Left" Width="16" Height="50"
-									Margin="1" ToolTip.Tip="Advanced Options" Background="{Binding Background, ElementName=ButtonLaunch}" BorderBrush="{Binding BorderBrush, ElementName=ButtonLaunch}">
-									<PathIcon Height="15" Width="10" Foreground="{Binding Foreground, ElementName=ButtonLaunch}" Data="{StaticResource ChevronLeftRegular}" />
+								<Button Grid.Column="0" HorizontalAlignment="Left" Width="16" Height="50" Classes="Accept" 
+									Margin="1" ToolTip.Tip="Advanced Options" Name="ButtonLaunchAdvanced">
+									<PathIcon Height="15" Width="10" Foreground="{Binding Foreground, ElementName=ButtonLaunchAdvanced}" Data="{StaticResource ChevronLeftRegular}" />
 									<Button.Flyout>
 										<Flyout Placement="Left">
 											<StackPanel>
-												<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="playvr" Content="Play in VR" HorizontalAlignment="Center" Margin="0,2,0,0" Width="115" ></Button>
-												<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="fred2" Content="Fred2" HorizontalAlignment="Center" Margin="0,2,0,0" Width="115" ></Button>
-												<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="qtfred" Content="QtFred" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
-												<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="debug" Content="FSO Debug" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
-												<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="fred2debug" Content="Fred2 Debug" HorizontalAlignment="Center" Margin="0,2,0,0" Width="115" ></Button>
-												<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="qtfreddebug" Content="QtFred Debug" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
-												<Button Command="{Binding HardcodedButtonCommand}" CommandParameter="logfile" Content="Open Logfile" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
+												<Button Name="ButtonPlayVR" Command="{Binding HardcodedButtonCommand}" CommandParameter="playvr" Content="Play in VR" HorizontalAlignment="Center" Margin="0,2,0,0" Width="115" ></Button>
+												<Button Name="ButtonFred2" Command="{Binding HardcodedButtonCommand}" CommandParameter="fred2" Content="Fred2" HorizontalAlignment="Center" Margin="0,2,0,0" Width="115" ></Button>
+												<Button Name="ButtonQtFred" Command="{Binding HardcodedButtonCommand}" CommandParameter="qtfred" Content="QtFred" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
+												<Button Name="ButtonDebug" Command="{Binding HardcodedButtonCommand}" CommandParameter="debug" Content="FSO Debug" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
+												<Button Name="ButtonFred2Debug" Command="{Binding HardcodedButtonCommand}" CommandParameter="fred2debug" Content="Fred2 Debug" HorizontalAlignment="Center" Margin="0,2,0,0" Width="115" ></Button>
+												<Button Name="ButtonQtFredDebug" Command="{Binding HardcodedButtonCommand}" CommandParameter="qtfreddebug" Content="QtFred Debug" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
+												<Button Name="ButtonLogFile" Command="{Binding HardcodedButtonCommand}" CommandParameter="logfile" Content="Open Logfile" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
 											</StackPanel>
 										</Flyout>
 									</Button.Flyout>

--- a/Knossos.NET/Views/CustomHomeView.axaml.cs
+++ b/Knossos.NET/Views/CustomHomeView.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Styling;
 using Knossos.NET.Converters;
 using Knossos.NET.Models;
 using System;
@@ -85,7 +87,7 @@ public partial class CustomHomeView : UserControl
                     var button = this.FindControl<Button>(config.ButtonID!);
                     if (button != null)
                     {
-                        if (config.DisplayText != null)
+                        if (config.DisplayText != null && config.ButtonID != "ButtonLaunchAdvanced")
                             button.Content = config.DisplayText;
                         if (config.ToolTip != null)
                             ToolTip.SetTip(button, config.ToolTip);
@@ -97,6 +99,24 @@ public partial class CustomHomeView : UserControl
                             button.Foreground = SolidColorBrush.Parse(config.ForegroundHexColor);
                         if (config.BorderHexColer != null)
                             button.BorderBrush = SolidColorBrush.Parse(config.BorderHexColer);
+
+                        if (config.MouseOverBackgroundHexColor != null || config.MouseOverForegroundHexColor != null || config.MouseOverBorderHexColer != null)
+                        {
+                            Style style = new Style(x => x.OfType<Button>().Class(":pointerover").Template().OfType<ContentPresenter>());
+                            if(config.MouseOverBackgroundHexColor != null)
+                            {
+                                style.Setters.Add(new Setter(Button.BackgroundProperty, SolidColorBrush.Parse(config.MouseOverBackgroundHexColor)));
+                            }
+                            if(config.MouseOverForegroundHexColor != null)
+                            {
+                                style.Setters.Add(new Setter(Button.ForegroundProperty, SolidColorBrush.Parse(config.MouseOverForegroundHexColor)));
+                            }
+                            if (config.MouseOverBorderHexColer != null)
+                            {
+                                style.Setters.Add(new Setter(Button.BorderBrushProperty, SolidColorBrush.Parse(config.MouseOverBorderHexColer)));
+                            }
+                            button.Styles.Add(style);
+                        }
                     }
                     else
                     {

--- a/Knossos.NET/Views/CustomHomeView.axaml.cs
+++ b/Knossos.NET/Views/CustomHomeView.axaml.cs
@@ -97,10 +97,10 @@ public partial class CustomHomeView : UserControl
                             button.Background = SolidColorBrush.Parse(config.BackgroundHexColor);
                         if (config.ForegroundHexColor != null)
                             button.Foreground = SolidColorBrush.Parse(config.ForegroundHexColor);
-                        if (config.BorderHexColer != null)
-                            button.BorderBrush = SolidColorBrush.Parse(config.BorderHexColer);
+                        if (config.BorderHexColor != null)
+                            button.BorderBrush = SolidColorBrush.Parse(config.BorderHexColor);
 
-                        if (config.MouseOverBackgroundHexColor != null || config.MouseOverForegroundHexColor != null || config.MouseOverBorderHexColer != null)
+                        if (config.MouseOverBackgroundHexColor != null || config.MouseOverForegroundHexColor != null || config.MouseOverBorderHexColor != null)
                         {
                             Style style = new Style(x => x.OfType<Button>().Class(":pointerover").Template().OfType<ContentPresenter>());
                             if(config.MouseOverBackgroundHexColor != null)
@@ -111,9 +111,9 @@ public partial class CustomHomeView : UserControl
                             {
                                 style.Setters.Add(new Setter(Button.ForegroundProperty, SolidColorBrush.Parse(config.MouseOverForegroundHexColor)));
                             }
-                            if (config.MouseOverBorderHexColer != null)
+                            if (config.MouseOverBorderHexColor != null)
                             {
-                                style.Setters.Add(new Setter(Button.BorderBrushProperty, SolidColorBrush.Parse(config.MouseOverBorderHexColer)));
+                                style.Setters.Add(new Setter(Button.BorderBrushProperty, SolidColorBrush.Parse(config.MouseOverBorderHexColor)));
                             }
                             button.Styles.Add(style);
                         }


### PR DESCRIPTION
Added MouseOverBackgroundHexColor, MouseOverForegroundHexColor and MouseOverBorderHexColer to HomeCustomButtonConfig struct.

Also exposed the missing button ids on the custom home view: ButtonLaunchAdvanced (the little "<") and all buttons on the advanced launch panel.