### PR TITLE
Feature: Skip launcher updates

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -423,12 +423,22 @@ namespace Knossos.NET
 
                             if (releaseAsset != null && releaseAsset.browser_download_url != null)
                             {
+                                if(globalSettings.ignoredLauncherUpdates.Contains(latest.tag_name))
+                                {
+                                    Log.Add(Log.LogSeverity.Information, "Knossos.CheckKnetUpdates()", "Launcher update: " + latest.tag_name + " is available, but it was skipped because it is on the ignore list.");
+                                    return;
+                                }
                                 if (!forceUpdateDownload && !globalSettings.autoUpdate)
                                 {
                                     MessageBox.MessageBoxResult result = MessageBox.MessageBoxResult.Cancel;
                                     await Dispatcher.UIThread.Invoke(async () => {
-                                        result = await MessageBox.Show(null, "Knossos.NET " + latest.tag_name + ":\n" + latest.body + "\n\n\nIf you continue Knossos.NET will be re-started after download.", "An update is available", MessageBox.MessageBoxButtons.ContinueCancel);
+                                        result = await MessageBox.Show(null, "Knossos.NET " + latest.tag_name + ":\n" + latest.body + "\n\n\nIf you continue Knossos.NET will be re-started after download.", "An update is available", MessageBox.MessageBoxButtons.ContinueCancelSkipVersion);
                                     }).ConfigureAwait(false);
+                                    if(result == MessageBox.MessageBoxResult.SkipVersion)
+                                    {
+                                        globalSettings.ignoredLauncherUpdates.Add(latest.tag_name);
+                                        globalSettings.Save();
+                                    }
                                     if (result != MessageBox.MessageBoxResult.Continue)
                                     {
                                         return;

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -10,6 +10,7 @@ using IniParser;
 using Avalonia.Threading;
 using Knossos.NET.ViewModels;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Knossos.NET.Models
 {
@@ -120,6 +121,9 @@ namespace Knossos.NET.Models
         public AutoUpdateFsoBuilds autoUpdateBuilds { get; set; } = new AutoUpdateFsoBuilds();
         [JsonPropertyName("warn_new_settings_system")]
         public bool warnNewSettingsSystem { get; set; } = true;
+        [JsonPropertyName("ignored_launcher_updates")]
+        public List<string> ignoredLauncherUpdates { get; set; } = new List<string>();
+
 
         /* 
          * Settings that can wait to be saved at app close so we dont have to call save() all the time
@@ -670,6 +674,7 @@ namespace Knossos.NET.Models
                         mainMenuOpen = tempSettings.mainMenuOpen;
                         sortType = tempSettings.sortType;
                         portableFsoPreferences = tempSettings.portableFsoPreferences;
+                        ignoredLauncherUpdates = tempSettings.ignoredLauncherUpdates;
 
                         ReadFS2IniValues();
                         Log.Add(Log.LogSeverity.Information, "GlobalSettings.Load()", "Global settings have been loaded");

--- a/Knossos.NET/Views/Windows/MessageBox.axaml.cs
+++ b/Knossos.NET/Views/Windows/MessageBox.axaml.cs
@@ -18,7 +18,8 @@ namespace Knossos.NET.Views
             Details,
             DetailsOKCancel,
             DetailsContinueCancel,
-            DontWarnAgainOK
+            DontWarnAgainOK,
+            ContinueCancelSkipVersion,
         }
 
         public enum MessageBoxResult
@@ -29,7 +30,8 @@ namespace Knossos.NET.Views
             No,
             Continue,
             Details,
-            DontWarnAgain
+            DontWarnAgain,
+            SkipVersion
         }
 
         public MessageBox()
@@ -84,12 +86,12 @@ namespace Knossos.NET.Views
                 AddButton("No", MessageBoxResult.No, true, "Cancel");
             }
 
-            if (buttons == MessageBoxButtons.Continue || buttons == MessageBoxButtons.ContinueCancel || buttons == MessageBoxButtons.DetailsContinueCancel)
+            if (buttons == MessageBoxButtons.Continue || buttons == MessageBoxButtons.ContinueCancel || buttons == MessageBoxButtons.DetailsContinueCancel || buttons == MessageBoxButtons.ContinueCancelSkipVersion)
             {
                 AddButton("Continue", MessageBoxResult.Continue, false, "Accept");
             }
 
-            if (buttons == MessageBoxButtons.OKCancel || buttons == MessageBoxButtons.YesNoCancel || buttons == MessageBoxButtons.ContinueCancel || buttons == MessageBoxButtons.DetailsOKCancel || buttons == MessageBoxButtons.DetailsContinueCancel)
+            if (buttons == MessageBoxButtons.OKCancel || buttons == MessageBoxButtons.YesNoCancel || buttons == MessageBoxButtons.ContinueCancel || buttons == MessageBoxButtons.DetailsOKCancel || buttons == MessageBoxButtons.DetailsContinueCancel || buttons == MessageBoxButtons.ContinueCancelSkipVersion)
             {
                 AddButton("Cancel", MessageBoxResult.Cancel, true, "Cancel");
             }
@@ -103,6 +105,11 @@ namespace Knossos.NET.Views
             {
                 AddButton("OK", MessageBoxResult.OK, true, "Accept");
                 AddButton("Don't warn again", MessageBoxResult.DontWarnAgain, false, "Option", 150);
+            }
+
+            if (buttons == MessageBoxButtons.ContinueCancelSkipVersion)
+            {
+                AddButton("Skip this version", MessageBoxResult.SkipVersion, false, "Option", 150);
             }
 
             var tcs = new TaskCompletionSource<MessageBoxResult>();


### PR DESCRIPTION
Add an option to ignore a launcher update and not to be asked again to update for that version.

How to test:
Change Knossos version to something below 1.2.4.