### PR TITLE
Some nebula API adjustments

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -728,7 +728,7 @@ namespace Knossos.NET.Models
                                 if (jsonReply != null)
                                 {
                                     var reply = JsonSerializer.Deserialize<ApiReply>(jsonReply);
-                                    if (!reply.result)
+                                    if (!reply.result && resourceUrl != "mod/check_id")
                                         Log.Add(Log.LogSeverity.Error, "Nebula.ApiCall(" + resourceUrl + ")", "An error has ocurred during nebula api POST call: " + response.StatusCode + "(" + (int)response.StatusCode + ")\n" + data);
 
                                     return reply;
@@ -1164,7 +1164,7 @@ namespace Knossos.NET.Models
                 if(editableIds != null)
                     return editableIds;
 
-                var reply = await ApiCall("mod/editable", null, true, 30, ApiMethod.GET);
+                var reply = await ApiCall("mod/editable", null, true, 45, ApiMethod.GET);
                 if (reply.HasValue)
                 { 
                     if (reply.Value.mods != null && reply.Value.mods.Any())
@@ -1202,7 +1202,7 @@ namespace Knossos.NET.Models
                 if (tryUseCache && privateMods != null)
                     return privateMods;
 
-                var reply = await ApiCall("mod/list_private", null, true, 30, ApiMethod.GET);
+                var reply = await ApiCall("mod/list_private", null, true, 45, ApiMethod.GET);
                 if (reply.Value.mods != null && reply.Value.mods.Any())
                 {
                     var mods = reply.Value.mods.Select(x => x.Deserialize<Mod>()!).ToArray()!;


### PR DESCRIPTION
Do not log "result = false" calls to "mod/check_id" as errors, this is expected for that resource.
Increased timeout of get editable ids and private mods to 45 seconds from 30, may help mitigate the problems some people were having but this is in no way a fix. #261 