### PR TITLE
Allow TC Mode to Hide QuickStart Button

### DIFF
--- a/Knossos.NET/Models/CustomLauncher.cs
+++ b/Knossos.NET/Models/CustomLauncher.cs
@@ -162,6 +162,11 @@ namespace Knossos.NET.Models
         public static bool MenuDisplayGlobalSettingsEntry { get; private set; } = false;
 
         /// <summary>
+        /// Display the QuickStart button in the Knossos settings menu
+        /// </summary>
+        public static bool SettingsDisplayQuickStartButton { get; private set; } = true;
+
+        /// <summary>
         /// Add custom buttons to the menu
         /// </summary>
         public static CustomMenuButton[]? CustomMenuButtons { get; private set; }
@@ -321,11 +326,14 @@ namespace Knossos.NET.Models
                     if (customData.MenuDisplayNebulaLoginEntry.HasValue)
                         MenuDisplayNebulaLoginEntry = customData.MenuDisplayNebulaLoginEntry.Value;
 
+                    if (customData.MenuDisplayCommunityEntry.HasValue)
+                        MenuDisplayCommunityEntry = customData.MenuDisplayCommunityEntry.Value;
+
                     if (customData.MenuDisplayGlobalSettingsEntry.HasValue)
                         MenuDisplayGlobalSettingsEntry = customData.MenuDisplayGlobalSettingsEntry.Value;
 
-                    if (customData.MenuDisplayCommunityEntry.HasValue)
-                        MenuDisplayCommunityEntry = customData.MenuDisplayCommunityEntry.Value;
+                    if (customData.SettingsDisplayQuickStartButton.HasValue)
+                        SettingsDisplayQuickStartButton = customData.SettingsDisplayQuickStartButton.Value;
 
                     CustomMenuButtons = customData.CustomMenuButtons;
 
@@ -380,8 +388,9 @@ namespace Knossos.NET.Models
             public bool? MenuDisplayEngineEntry { get; set; }
             public bool? MenuDisplayDebugEntry { get; set; }
             public bool? MenuDisplayNebulaLoginEntry { get; set; }
-            public bool? MenuDisplayGlobalSettingsEntry { get; set; }
             public bool? MenuDisplayCommunityEntry { get; set; }
+            public bool? MenuDisplayGlobalSettingsEntry { get; set; }
+            public bool? SettingsDisplayQuickStartButton { get; set; }
             public string[]? CustomCmdlineArray { get; set; }
             public bool? UseNebulaServices { get; set; }
             public bool? WriteLogFile { get; set; }

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -64,6 +64,7 @@ namespace Knossos.NET.ViewModels
         internal bool displaySettingsWarning = true;
         [ObservableProperty]
         internal bool quickStartButtonVisibility = true;
+        [ObservableProperty]
         internal bool expandKnossosSettings = false;
 
         /* Knossos Settings */

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -62,6 +62,8 @@ namespace Knossos.NET.ViewModels
         internal bool isAVX2 = false;
         [ObservableProperty]
         internal bool displaySettingsWarning = true;
+        [ObservableProperty]
+        internal bool quickStartButtonVisibility = true;
 
         /* Knossos Settings */
         [ObservableProperty]
@@ -580,6 +582,7 @@ namespace Knossos.NET.ViewModels
             LogLevel= Knossos.globalSettings.logLevel;
             Fs2RootPack = Knossos.retailFs2RootFound;
             NumberOfMods = Knossos.GetInstalledModList(null).Count.ToString();
+            QuickStartButtonVisibility = CustomLauncher.IsCustomMode ? CustomLauncher.SettingsDisplayQuickStartButton : true;
             NumberOfBuilds = Knossos.GetInstalledBuildsList(null).Count.ToString();
             if(KnUtils.IsWindows)
             {

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -14,7 +14,7 @@
 
 	<Grid RowDefinitions="Auto,*">
 		<WrapPanel Margin="5,5,0,5" Grid.Row="0" VerticalAlignment="Center">
-			<Button Margin="0,5,30,0" Command="{Binding QuickSetupCommand}" FontSize="20" ToolTip.Tip="Open the initial 'Getting Started' guide window" Classes="Quaternary">Quick Setup Guide</Button>
+			<Button Margin="0,5,30,0" IsVisible="{Binding QuickStartButtonVisibility}" Command="{Binding QuickSetupCommand}" FontSize="20" ToolTip.Tip="Open the initial 'Getting Started' guide window" Classes="Quaternary">Quick Setup Guide</Button>
 			<Button Margin="0,5,30,0" Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" ToolTip.Tip="Reset all settings to defaults" Classes="Cancel">Reset to defaults</Button>
 			<Button Margin="0,5,30,0" Command="{Binding ReloadFlagData}" FontSize="20" ToolTip.Tip="Reload all settings from the configuration file and reload system data.">Reload Data</Button>
 		</WrapPanel>


### PR DESCRIPTION
Fixes #291. Happy to alter the method if preferred, thanks!

For TCs that only show the Home Screen and Options screen the Quickstart button becomes confusing b/c it references buttons and tabs that are not visible. This PR allows hiding the Quickstart button in TC mode.