### PR TITLE
Hides the Build Settings Warning in TC Mode

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1368,7 +1368,7 @@ namespace Knossos.NET
 
             
 
-            if (MainWindow.instance != null && globalSettings.warnNewSettingsSystem)
+            if (MainWindow.instance != null && globalSettings.warnNewSettingsSystem && !CustomLauncher.IsCustomMode)
             {
                 try
                 {


### PR DESCRIPTION
As discussed on Discord, modders who make a TC customization will either be using in-game options or not for their specific mod, so no need to warn new players about the options (and warning new players creates a confusing and less streamline first-time experience).