### PR TITLE
Change trayicon to close to tray mode

### DIFF
--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -122,24 +122,13 @@ namespace Knossos.NET.Models
         [JsonPropertyName("warn_new_settings_system")]
         public bool warnNewSettingsSystem { get; set; } = true;
         [JsonIgnore]
-        public bool _minimizeToTray { get; set; } = false;
-        [JsonPropertyName("minimize_to_tray")]
-        public bool minimizeToTray {
-            get { return _minimizeToTray; }
-            set { if (_minimizeToTray != value) { 
-                    _minimizeToTray = value;
+        private bool _closeToTray { get; set; } = false;
+        [JsonPropertyName("close_to_tray")]
+        public bool closeToTray {
+            get { return _closeToTray; }
+            set { if (_closeToTray != value) { 
+                    _closeToTray = value;
                     pendingChangesOnAppClose = true;
-                    if (Avalonia.Application.Current is App app)
-                    {
-                        if (_minimizeToTray)
-                        {
-                            app.EnableMinimizeToTrayRuntime();
-                        }
-                        else
-                        {
-                            app.DisableMinimizeToTrayRuntime();
-                        }
-                    }
                 }
             }
         }
@@ -695,7 +684,7 @@ namespace Knossos.NET.Models
                         mainMenuOpen = tempSettings.mainMenuOpen;
                         sortType = tempSettings.sortType;
                         portableFsoPreferences = tempSettings.portableFsoPreferences;
-                        minimizeToTray = tempSettings.minimizeToTray;
+                        closeToTray = tempSettings.closeToTray;
                         ignoredLauncherUpdates = tempSettings.ignoredLauncherUpdates;
 
                         ReadFS2IniValues();

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -198,11 +198,11 @@ namespace Knossos.NET.ViewModels
         }
 
         /* This change is applied right away */
-        private bool minimizeToTray = false;
-        internal bool MinimizeToTray
+        private bool closeToTray = false;
+        internal bool CloseToTray
         {
-            get { return minimizeToTray; }
-            set { if (minimizeToTray != value) { this.SetProperty(ref minimizeToTray, value); Knossos.globalSettings.minimizeToTray = value ; UnCommitedChanges = true; } }
+            get { return closeToTray; }
+            set { if (closeToTray != value) { this.SetProperty(ref closeToTray, value); Knossos.globalSettings.closeToTray = value ; UnCommitedChanges = true; } }
         }
 
         /*VIDEO*/
@@ -668,7 +668,7 @@ namespace Knossos.NET.ViewModels
             PrefixCMD = Knossos.globalSettings.prefixCMD;
             EnvVars = Knossos.globalSettings.envVars;
             ShowDevOptions = Knossos.globalSettings.showDevOptions || NoSystemCMD;
-            MinimizeToTray = Knossos.globalSettings.minimizeToTray;
+            CloseToTray = Knossos.globalSettings.closeToTray;
 
             /* VIDEO SETTINGS */
             //RESOLUTION
@@ -1248,7 +1248,7 @@ namespace Knossos.NET.ViewModels
             Knossos.globalSettings.prefixCMD = PrefixCMD;
             Knossos.globalSettings.envVars = EnvVars;
             Knossos.globalSettings.showDevOptions = ShowDevOptions;
-            Knossos.globalSettings.minimizeToTray = MinimizeToTray;
+            Knossos.globalSettings.closeToTray = CloseToTray;
 
             /* VIDEO */
             //Resolution

--- a/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/MainWindowViewModel.cs
@@ -44,13 +44,13 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string appTitle = "Knossos.NET v" + Knossos.AppVersion;
         [ObservableProperty]
-        internal int? windowWidth = null;
+        internal int windowWidth = 1200;
         [ObservableProperty]
-        internal int? windowHeight = null;
+        internal int windowHeight = 700;
         [ObservableProperty]
-        internal int? minWindowWidth = null;
+        internal int minWindowWidth = 900;
         [ObservableProperty]
-        internal int? minWindowHeight = null;
+        internal int minWindowHeight = 500;
         [ObservableProperty]
         internal ModListViewModel? installedModsView;
         [ObservableProperty]
@@ -107,8 +107,6 @@ namespace Knossos.NET.ViewModels
             }
             if (!CustomLauncher.IsCustomMode)
             {
-                MinWindowWidth = 900;
-                MinWindowHeight = 500;
                 placeholderTileImage = new Bitmap(AssetLoader.Open(new Uri("avares://Knossos.NET/Assets/general/NebulaDefault.png")));
                 InstalledModsView = new ModListViewModel();
                 NebulaModsView = new NebulaModListViewModel();
@@ -125,10 +123,10 @@ namespace Knossos.NET.ViewModels
                 //Apply customization for Single TC Mode
                 Knossos.globalSettings.mainMenuOpen = CustomLauncher.MenuOpenFirstTime;
                 AppTitle = CustomLauncher.WindowTitle + " v" + Knossos.AppVersion;
-                WindowHeight = CustomLauncher.WindowHeight;
-                WindowWidth = CustomLauncher.WindowWidth;
-                MinWindowWidth = CustomLauncher.MinWindowWidth;
-                MinWindowHeight = CustomLauncher.MinWindowHeight;
+                WindowHeight = CustomLauncher.WindowHeight.HasValue ? CustomLauncher.WindowHeight.Value : 1200;
+                WindowWidth = CustomLauncher.WindowWidth.HasValue ? CustomLauncher.WindowWidth.Value : 700;
+                MinWindowWidth = CustomLauncher.MinWindowWidth.HasValue ? CustomLauncher.MinWindowWidth.Value : 900;
+                MinWindowHeight = CustomLauncher.MinWindowHeight.HasValue ? CustomLauncher.MinWindowHeight.Value : 500;
                 CustomHomeVM = new CustomHomeViewModel();
                 if (CustomLauncher.MenuDisplayEngineEntry)
                     FsoBuildsView = new FsoBuildsViewModel();

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -60,10 +60,10 @@
 							</ComboBox>
 							<NumericUpDown IsEnabled="{Binding ModCompression}" Margin="10,0,0,0" Width="120" Grid.Column="2" Minimum="1" Maximum="8" Value="{Binding CompressionMaxParallelism}" ToolTip.Tip="Max number of parallel compression tasks"></NumericUpDown>
 						</WrapPanel>
-            <!-- MinimizeToTray -->
+						<!-- CloseToTray -->
 							<WrapPanel Margin="5,10,0,0">
-								<Label Margin="0,5,0,0" Width="205">Minimize to tray</Label>
-								<ToggleSwitch IsChecked="{Binding MinimizeToTray}" Margin="5,0,0,0" ToolTip.Tip="As of Knossos.NET v1.3, this is a experimental feature."></ToggleSwitch>
+								<Label Margin="0,5,0,0" Width="205">Close to tray</Label>
+								<ToggleSwitch IsChecked="{Binding CloseToTray}" Margin="5,0,0,0" ToolTip.Tip="As of Knossos.NET v1.3, this is a experimental feature."></ToggleSwitch>
 							</WrapPanel>
 						<!-- AutoUpdates -->
 						<WrapPanel Margin="5,10,0,0">


### PR DESCRIPTION
This changes the trayicon function from "minimize to tray" to "close to tray".

And some other minor adjustments for that.

Tested working on Windows and Mac, linux crashes 90% of the time this looks like an avalonia bug or something im doing wrong and i cant figure out what.

After this is merged i will create a issue in AvaloniaUI about it.