### PR TITLE
Hide more advanced video options

### DIFF
--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -235,14 +235,14 @@
 							<ToggleSwitch ToolTip.Tip="Enable basic Post Processing, which helps ensure visuals are balanced. Enabled by default." Tag="-no_post_process" IsChecked="{Binding PostProcess}"></ToggleSwitch>
 						</WrapPanel>
 						<!-- VSYNC -->
-            <!-- More advanced option that power users can set via Command Line or in individual mod settings.
+						<!-- More advanced option that power users can set via Command Line or in individual mod settings.
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">VSync</Label>
 							<ToggleSwitch ToolTip.Tip="Enable vertical sync, which ensures the game FPS matches the monitor FPS. Enabled by default." Tag="-no_vsync" IsChecked="{Binding Vsync}"></ToggleSwitch>
 						</WrapPanel>
 						-->
-            <!-- FPS Cap -->
-            <!-- More advanced option that power users can set via Command Line or in individual mod settings.
+						<!-- FPS Cap -->
+						<!-- More advanced option that power users can set via Command Line or in individual mod settings.
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Limit to 120 FPS</Label>
 							<ToggleSwitch ToolTip.Tip="Caps the frames-per-second (FPS) of FSO to 120. Enabled by default." Tag="-no_fps_capping" IsChecked="{Binding !NoFpsCapping}"></ToggleSwitch>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -240,14 +240,14 @@
 							<Label Margin="5,5,0,0" Width="210">VSync</Label>
 							<ToggleSwitch ToolTip.Tip="Enable vertical sync, which ensures the game FPS matches the monitor FPS. Enabled by default." Tag="-no_vsync" IsChecked="{Binding Vsync}"></ToggleSwitch>
 						</WrapPanel>
-            -->
+						-->
 						<!-- FPS Cap -->
             <!-- More advanced option that power users can set via Command Line or in individual mod settings.
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Limit to 120 FPS</Label>
 							<ToggleSwitch ToolTip.Tip="Caps the frames-per-second (FPS) of FSO to 120. Enabled by default." Tag="-no_fps_capping" IsChecked="{Binding !NoFpsCapping}"></ToggleSwitch>
 						</WrapPanel>
-             -->
+						-->
 						<!-- Show FPS -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -236,12 +236,12 @@
 						</WrapPanel>
 						<!-- VSYNC -->
             <!-- More advanced option that power users can set via Command Line or in individual mod settings.
-            <WrapPanel>
+						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">VSync</Label>
 							<ToggleSwitch ToolTip.Tip="Enable vertical sync, which ensures the game FPS matches the monitor FPS. Enabled by default." Tag="-no_vsync" IsChecked="{Binding Vsync}"></ToggleSwitch>
 						</WrapPanel>
 						-->
-						<!-- FPS Cap -->
+            <!-- FPS Cap -->
             <!-- More advanced option that power users can set via Command Line or in individual mod settings.
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Limit to 120 FPS</Label>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -235,15 +235,19 @@
 							<ToggleSwitch ToolTip.Tip="Enable basic Post Processing, which helps ensure visuals are balanced. Enabled by default." Tag="-no_post_process" IsChecked="{Binding PostProcess}"></ToggleSwitch>
 						</WrapPanel>
 						<!-- VSYNC -->
-						<WrapPanel>
+            <!-- More advanced option that power users can set via Command Line or in individual mod settings.
+            <WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">VSync</Label>
 							<ToggleSwitch ToolTip.Tip="Enable vertical sync, which ensures the game FPS matches the monitor FPS. Enabled by default." Tag="-no_vsync" IsChecked="{Binding Vsync}"></ToggleSwitch>
 						</WrapPanel>
+            -->
 						<!-- FPS Cap -->
+            <!-- More advanced option that power users can set via Command Line or in individual mod settings.
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Limit to 120 FPS</Label>
 							<ToggleSwitch ToolTip.Tip="Caps the frames-per-second (FPS) of FSO to 120. Enabled by default." Tag="-no_fps_capping" IsChecked="{Binding !NoFpsCapping}"></ToggleSwitch>
 						</WrapPanel>
+             -->
 						<!-- Show FPS -->
 						<WrapPanel>
 							<Label Margin="5,5,0,0" Width="210">Display FPS</Label>


### PR DESCRIPTION
There have been new players/testers that have disabled `Vsync` and `120 FPS Limit` without fully realizing the downstream side effects and then ran into various issues. These are typically somewhat advanced options for graphics, so after talking it over this PR removes them by commenting out the UI fields from the global graphics options.