### PR TITLE
Move minWidth For better spacing on tabs

### DIFF
--- a/Knossos.NET/Views/DeveloperModsView.axaml
+++ b/Knossos.NET/Views/DeveloperModsView.axaml
@@ -13,9 +13,9 @@
 	</Design.DataContext>
 
 	<ScrollViewer HorizontalScrollBarVisibility="Visible">
-		<TabControl Margin="10" MinWidth="1000" SelectedIndex="{Binding TabIndex}">
+		<TabControl Margin="10" SelectedIndex="{Binding TabIndex}">
 		  <TabItem Header="Mods">
-					<SplitView Margin="0,0,0,5" IsPaneOpen="True" DisplayMode="Inline" OpenPaneLength="350">
+					<SplitView MinWidth="1000" Margin="0,0,0,5" IsPaneOpen="True" DisplayMode="Inline" OpenPaneLength="350">
 						<SplitView.Pane>
 							<Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
 							


### PR DESCRIPTION
This allows the nebula login and Mod Tools tabs to dynamically match the window size, while still requiring the minimum space on the mod development tab.

