### PR TITLE
Warn Users If Library Folder is Missing

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1600,6 +1600,16 @@ namespace Knossos.NET
             {
                 /* Likely file/folder permission issues */
                 Log.Add(Log.LogSeverity.Error, "Knossos.ModSearchRecursive", ex);
+
+                if (folderLevel == 0 )
+                {
+                    if (MainWindow.instance != null)
+                    {
+                        Dispatcher.UIThread.Invoke(() => {
+                            MessageBox.Show(MainWindow.instance!, "Knossos either cannot find or does not have permission to read a previously selected library folder.\nEither slect a new library folder in knossos's settings, or check if the folder is now protected.", "Knossos.NET Library Folder Error" , MessageBox.MessageBoxButtons.OK);
+                        });
+                    }
+                }
             }
         }
 

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1606,7 +1606,7 @@ namespace Knossos.NET
                     if (MainWindow.instance != null)
                     {
                         Dispatcher.UIThread.Invoke(() => {
-                            MessageBox.Show(MainWindow.instance!, "Knossos either cannot find or does not have permission to read a previously selected library folder.\nEither slect a new library folder in knossos's settings, or check if the folder is now protected.", "Knossos.NET Library Folder Error" , MessageBox.MessageBoxButtons.OK);
+                            MessageBox.Show(MainWindow.instance!, "KnossosNET either cannot find or does not have permission to read a previously selected library folder.\nEither select a new library folder in KnossosNET's settings, or check if the folder is now protected.", "Knossos.NET Library Folder Error" , MessageBox.MessageBoxButtons.OK);
                         });
                     }
                 }


### PR DESCRIPTION
  Give the user a basic warning if their library folder has moved.
  
  Not fully tested on all platforms, so in draft status.  Could also use a test on a fresh install.