### PR TITLE
Fixup dev tab

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using Knossos.NET.Classes;
 using System.Threading;
 using System.Security.Cryptography;
+using Knossos.NET.Views;
 
 namespace Knossos.NET.Models
 {
@@ -1315,6 +1316,11 @@ namespace Knossos.NET.Models
                     { new StringContent(modid), "mid" }
                 };
 
+                if (!userIsLoggedIn){
+                    
+                    return null;
+                }
+
                 var reply = await ApiCall("mod/team/fetch", data, true);
                 if (reply.HasValue)
                 {
@@ -1338,7 +1344,7 @@ namespace Knossos.NET.Models
                 }
                 else
                 {
-                    Log.Add(Log.LogSeverity.Error, "Nebula.GetTeamMembers", "Unable to check if mod team members.");
+                    Log.Add(Log.LogSeverity.Error, "Nebula.GetTeamMembers", "Unable to check if this mod has team members.");
                 }
             }
             catch (Exception ex)

--- a/Knossos.NET/ViewModels/Templates/DevModMembersMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModMembersMgrViewModel.cs
@@ -87,6 +87,8 @@ namespace Knossos.NET.ViewModels
         internal bool buttonsEnabled = true;
         [ObservableProperty]
         internal bool loading = true;
+        [ObservableProperty]
+        internal bool showLoginError = false;
 
         public DevModMembersMgrViewModel() 
         { 
@@ -101,21 +103,28 @@ namespace Knossos.NET.ViewModels
         {
             if (editor != null && !MemberItems.Any())
             {
-                var members = await Nebula.GetTeamMembers(editor.ActiveVersion.id).ConfigureAwait(false);
-                Dispatcher.UIThread.Invoke(() =>
-                {
-                    if (members != null)
+                if (Nebula.userIsLoggedIn) {
+                    ButtonsEnabled = true;
+                    ShowLoginError = false;
+                    var members = await Nebula.GetTeamMembers(editor.ActiveVersion.id).ConfigureAwait(false);
+                    Dispatcher.UIThread.Invoke(() =>
                     {
-                        foreach (var member in members)
+                        if (members != null)
                         {
-                            MemberItems.Add(new MemberItem(member, this));
+                            foreach (var member in members)
+                            {
+                                MemberItems.Add(new MemberItem(member, this));
+                            }
                         }
-                    }
-                    else
-                    {
-                        _ = MessageBox.Show(MainWindow.instance!, "An error has ocurred while retrieving the mod member list. The log may provide more information.", "Error", MessageBox.MessageBoxButtons.OK);
-                    }
-                });
+                        else
+                        {
+                            _ = MessageBox.Show(MainWindow.instance!, "An error has ocurred while retrieving the mod member list. The log may provide more information.", "Error", MessageBox.MessageBoxButtons.OK);
+                        }
+                    });
+                } else {
+                    ButtonsEnabled = false;
+                    ShowLoginError = true;
+                }
             }
             Dispatcher.UIThread.Invoke(() =>
             {

--- a/Knossos.NET/Views/DeveloperModsView.axaml
+++ b/Knossos.NET/Views/DeveloperModsView.axaml
@@ -15,7 +15,7 @@
 	<ScrollViewer HorizontalScrollBarVisibility="Visible">
 		<TabControl Margin="10" SelectedIndex="{Binding TabIndex}">
 		  <TabItem Header="Mods">
-					<SplitView MinWidth="1000" Margin="0,0,0,5" IsPaneOpen="True" DisplayMode="Inline" OpenPaneLength="350">
+					<SplitView MinWidth="1000" Margin="0,0,0,5" IsPaneOpen="True" DisplayMode="CompactInline" CompactPaneLength="100" OpenPaneLength="300">
 						<SplitView.Pane>
 							<Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
 							
@@ -35,14 +35,15 @@
 									</ListBox.ItemTemplate>
 								</ListBox>
 							
-								<Button Command="{Binding InstallLatestStable}" Grid.Row="3" Margin="0,10,0,10" HorizontalAlignment="Center" IsEnabled="{Binding !StableInstalled}" IsVisible="{Binding !StableInstalled}" >Get Latest Stable Build</Button>
-								<Button Command="{Binding InstallLatestNightly}" Grid.Row="4" Margin="0,0,0,10" HorizontalAlignment="Center" IsEnabled="{Binding !NightlyInstalled}" IsVisible="{Binding !NightlyInstalled}" >Get Latest Nightly Build</Button>
+								<Button Command="{Binding InstallLatestStable}" Grid.Row="3" Margin="0,20,0,10" HorizontalAlignment="Center" IsEnabled="{Binding !StableInstalled}" IsVisible="{Binding !StableInstalled}" >Get Latest Stable Build</Button>
+								<Button Command="{Binding InstallLatestNightly}" Grid.Row="4" Margin="0,10,0,10" HorizontalAlignment="Center" IsEnabled="{Binding !NightlyInstalled}" IsVisible="{Binding !NightlyInstalled}" >Get Latest Nightly Build</Button>
 							
 							</Grid>
 						</SplitView.Pane>
 
-					<v:DevModEditorView Content="{Binding ModEditor}"/>
-					
+						<SplitView.Content>
+							<v:DevModEditorView Content="{Binding ModEditor}"/>
+						</SplitView.Content>	
 				</SplitView>
 			</TabItem>
 

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -54,7 +54,7 @@
 			<WrapPanel HorizontalAlignment="Left">
 				<StackPanel>
 					<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Youtube Videos</Label>
-					<TextBlock HorizontalAlignment="Right" Margin="30,10,5,5" Foreground="Gray" FontSize="12" TextWrapping="Wrap">One link per line</TextBlock>
+					<TextBlock HorizontalAlignment="Right" Margin="30,10,5,5" Foreground="Gray" FontSize="12" TextWrapping="Wrap">One video link per line</TextBlock>
 				</StackPanel>
 				<StackPanel>
 					<TextBox Height="400" Width="400" Text="{Binding ModVideos}" Margin="5"></TextBox>
@@ -66,15 +66,15 @@
 					<Label HorizontalContentAlignment="Right" FontWeight="Bold" FontSize="18">Title Image</Label>
 					<TextBlock Margin="30,10,0,0" HorizontalAlignment="Right" Foreground="Gray" FontSize="12" TextWrapping="Wrap">This image should be 150×225 pixels large, 300KB max.</TextBlock>
 				</StackPanel>
-				<StackPanel MinWidth="225">
+				<StackPanel HorizontalAlignment="Center" MinWidth="225">
 					<Border Width="152" Height="227" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="150" Height="225" Source="{Binding TileImage}"></Image>
 					</Border>
+					<Button Command="{Binding ChangeTileImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
+					<Button Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 				</StackPanel>
 			</WrapPanel>
 			<WrapPanel Margin="160,0,0,0">
-				<Button Command="{Binding ChangeTileImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
-				<Button Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 			</WrapPanel>
 			<!--Banner Image-->
 			<WrapPanel HorizontalAlignment="Left">

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -20,7 +20,7 @@
 			<!--NAME-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" Margin="5" FontWeight="Bold" HorizontalContentAlignment="Right" FontSize="18">Name</Label>
-				<TextBox MinWidth="280" Text="{Binding ModName}" Margin="5"></TextBox>
+				<TextBox MinWidth="400" Text="{Binding ModName}" Margin="5"></TextBox>
 			</WrapPanel>
 			<!--ID-->
 			<WrapPanel HorizontalAlignment="Left">
@@ -41,31 +41,35 @@
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Description</Label>
 				<StackPanel MinWidth="280" MaxWidth="600">
-					<TextBox TextWrapping="Wrap" Height="200" Text="{Binding ModDescription}" Margin="5"></TextBox>
-					<Button Command="{Binding OpenDescriptionEditor}" Classes="Quaternary" Margin="5">Open Editor</Button>
+					<TextBox TextWrapping="Wrap" Width="400" Height="200" Text="{Binding ModDescription}" Margin="5"></TextBox>
+					<Button HorizontalAlignment="Center" Command="{Binding OpenDescriptionEditor}" Classes="Quaternary" Margin="5">Open Editor</Button>
 				</StackPanel>
 			</WrapPanel>
 			<!--FORUM-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Release Thread</Label>
-				<TextBox MinWidth="280" Text="{Binding ModForumLink}" Margin="5"></TextBox>
+				<TextBox Width="400" Text="{Binding ModForumLink}" Margin="5"></TextBox>
 			</WrapPanel>
 			<!--Videos-->
 			<WrapPanel HorizontalAlignment="Left">
-				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Youtube Videos</Label>
-				<StackPanel MinWidth="280">
-					<TextBox Height="125" Text="{Binding ModVideos}" Margin="5"></TextBox>
-					<Label Margin="5" Foreground="Yellow" FontSize="12">One link per line</Label>
+				<StackPanel>
+					<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Youtube Videos</Label>
+					<TextBlock HorizontalAlignment="Right" Margin="30,10,5,5" Foreground="Gray" FontSize="12" TextWrapping="Wrap">One link per line</TextBlock>
+				</StackPanel>
+				<StackPanel>
+					<TextBox Height="400" Width="400" Text="{Binding ModVideos}" Margin="5"></TextBox>
 				</StackPanel>
 			</WrapPanel>
 			<!--Tile Image-->
-			<WrapPanel HorizontalAlignment="Left" Margin="20,0,0,0">
-				<Label HorizontalContentAlignment="Right" FontWeight="Bold" FontSize="18">Title Image</Label>
+			<WrapPanel HorizontalAlignment="Left">
+				<StackPanel Width="150">
+					<Label HorizontalContentAlignment="Right" FontWeight="Bold" FontSize="18">Title Image</Label>
+					<TextBlock Margin="30,10,0,0" HorizontalAlignment="Right" Foreground="Gray" FontSize="12" TextWrapping="Wrap">This image should be 150×225 pixels large, 300KB max.</TextBlock>
+				</StackPanel>
 				<StackPanel MinWidth="225">
 					<Border Width="152" Height="227" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="150" Height="225" Source="{Binding TileImage}"></Image>
 					</Border>
-					<Label Margin="5,5,0,0" HorizontalAlignment="Center" Foreground="Yellow" FontSize="12">This image should be 150×225 pixels large, 300KB max.</Label>
 				</StackPanel>
 			</WrapPanel>
 			<WrapPanel Margin="160,0,0,0">
@@ -74,13 +78,15 @@
 			</WrapPanel>
 			<!--Banner Image-->
 			<WrapPanel HorizontalAlignment="Left">
-				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Banner Image</Label>
+				<StackPanel Width="150">
+					<Label HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Banner Image</Label>
+					<TextBlock HorizontalAlignment="Center" Margin="30,10,0,0" Foreground="Gray" FontSize="12" TextWrapping="Wrap">This image should be 1070x300 pixels large. 10MB max, 1MB or less recommended. APNG is supported.</TextBlock>
+				</StackPanel>
 				<StackPanel HorizontalAlignment="Left" MinWidth="300">
-					<Border Margin="45,5,5,5" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
+					<Border Margin="5,5,5,5" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="535" Height="150" Source="{Binding BannerImage}"></Image>
 					</Border>
-					<Label HorizontalAlignment="Center" Margin="0,5,0,0" Foreground="Yellow" FontSize="12">This image should be 1070x300 pixels large. 10MB max, 1MB or less recommended. APNG is supported.</Label>
-					<WrapPanel HorizontalAlignment="Center">
+					<WrapPanel Margin="160,0,0,0">
 						<Button Command="{Binding ChangeBannerImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
 						<Button Command="{Binding RemoveBannerImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
 					</WrapPanel>
@@ -91,7 +97,7 @@
 				<Label Width="150" VerticalAlignment="Center" Margin="5" FontWeight="Bold" FontSize="18">Screenshots</Label>
 				<Button Command="{Binding NewScreenShot}" Classes="Option" Margin="10">Add</Button>
 			</WrapPanel>
-			<Label HorizontalAlignment="Left" Margin="5,0,0,0" Foreground="Yellow" FontSize="12">This images will be displayed at 640x360 (16:9). 10MB max, 1MB or less recommended. APNG is supported.</Label>
+			<Label HorizontalAlignment="Left" Margin="5,0,0,0" Foreground="Gray" FontSize="12">This images will be displayed at 640x360 (16:9). 10MB max, 1MB or less recommended. APNG is supported.</Label>
 			<StackPanel>
 				<ListBox ItemsSource="{Binding Screenshots}" Margin="5,0,0,0">
 					<ListBox.ItemTemplate>

--- a/Knossos.NET/Views/Templates/DevModDetailsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModDetailsView.axaml
@@ -15,12 +15,12 @@
 	<ScrollViewer>
 		<StackPanel Margin="10,5,0,0">
 			<!--Convenience Save button-->
-			<Button Command="{Binding Save}" Classes="Accept" HorizontalAlignment="Center" Margin="5">Save Changes</Button>
+			<Button Command="{Binding Save}" Classes="Accept" HorizontalAlignment="Center" Width="160" Margin="5">Save Changes</Button>
 
 			<!--NAME-->
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" Margin="5" FontWeight="Bold" HorizontalContentAlignment="Right" FontSize="18">Name</Label>
-				<TextBox MinWidth="400" Text="{Binding ModName}" Margin="5"></TextBox>
+				<TextBox MinWidth="480" Text="{Binding ModName}" Margin="5"></TextBox>
 			</WrapPanel>
 			<!--ID-->
 			<WrapPanel HorizontalAlignment="Left">
@@ -41,41 +41,37 @@
 			<WrapPanel HorizontalAlignment="Left">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Description</Label>
 				<StackPanel MinWidth="280" MaxWidth="600">
-					<TextBox TextWrapping="Wrap" Width="400" Height="200" Text="{Binding ModDescription}" Margin="5"></TextBox>
-					<Button HorizontalAlignment="Center" Command="{Binding OpenDescriptionEditor}" Classes="Quaternary" Margin="5">Open Editor</Button>
+					<TextBox TextWrapping="Wrap" Width="480" Height="200" Text="{Binding ModDescription}" Margin="5"></TextBox>
 				</StackPanel>
 			</WrapPanel>
+			<Button HorizontalAlignment="Center" Command="{Binding OpenDescriptionEditor}" Classes="Quaternary" Margin="5,5,5,20">Open Editor</Button>
 			<!--FORUM-->
-			<WrapPanel HorizontalAlignment="Left">
+			<WrapPanel HorizontalAlignment="Left" Margin="0,0,0,20">
 				<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Release Thread</Label>
-				<TextBox Width="400" Text="{Binding ModForumLink}" Margin="5"></TextBox>
+				<TextBox Width="480" Text="{Binding ModForumLink}" Margin="5"></TextBox>
 			</WrapPanel>
 			<!--Videos-->
-			<WrapPanel HorizontalAlignment="Left">
+			<WrapPanel HorizontalAlignment="Left" Margin="0,0,0,20">
 				<StackPanel>
 					<Label Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Youtube Videos</Label>
-					<TextBlock HorizontalAlignment="Right" Margin="30,10,5,5" Foreground="Gray" FontSize="12" TextWrapping="Wrap">One video link per line</TextBlock>
+					<TextBlock HorizontalAlignment="Right" Margin="20,10,0,5" Foreground="Gray" FontSize="12" TextWrapping="Wrap">One video link per line</TextBlock>
 				</StackPanel>
 				<StackPanel>
-					<TextBox Height="400" Width="400" Text="{Binding ModVideos}" Margin="5"></TextBox>
+					<TextBox Height="400" Width="480" Text="{Binding ModVideos}" Margin="5"></TextBox>
 				</StackPanel>
 			</WrapPanel>
 			<!--Tile Image-->
 			<WrapPanel HorizontalAlignment="Left">
-				<StackPanel Width="150">
-					<Label HorizontalContentAlignment="Right" FontWeight="Bold" FontSize="18">Title Image</Label>
-					<TextBlock Margin="30,10,0,0" HorizontalAlignment="Right" Foreground="Gray" FontSize="12" TextWrapping="Wrap">This image should be 150×225 pixels large, 300KB max.</TextBlock>
+				<StackPanel>
+					<Label  Width="150" HorizontalContentAlignment="Right" Margin="5" FontWeight="Bold" FontSize="18">Title Image</Label>
+					<TextBlock Margin="30,10,0,0" Width="150" HorizontalAlignment="Right" Foreground="Gray" FontSize="12" TextWrapping="Wrap">This image should be 150×225 pixels large, 300KB max.</TextBlock>
 				</StackPanel>
-				<StackPanel HorizontalAlignment="Center" MinWidth="225">
-					<Border Width="152" Height="227" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
-						<Image Width="150" Height="225" Source="{Binding TileImage}"></Image>
-					</Border>
-					<Button Command="{Binding ChangeTileImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
-					<Button Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
-				</StackPanel>
+				<Border Width="152" Height="227" HorizontalAlignment="Center" BorderBrush="Gray" CornerRadius="2" BorderThickness="1" Margin="140,0,0,0">
+					<Image Width="150" Height="225" HorizontalAlignment="Center" Source="{Binding TileImage}"></Image>
+				</Border>
 			</WrapPanel>
-			<WrapPanel Margin="160,0,0,0">
-			</WrapPanel>
+			<Button HorizontalAlignment="Center" Command="{Binding ChangeTileImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
+			<Button HorizontalAlignment="Center" Command="{Binding RemoveTileImage}" Width="100" Classes="Cancel" Margin="5,5,5,20">Remove</Button>
 			<!--Banner Image-->
 			<WrapPanel HorizontalAlignment="Left">
 				<StackPanel Width="150">
@@ -86,18 +82,16 @@
 					<Border Margin="5,5,5,5" BorderBrush="Gray" CornerRadius="2" BorderThickness="1">
 						<Image Width="535" Height="150" Source="{Binding BannerImage}"></Image>
 					</Border>
-					<WrapPanel Margin="160,0,0,0">
-						<Button Command="{Binding ChangeBannerImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
-						<Button Command="{Binding RemoveBannerImage}" Width="100" Classes="Cancel" Margin="5">Remove</Button>
-					</WrapPanel>
 				</StackPanel>
 			</WrapPanel>
+			<Button HorizontalAlignment="Center" Command="{Binding ChangeBannerImage}" Width="100" Classes="Quaternary" Margin="5">Browse</Button>
+			<Button HorizontalAlignment="Center" Command="{Binding RemoveBannerImage}" Width="100" Classes="Cancel" Margin="5,5,5,20">Remove</Button>
 			<!--Screenshots-->
 			<WrapPanel Margin="0,15,0,0" HorizontalAlignment="Left">
 				<Label Width="150" VerticalAlignment="Center" Margin="5" FontWeight="Bold" FontSize="18">Screenshots</Label>
-				<Button Command="{Binding NewScreenShot}" Classes="Option" Margin="10">Add</Button>
+				<Label HorizontalAlignment="Left" Margin="5,0,0,0" FontSize="12">These images will be displayed at 640x360 (16:9). 10MB max, 1MB or less recommended. APNG is supported.</Label>
 			</WrapPanel>
-			<Label HorizontalAlignment="Left" Margin="5,0,0,0" Foreground="Gray" FontSize="12">This images will be displayed at 640x360 (16:9). 10MB max, 1MB or less recommended. APNG is supported.</Label>
+			<Button HorizontalAlignment="Center" Command="{Binding NewScreenShot}" Classes="Option" Width="100" Margin="10">Add</Button>
 			<StackPanel>
 				<ListBox ItemsSource="{Binding Screenshots}" Margin="5,0,0,0">
 					<ListBox.ItemTemplate>
@@ -108,14 +102,13 @@
 								<Button Command="{Binding ScDel}" Classes="Cancel">
 									<Image Height="14" Width="14" Source="/Assets/general/x.png"></Image>								
 								</Button>
-								<Image Margin="5,0,0,0" Width="320" Height="180" Source="{Binding Bitmap}"></Image>
+								<Image Margin="5,0,0,0" Width="640" Height="360" Source="{Binding Bitmap}"></Image>
 							</WrapPanel>
 						</DataTemplate>
 					</ListBox.ItemTemplate>
 				</ListBox>
 			</StackPanel>
-			<Button Command="{Binding Save}" Classes="Accept" HorizontalAlignment="Center" Margin="5">Save Changes</Button>
+			<Button Width="150" Command="{Binding Save}" Classes="Accept" HorizontalAlignment="Center" Margin="5">Save Changes</Button>
 		</StackPanel>
 	</ScrollViewer>
-	
 </UserControl>

--- a/Knossos.NET/Views/Templates/DevModEditorView.axaml
+++ b/Knossos.NET/Views/Templates/DevModEditorView.axaml
@@ -13,10 +13,10 @@
 	</Design.DataContext>
 
 	<Grid ColumnDefinitions="Auto,*">
-		<ScrollViewer Width="190" Grid.Column="0">
+		<ScrollViewer Width="190" Margin="10,0,0,0" Grid.Column="0">
 			<StackPanel Width="190" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-				<TextBlock HorizontalAlignment="Center" Text="{Binding Name}" FontSize="14" FontWeight="Bold" TextWrapping="Wrap" Margin="0"></TextBlock>
-				<Image HorizontalAlignment="Center" Margin="10" Source="{Binding ModImage}" Width="150" Height="225"></Image>
+				<TextBlock HorizontalAlignment="Center" Text="{Binding Name}" TextAlignment="Center" FontSize="14" FontWeight="Bold" TextWrapping="Wrap" Margin="0"></TextBlock>
+				<Image HorizontalAlignment="Center" Margin="10,10,5,10" Source="{Binding ModImage}" Width="150" Height="225"></Image>
 				<TextBlock HorizontalAlignment="Center" Text="Active Version" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0"></TextBlock>
 				<TextBlock HorizontalAlignment="Center" Text="{Binding Version}" FontSize="14" TextWrapping="Wrap" Margin="0"></TextBlock>
 				<!--MODS-->

--- a/Knossos.NET/Views/Templates/DevModMembersMgrView.cs.axaml
+++ b/Knossos.NET/Views/Templates/DevModMembersMgrView.cs.axaml
@@ -31,6 +31,9 @@
 					</DataTemplate>
 				</ListBox.ItemTemplate>
 			</ListBox>
+			<TextBlock Margin="20" Width="400" TextWrapping="Wrap" IsEnabled="{Binding ShowLoginError}" FontSize="20" Foreground="Red">
+				You must be logged in to Nebula to manage your mod development team.
+			</TextBlock>
 		</StackPanel>
 	</ScrollViewer>
 	

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -15,7 +15,7 @@
 	<Grid RowDefinitions="*,Auto,Auto,Auto">
 		<Grid ZIndex="1" Grid.Row="0" RowDefinitions="Auto,*, Auto, Auto" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
 			<WrapPanel IsEnabled="{Binding ButtonsEnabled}" Grid.Row="0" Margin="10" HorizontalAlignment="Center">
-				<Button Classes="Primary" Content="New Version" x:Name="CreateVersion">
+				<Button Classes="Primary" Content="Create New Version" Margin="10,0,0,0" Width="200" x:Name="CreateVersion">
 					<Button.Flyout>
 						<Flyout>
 							<StackPanel>
@@ -29,11 +29,11 @@
 						</Flyout>
 					</Button.Flyout>
 				</Button>
-				<Button Command="{Binding LoadVersionsFromNebula}" Classes="Settings" Margin="20,0,0,0">Install or Modify</Button>
-				<Button Command="{Binding DeleteAll}" Classes="Cancel" Margin="20,0,0,0">Delete Mod</Button>
+				<Button Command="{Binding CreateDevEnv}" IsVisible="{Binding !ModHasDevEnvVersion}" Classes="Primary" Margin="20,0,0,0" Width="200">Create Developer Version</Button>
 			</WrapPanel>
-			<WrapPanel HorizontalAlignment="Center" Grid.Row="0" Margin="10,45,10,10">
-				<Button Command="{Binding CreateDevEnv}" IsVisible="{Binding !ModHasDevEnvVersion}" Classes="Quaternary" Margin="0,0,190,0">Create DevEnv Version</Button>
+			<WrapPanel HorizontalAlignment="Center" Grid.Row="0" Margin="10,50,10,10">
+				<Button Command="{Binding LoadVersionsFromNebula}" Classes="Quaternary" Margin="10,0,0,0" Width="200">Install or Modify Locally</Button>
+				<Button Command="{Binding DeleteAll}" Classes="Cancel" Margin="20,0,0,0" Width="200">Delete All Local Versions</Button>
 			</WrapPanel>
 			<ListBox Background="{StaticResource BackgroundColorSecondary}" IsEnabled="{Binding ButtonsEnabled}" Margin="10,0,10,10" Grid.Row="1" ItemsSource="{Binding Mods}" SelectedIndex="{Binding SelectedIndex}" HorizontalAlignment="Stretch" MinHeight="180">
 				<ListBox.ItemTemplate>
@@ -48,15 +48,15 @@
 				</ListBox.ItemTemplate>
 			</ListBox>
 		</Grid>
-		<Label Grid.Row="1" Margin="0,0,0,0" HorizontalAlignment="Center">Actions for Active Version</Label>
+		<Label Grid.Row="1" Margin="0,0,0,0" HorizontalAlignment="Center">Actions to Apply to Active Version</Label>
 		<WrapPanel Grid.Row="2" Margin="0,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-			<Button Width="146" Margin="0,0,20,0" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Settings">Upload to Nebula</Button>
-			<Button Width="146" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadModAdvanced}" Classes="Secondary">Advanced Upload</Button>
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Settings" Margin="24,0,0,0"/>
+			<Button Width="150" Margin="0,0,0,0" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Settings">Upload to Nebula</Button>
+			<Button Width="150" Margin="20,0,0,0" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadModAdvanced}" Classes="Secondary">Advanced Upload</Button>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Settings" Width="150" Margin="24,0,0,0"/>
 		</WrapPanel>
-		<WrapPanel Grid.Row="3" Margin="0,8,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Margin="0,0,5,0">Delete from Nebula</Button>
-			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="18,0,0,0">Delete Locally</Button>
+		<WrapPanel Grid.Row="3" Margin="0,10,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Width="150" Margin="0,0,0,0">Delete from Nebula</Button>
+			<Button Command="{Binding DeleteLocally}" Classes="Cancel" Margin="20,0,0,0" Width="150">Delete Locally</Button>
 		</WrapPanel>
 	</Grid>
 	

--- a/Knossos.NET/Views/Templates/DevModVersionsView.axaml
+++ b/Knossos.NET/Views/Templates/DevModVersionsView.axaml
@@ -32,7 +32,7 @@
 				<Button Command="{Binding CreateDevEnv}" IsVisible="{Binding !ModHasDevEnvVersion}" Classes="Primary" Margin="20,0,0,0" Width="200">Create Developer Version</Button>
 			</WrapPanel>
 			<WrapPanel HorizontalAlignment="Center" Grid.Row="0" Margin="10,50,10,10">
-				<Button Command="{Binding LoadVersionsFromNebula}" Classes="Quaternary" Margin="10,0,0,0" Width="200">Install or Modify Locally</Button>
+				<Button Command="{Binding LoadVersionsFromNebula}" Classes="Quaternary" Margin="10,0,0,0" Width="200" ToolTip.Tip="Install a new version of a developed mod from Nebula. Local installation of development mods should not be modified. Package addition and removal for testing can be handled in the packages tab.">Install Locally</Button>
 				<Button Command="{Binding DeleteAll}" Classes="Cancel" Margin="20,0,0,0" Width="200">Delete All Local Versions</Button>
 			</WrapPanel>
 			<ListBox Background="{StaticResource BackgroundColorSecondary}" IsEnabled="{Binding ButtonsEnabled}" Margin="10,0,10,10" Grid.Row="1" ItemsSource="{Binding Mods}" SelectedIndex="{Binding SelectedIndex}" HorizontalAlignment="Stretch" MinHeight="180">
@@ -49,10 +49,10 @@
 			</ListBox>
 		</Grid>
 		<Label Grid.Row="1" Margin="0,0,0,0" HorizontalAlignment="Center">Actions to Apply to Active Version</Label>
-		<WrapPanel Grid.Row="2" Margin="0,4,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
-			<Button Width="150" Margin="0,0,0,0" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Settings">Upload to Nebula</Button>
+		<WrapPanel Grid.Row="2" Margin="0,5,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
+			<Button Width="150" Margin="0,0,0,0" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadMod}" Classes="Primary">Upload to Nebula</Button>
 			<Button Width="150" Margin="20,0,0,0" IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding UploadModAdvanced}" Classes="Secondary">Advanced Upload</Button>
-			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Settings" Width="150" Margin="24,0,0,0"/>
+			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding ChangeVisibility}" Content="{Binding VisibilityButtonText}" Classes="Primary" Width="150" Margin="20,0,0,0"/>
 		</WrapPanel>
 		<WrapPanel Grid.Row="3" Margin="0,10,0,0" HorizontalAlignment="Center" IsEnabled="{Binding ButtonsEnabled}">
 			<Button IsVisible="{Binding !IsDevEnvVersion}" Command="{Binding DeleteNebula}" Classes="Cancel" Width="150" Margin="0,0,0,0">Delete from Nebula</Button>


### PR DESCRIPTION
Formatting changes to the dev tab, specifically, make the buttons make sense on versions sub tab, line up everything on the details sub tab, and warn the user when they are not logged in in the Members subtab.

If someone with an active member list could test this patch to make sure it still works, I would be grateful!

![Screenshot 2025-02-27 234007](https://github.com/user-attachments/assets/49909c12-2051-4070-9d3a-dec9d5590fae)

![Screenshot 2025-02-27 234038](https://github.com/user-attachments/assets/063001e8-8dff-442e-b053-4bc0fbad0657)

![Screenshot 2025-02-27 234052](https://github.com/user-attachments/assets/91d5fcbd-84f4-4836-9f90-6f781eae0117)

![Screenshot 2025-02-27 234109](https://github.com/user-attachments/assets/1d3ee4c6-ba6c-4bf4-abf1-3dee16cd598a)

![Screenshot 2025-02-27 234952](https://github.com/user-attachments/assets/3248507a-d836-45c2-9f77-1ad2fcb84781)
