### PR TITLE
Only have the qtfred button appear when qtfred is available

### DIFF
--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -1024,5 +1024,68 @@ namespace Knossos.NET.Models
             }
             return null;
         }
+
+        /// <summary>
+        /// Check to see if a mod has a qtfred build
+        /// used mainly to see if we should create a qtfred button on the mod tiles
+        /// </summary>
+        public bool[] IsQtFredAvailable()
+        {
+            FsoBuild? fsoBuild = null;
+
+            /* Resolve Dependencies should be all valid at this point */
+            var dependencyList = GetModDependencyList(false,true);
+            if (dependencyList != null)
+            {
+                foreach (var dep in dependencyList)
+                {
+                    var selectedMod = dep.SelectMod();
+                    if (selectedMod == null)
+                    {
+                        /* 
+                            It has to be the engine dependency ... based on what shivanSPS commented elsewhere - Cyborg
+                        */
+                        if (fsoBuild == null && modSettings.customBuildId == null)
+                        {
+                            fsoBuild = dep.SelectBuild(true);
+                        }
+                    }
+                }
+            }
+
+            if (fsoBuild == null)
+            {
+                if (modSettings.customBuildExec == null)
+                {
+                    fsoBuild = Knossos.GetInstalledBuildsList().FirstOrDefault(builds => builds.id == modSettings.customBuildId && builds.version == modSettings.customBuildVersion);
+                }
+                else
+                {
+                    fsoBuild = new FsoBuild(modSettings.customBuildExec);
+                }            
+            }
+
+            bool[] result = { false, false };
+
+            if (fsoBuild == null)
+            {
+                return result;
+            }
+
+            var exe = fsoBuild.GetExecutable(FsoExecType.QtFred);
+            var exe2 = fsoBuild.GetExecutable(FsoExecType.QtFredDebug);
+            
+            if (exe != null)
+            {
+                result[0] = true;
+            }
+
+            if (exe != null)
+            {
+                result[1] = true;
+            }
+
+            return result;
+        }        
     }
 }

--- a/Knossos.NET/ViewModels/Templates/ModCardViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/ModCardViewModel.cs
@@ -80,6 +80,10 @@ namespace Knossos.NET.ViewModels
         internal bool isCustomConfig = false;
         [ObservableProperty]
         internal bool cardVisible = true;
+        [ObservableProperty]
+        internal bool isQtFredAvailable = false;
+        [ObservableProperty]
+        internal bool isQtFredDebugAvailable = false;
         private Bitmap? tileModBitmap;
 
         /* Should only be used by the editor preview */
@@ -176,6 +180,8 @@ namespace Knossos.NET.ViewModels
                         });
                     }
                 }
+
+                RefreshQtFredAvailability();
             });
         }
 
@@ -201,6 +207,7 @@ namespace Knossos.NET.ViewModels
                 LoadImage();
                 CheckDependencyActiveVersion();
                 RefreshSpecialIcons();
+                RefreshQtFredAvailability();
             }
         }
 
@@ -251,6 +258,20 @@ namespace Knossos.NET.ViewModels
         public void RefreshSpecialIcons()
         {
             IsCustomConfig = !modVersions[activeVersionIndex].modSettings.IsDefaultConfig();
+        }
+
+        public void RefreshQtFredAvailability()
+        {
+            var bools = modVersions[activeVersionIndex].IsQtFredAvailable();
+
+            if (bools == null || bools.Length < 2){
+                IsQtFredAvailable = false;
+                IsQtFredDebugAvailable = false;
+                return;
+            }
+
+            IsQtFredAvailable = bools[0];
+            IsQtFredDebugAvailable = bools[1];
         }
 
         /* Button Commands */

--- a/Knossos.NET/Views/Templates/ModCardView.axaml
+++ b/Knossos.NET/Views/Templates/ModCardView.axaml
@@ -57,8 +57,8 @@
 					</TabItem.Header>
 					<StackPanel Margin="5">
 						<Button Command="{Binding ButtonCommand}" CommandParameter="playvr" Content="Play in VR" Classes="Accept Rounded" HorizontalAlignment="Center" Margin="0,2,0,0" Width="100" ></Button>
-						<Button Command="{Binding ButtonCommand}" CommandParameter="fred2" Content="Fred2" Classes="Secondary Rounded" HorizontalAlignment="Center" Margin="0,2,0,0" Width="100" ></Button>
-						<Button Command="{Binding ButtonCommand}" CommandParameter="qtfred" Content="QtFred" Classes="Settings Rounded" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="100" ></Button>
+						<Button Command="{Binding ButtonCommand}" CommandParameter="fred2" Content="Fred2" Classes="Secondary Rounded" HorizontalAlignment="Center" Margin="0,2,0,0" Width="100" ></Button>						
+						<Button Command="{Binding ButtonCommand}" CommandParameter="qtfred" Content="QtFred" Classes="Settings Rounded" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="100" IsVisible="{Binding IsQtFredAvailable}"></Button>
 						<Button Command="{Binding ButtonCommand}" CommandParameter="delete" Content="Delete" Classes="Cancel Rounded" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="100" ></Button>
 					</StackPanel>
 				</TabItem>
@@ -69,7 +69,7 @@
 					<StackPanel Margin="5">
 						<Button Command="{Binding ButtonCommand}" CommandParameter="debug" Content="FSO Debug" Classes="Primary Rounded" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
 						<Button Command="{Binding ButtonCommand}" CommandParameter="fred2debug" Content="Fred2 Debug" Classes="Secondary Rounded" HorizontalAlignment="Center" Margin="0,2,0,0" Width="115" ></Button>
-						<Button Command="{Binding ButtonCommand}" CommandParameter="qtfreddebug" Content="QtFred Debug" Classes="Settings Rounded" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
+						<Button Command="{Binding ButtonCommand}" CommandParameter="qtfreddebug" Content="QtFred Debug" Classes="Settings Rounded" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" IsVisible="{Binding IsQtFredDebugAvailable}"></Button>
 						<Button Command="{Binding ButtonCommand}" CommandParameter="logfile" Content="Open Logfile" Classes="Quaternary Rounded" HorizontalAlignment="Center"  Margin="0,2,0,0" Width="115" ></Button>
 					</StackPanel>
 				</TabItem>


### PR DESCRIPTION
Disallow the qtfred and qtfred debug buttons when those builds are not available.  Tested using 22.2 and 24.2]