### PR TITLE
Fix improper file copy and improve "import local build" window

### DIFF
--- a/Knossos.NET/ViewModels/FsoBuildsViewModel.cs
+++ b/Knossos.NET/ViewModels/FsoBuildsViewModel.cs
@@ -342,7 +342,7 @@ namespace Knossos.NET.ViewModels
             if (MainWindow.instance != null)
             {
                 var dialog = new AddUserBuildView();
-                dialog.DataContext = new AddUserBuildViewModel();
+                dialog.DataContext = new AddUserBuildViewModel(dialog);
 
                 await dialog.ShowDialog<AddUserBuildView?>(MainWindow.instance);
             }

--- a/Knossos.NET/ViewModels/Windows/AddUserBuildViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/AddUserBuildViewModel.cs
@@ -350,7 +350,7 @@ namespace Knossos.NET.ViewModels
                 CollapseData = true;
                 CollapseExecs = true;
                 CollapseArch = true;
-                string[] ignoreList = { ".pdb", ".lib", ".exp", ".a" };
+                string[] ignoreList = { ".pdb", ".lib", ".exp", ".a", ".map" };
                 if(await KnUtils.CopyDirectoryAsync(folderPath, BuildNewPath, true, new CancellationTokenSource(), copyCallback, ignoreList))
                 {
                     Mod mod = new Mod();

--- a/Knossos.NET/ViewModels/Windows/AddUserBuildViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/AddUserBuildViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Platform.Storage;
+﻿using Avalonia.Controls;
+using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Knossos.NET.Classes;
@@ -8,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Knossos.NET.ViewModels
@@ -55,8 +57,6 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal bool riscv64 = false;
         [ObservableProperty]
-        internal bool modCreated = false;
-        [ObservableProperty]
         internal int copyProgress = 0;
         [ObservableProperty]
         internal int maxFiles = 100;
@@ -64,12 +64,24 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string buildNewPath = string.Empty;
 
+        [ObservableProperty]
+        internal bool collapseData = false;
+        [ObservableProperty]
+        internal bool collapseArch = false;
+        [ObservableProperty]
+        internal bool collapseExecs = false;
+
         private string buildId = string.Empty;
         private string? folderPath = null;
-
+        private Window? window = null;
 
         public AddUserBuildViewModel() 
         {
+        }
+
+        public AddUserBuildViewModel(Window window)
+        {
+            this.window = window;
         }
 
         internal async void OpenFolderCommand()
@@ -83,15 +95,15 @@ namespace Knossos.NET.ViewModels
                     string[] execs;
                     if (KnUtils.IsWindows)
                     {
-                        execs=Directory.GetFiles(folderPath, "*.exe");
+                        execs=Directory.GetFiles(folderPath, "*.exe", SearchOption.AllDirectories);
                     }
                     else if (KnUtils.IsMacOS)
                     {
-                        execs=Directory.GetDirectories(folderPath, "*.app");
+                        execs=Directory.GetDirectories(folderPath, "*.app", SearchOption.AllDirectories);
                     }
                     else
                     {
-                        execs=Directory.GetFiles(folderPath, "*.AppImage");
+                        execs=Directory.GetFiles(folderPath, "*.AppImage", SearchOption.AllDirectories);
                     }
                     ScanResults += "\nDetected Executables: " + execs.Count();
                     foreach (string exe in execs)
@@ -103,7 +115,7 @@ namespace Knossos.NET.ViewModels
                             {
                                 if (file.Name.ToLower().Contains("fs2_open"))
                                 {
-                                    DebugFile = file.Name;
+                                    DebugFile = Path.GetRelativePath(folderPath, exe);
                                     if (BuildVersion == string.Empty)
                                     {
                                         ParseVersion(file.Name);
@@ -114,7 +126,7 @@ namespace Knossos.NET.ViewModels
                                 {
                                     if (file.Name.ToLower().Contains("fred2_open"))
                                     {
-                                        Fred2Debug = file.Name;
+                                        Fred2Debug = Path.GetRelativePath(folderPath, exe);
                                         if (BuildVersion == string.Empty)
                                         {
                                             ParseVersion(file.Name);
@@ -125,7 +137,7 @@ namespace Knossos.NET.ViewModels
                                     {
                                         if (file.Name.ToLower().Contains("qtfred"))
                                         {
-                                            QtFredDebug = file.Name;
+                                            QtFredDebug = Path.GetRelativePath(folderPath, exe);
                                         }
                                     }
                                 }
@@ -134,7 +146,7 @@ namespace Knossos.NET.ViewModels
                             {
                                 if (file.Name.ToLower().Contains("fs2_open"))
                                 {
-                                    Release = file.Name;
+                                    Release = Path.GetRelativePath(folderPath, exe);
                                     if (BuildVersion == string.Empty)
                                     {
                                         ParseVersion(file.Name);
@@ -145,7 +157,7 @@ namespace Knossos.NET.ViewModels
                                 {
                                     if (file.Name.ToLower().Contains("fred2_open"))
                                     {
-                                        Fred2 = file.Name;
+                                        Fred2 = Path.GetRelativePath(folderPath, exe);
                                         if (BuildVersion == string.Empty)
                                         {
                                             ParseVersion(file.Name);
@@ -156,7 +168,7 @@ namespace Knossos.NET.ViewModels
                                     {
                                         if (file.Name.ToLower().Contains("qtfred"))
                                         {
-                                            QtFred = file.Name;
+                                            QtFred = Path.GetRelativePath(folderPath, exe);
                                         }
                                     }
                                 }
@@ -224,7 +236,10 @@ namespace Knossos.NET.ViewModels
                 FolderPickerOpenOptions options = new FolderPickerOpenOptions();
                 options.AllowMultiple = false;
                 options.Title = "Select the folder containing the FSO execs files";
-                var result = await MainWindow.instance.StorageProvider.OpenFolderPickerAsync(options);
+
+                var topmostWindow = window == null ? MainWindow.instance : window; 
+
+                var result = await topmostWindow.StorageProvider.OpenFolderPickerAsync(options);
                 if (result != null && result.Count > 0)
                     return result[0].Path.LocalPath.ToString();
                 else
@@ -304,22 +319,20 @@ namespace Knossos.NET.ViewModels
 
         public async Task<string?> GetPath(string? folderRoot)
         {
-            if(MainWindow.instance != null && folderPath != null)
+            if(MainWindow.instance != null && folderRoot != null)
             {
                 FilePickerOpenOptions options = new FilePickerOpenOptions();
                 options.AllowMultiple = false;
                 options.Title = "Select the executable file";
-                if (folderRoot != null)
-                {
-                    options.SuggestedStartLocation = await MainWindow.instance.StorageProvider.TryGetFolderFromPathAsync(folderRoot);
-                }
+                options.SuggestedStartLocation = await MainWindow.instance.StorageProvider.TryGetFolderFromPathAsync(folderRoot);
 
-                var result = await MainWindow.instance.StorageProvider.OpenFilePickerAsync(options);
+                var topmostWindow = window == null ? MainWindow.instance : window;
+
+                var result = await topmostWindow.StorageProvider.OpenFilePickerAsync(options);
 
                 if (result != null && result.Count > 0)
                 {
-                    var file = new FileInfo(result[0].Path.LocalPath.ToString());
-                    return file.Name;
+                    return Path.GetRelativePath(folderRoot, result[0].Path.LocalPath.ToString());
                 }
             }
             return null;
@@ -331,10 +344,14 @@ namespace Knossos.NET.ViewModels
             {
                 return;
             }
-
+            
             if (folderPath != null)
             {
-                if(await CopyFilesRecursively(folderPath, BuildNewPath))
+                CollapseData = true;
+                CollapseExecs = true;
+                CollapseArch = true;
+                string[] ignoreList = { ".pdb", ".lib", ".exp", ".a" };
+                if(await KnUtils.CopyDirectoryAsync(folderPath, BuildNewPath, true, new CancellationTokenSource(), copyCallback, ignoreList))
                 {
                     Mod mod = new Mod();
                     mod.fullPath = BuildNewPath + Path.DirectorySeparatorChar;
@@ -485,7 +502,14 @@ namespace Knossos.NET.ViewModels
                     Knossos.AddBuild(userBuild);
                     FsoBuildsViewModel.Instance?.AddBuildToUi(userBuild);
 
-                    ModCreated = true;
+                    Dispatcher.UIThread.Invoke(() => { window?.Close(); });
+                }
+                else
+                {
+                    CollapseData = false;
+                    CollapseExecs = false;
+                    CollapseArch = false;
+                    await MessageBox.Show(window, "An error has ocurred while copying files", "Filecopy error", MessageBox.MessageBoxButtons.OK);
                 }
             }
         }
@@ -531,37 +555,10 @@ namespace Knossos.NET.ViewModels
             return true;
         }
 
-        private async Task<bool> CopyFilesRecursively(string sourcePath, string targetPath)
+        private async void copyCallback(string filename)
         {
-            return await Task<bool>.Factory.StartNew(() => { 
-                try
-                {
-                    Directory.CreateDirectory(targetPath);
-                    foreach (string dirPath in Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories))
-                    {
-                        Directory.CreateDirectory(dirPath.Replace(sourcePath, targetPath));
-                    }
-                    var allFiles = Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories);
-                    Dispatcher.UIThread.Invoke(()=> MaxFiles = allFiles.Length );
-                    foreach (string newPath in Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories))
-                    {
-                        if (!newPath.ToLower().Contains(".pdb") && !newPath.ToLower().Contains(".lib") && !newPath.ToLower().Contains(".exp") && !newPath.ToLower().EndsWith(".a"))
-                        {
-                            System.IO.File.Copy(newPath, newPath.Replace(sourcePath, targetPath), true);
-                        }
-                        Dispatcher.UIThread.Invoke(() => CopyProgress++);
-                    }
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    Log.Add(Log.LogSeverity.Error, "AddUserBuildViewModel.CopyFilesRecursively()", ex);
-                    if (MainWindow.instance != null)
-                    {
-                        MessageBox.Show(MainWindow.instance, "Error while copying files:\n"+ex.Message.ToString(), "Filecopy error", MessageBox.MessageBoxButtons.OK);
-                    }
-                    return false;
-                }
+            await Dispatcher.UIThread.InvokeAsync(() => {
+                CopyProgress++;
             });
         }
     }

--- a/Knossos.NET/Views/Windows/AddUserBuildView.axaml
+++ b/Knossos.NET/Views/Windows/AddUserBuildView.axaml
@@ -2,15 +2,15 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        mc:Ignorable="d" d:DesignWidth="550" d:DesignHeight="600"
         x:Class="Knossos.NET.Views.Windows.AddUserBuildView"
 	    xmlns:v="using:Knossos.NET.Views"
 		xmlns:vm="using:Knossos.NET.ViewModels"
 		x:DataType="vm:AddUserBuildViewModel"
 		Icon="/Assets/knossos-icon.ico"
 		WindowStartupLocation="CenterScreen"
-        Title="Add Custom FSO Build" 
-		SizeToContent="Width"
+        Title="Add Custom FSO Build"
+		Width="550"
 		Height="600"
 		CanResize="True">
 	
@@ -19,49 +19,71 @@
 	</Design.DataContext>
 
 	<ScrollViewer Background="{StaticResource BackgroundColorPrimary}">
-	<Grid RowDefinitions="*,Auto,Auto">
+	<Grid Margin="5" RowDefinitions="*,Auto,Auto">
 		<StackPanel Grid.Row="0" IsEnabled="{Binding !CopyProgress}">
 			<Label>1) Click on the button and select the folders where the executables are located.</Label>
 			<Button Classes="Secondary" Command="{Binding OpenFolderCommand}">Open Folder</Button>
 			<TextBlock TextWrapping="Wrap" Text="{Binding ScanResults}"></TextBlock>
 			<StackPanel Margin="0,15,0,0" IsVisible="{Binding Stage2}">
 				<Label>2) Verify autodetect values and update if needed</Label>
-				<WrapPanel>
-					<CheckBox IsChecked="{Binding X86}" Margin="5">X86</CheckBox>
-					<CheckBox IsChecked="{Binding X64}" Margin="5">X64</CheckBox>
-					<CheckBox IsChecked="{Binding AVX}" Margin="5">AVX</CheckBox>
-					<CheckBox IsChecked="{Binding AVX2}" Margin="5">AVX2</CheckBox>
-					<CheckBox IsChecked="{Binding Arm32}" Margin="5">ARM32</CheckBox>
-					<CheckBox IsChecked="{Binding Arm64}" Margin="5">ARM64</CheckBox>
-					<CheckBox IsChecked="{Binding Riscv32}" Margin="5">RISCV32</CheckBox>
-					<CheckBox IsChecked="{Binding Riscv64}" Margin="5">RISCV64</CheckBox>
-				</WrapPanel>
-				<Label Margin="0,10,0,0" FontWeight="Bold">Release</Label>
-				<TextBlock TextWrapping="Wrap" Text="{Binding Release}"></TextBlock>
-				<Button Command="{Binding ChangeReleaseCommand}">Select Release</Button>
-				<Label Margin="0,10,0,0" FontWeight="Bold">Debug</Label>
-				<TextBlock TextWrapping="Wrap" Text="{Binding DebugFile}"></TextBlock>
-				<Button Command="{Binding ChangeDebugCommand}">Select Debug</Button>
-				<Label Margin="0,10,0,0" FontWeight="Bold">Fred2</Label>
-				<TextBlock TextWrapping="Wrap" Text="{Binding Fred2}"></TextBlock>
-				<Button Command="{Binding ChangeFred2Command}">Select Fred2</Button>
-				<Label Margin="0,10,0,0" FontWeight="Bold">Fred2 Debug</Label>
-				<TextBlock TextWrapping="Wrap" Text="{Binding Fred2Debug}"></TextBlock>
-				<Button Command="{Binding ChangeFred2DebugCommand}">Select Fred2 Debug</Button>
-				<Label Margin="0,10,0,0" FontWeight="Bold">QtFred</Label>
-				<TextBlock TextWrapping="Wrap" Text="{Binding QtFred}"></TextBlock>
-				<Button Command="{Binding ChangeQtFredCommand}">Select QtFred</Button>
-				<Label Margin="0,10,0,0" FontWeight="Bold">QtFred Debug</Label>
-				<TextBlock TextWrapping="Wrap" Text="{Binding QtFredDebug}"></TextBlock>
-				<Button Command="{Binding ChangeQtFredDebugCommand}">Select QtFred Debug</Button>
-				<Label Margin="0,20,0,0" FontWeight="Bold">Build Version</Label>
-				<TextBox Width="200" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding BuildVersion}"></TextBox>
-				<Label>*Required, it has to be a valid semantic version.</Label>
-				<Label Margin="0,20,0,0" FontWeight="Bold">Build Name</Label>
-				<TextBox Width="200" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding BuildName}"></TextBox>
-				<Label>*Required</Label>
+				<Expander Margin="5" VerticalAlignment="Top" HorizontalAlignment="Stretch" IsExpanded="{Binding !CollapseData}">
+					<Expander.Header>
+						Build Data
+					</Expander.Header>
+					<StackPanel>
+						<Label FontWeight="Bold">Build Version</Label>
+						<TextBox Width="200" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding BuildVersion}"></TextBox>
+						<Label>*Required, it has to be a valid semantic version.</Label>
+						<Label Margin="0,20,0,0" FontWeight="Bold">Build Name</Label>
+						<TextBox Width="200" HorizontalAlignment="Left" TextWrapping="Wrap" Text="{Binding BuildName}"></TextBox>
+						<Label>*Required</Label>
+					</StackPanel>
+				</Expander>
+				<Expander Margin="5" VerticalAlignment="Top" HorizontalAlignment="Stretch" IsExpanded="{Binding !CollapseArch}">
+					<Expander.Header>
+						Build CPU Arch
+					</Expander.Header>
+					<StackPanel>
+						<WrapPanel>
+							<CheckBox IsChecked="{Binding X86}" Margin="5">X86</CheckBox>
+							<CheckBox IsChecked="{Binding X64}" Margin="5">X64</CheckBox>
+							<CheckBox IsChecked="{Binding AVX}" Margin="5">AVX</CheckBox>
+							<CheckBox IsChecked="{Binding AVX2}" Margin="5">AVX2</CheckBox>
+							<CheckBox IsChecked="{Binding Arm64}" Margin="5">ARM64</CheckBox>
+							<CheckBox IsChecked="{Binding Riscv64}" Margin="5">RISCV64</CheckBox>
+							<CheckBox IsChecked="{Binding Riscv32}" Margin="5">RISCV32</CheckBox>
+							<CheckBox IsChecked="{Binding Arm32}" Margin="5">ARM32</CheckBox>
+						</WrapPanel>
+					</StackPanel>
+				</Expander>
+
+				<Expander Margin="5" VerticalAlignment="Top" HorizontalAlignment="Stretch" IsExpanded="{Binding !CollapseExecs}">
+					<Expander.Header>
+						Build Executables
+					</Expander.Header>
+					<StackPanel>
+						<Label Margin="0,0,0,0" FontWeight="Bold">Release</Label>
+						<TextBlock TextWrapping="Wrap" Text="{Binding Release}"></TextBlock>
+						<Button Command="{Binding ChangeReleaseCommand}">Select Release</Button>
+						<Label Margin="0,10,0,0" FontWeight="Bold">Debug</Label>
+						<TextBlock TextWrapping="Wrap" Text="{Binding DebugFile}"></TextBlock>
+						<Button Command="{Binding ChangeDebugCommand}">Select Debug</Button>
+						<Label Margin="0,10,0,0" FontWeight="Bold">Fred2</Label>
+						<TextBlock TextWrapping="Wrap" Text="{Binding Fred2}"></TextBlock>
+						<Button Command="{Binding ChangeFred2Command}">Select Fred2</Button>
+						<Label Margin="0,10,0,0" FontWeight="Bold">Fred2 Debug</Label>
+						<TextBlock TextWrapping="Wrap" Text="{Binding Fred2Debug}"></TextBlock>
+						<Button Command="{Binding ChangeFred2DebugCommand}">Select Fred2 Debug</Button>
+						<Label Margin="0,10,0,0" FontWeight="Bold">QtFred</Label>
+						<TextBlock TextWrapping="Wrap" Text="{Binding QtFred}"></TextBlock>
+						<Button Command="{Binding ChangeQtFredCommand}">Select QtFred</Button>
+						<Label Margin="0,10,0,0" FontWeight="Bold">QtFred Debug</Label>
+						<TextBlock TextWrapping="Wrap" Text="{Binding QtFredDebug}"></TextBlock>
+						<Button Command="{Binding ChangeQtFredDebugCommand}">Select QtFred Debug</Button>
+					</StackPanel>
+				</Expander>
 			</StackPanel>
-			<StackPanel IsVisible="{Binding Stage2}" Margin="0,30,0,0">
+			<StackPanel IsVisible="{Binding Stage2}" Margin="5,30,0,0">
 				<Label>3) Click the button when ready, the folder will be copied to:</Label>
 				<TextBlock TextWrapping="Wrap" Text="{Binding BuildNewPath}"></TextBlock>
 				<Label>Any (.lib, .a, .pdb and .exp) will be ignored, and a mod.json file will be generated.</Label>
@@ -69,7 +91,6 @@
 			</StackPanel>
 		</StackPanel>
 		<ProgressBar Grid.Row="1" IsVisible="{Binding CopyProgress}" Value="{Binding CopyProgress}" Maximum="{Binding MaxFiles}" Height="50" Minimum="0" Width="200" HorizontalAlignment="Center"></ProgressBar>
-		<Label Grid.Row="2" IsVisible="{Binding ModCreated}" HorizontalAlignment="Center" FontWeight="Bold">Complete!</Label>
 	</Grid>
 	</ScrollViewer>
 </Window>


### PR DESCRIPTION
This fixes the problems ive been encountering on linux by using the import local build function where build files where copied to an incorrect folder.

Additionally:

1) I reworked the look of the window a bit, added expanders and auto close on finish.

2) Changed the open file / open folder dialogs to use this window as the base rather than the mainwindow, this avoids the posibility of the dialog to be open hidden behind the import local build window.
This same method needs to be applied to other dialogs where a file open or folder open dialog is involved, but will be done on a separated PR.

As for the file copy fix, it mostly involves removing the specific folder copy method used here and instead adapt the one on KnUtils to be usable for this task.