### PR TITLE
remove checksum generation step

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -174,12 +174,6 @@ jobs:
           ARCH: aarch64
         run: ${{ github.workspace }}/ci/create_appimage.sh
 
-      - name: Generate checksums
-        run: |
-          cd $OUTPUT_DIR
-          sha256sum *.* >checksums.txt
-          cat checksums.txt
-
       - name: Generate Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
GitHub will now do this for us automatically and in a more secure fashion. These new checksums will be displayed next to each release asset as well as being available through the REST API and gh CLI app.

Note that this feature only applies to new releases, not existing ones.

https://github.blog/changelog/2025-06-03-releases-now-expose-digests-for-release-assets/