### PR TITLE
fix issues with spaces in path to binaries

### DIFF
--- a/Knossos.NET/Classes/FsoBuild.cs
+++ b/Knossos.NET/Classes/FsoBuild.cs
@@ -266,11 +266,11 @@ namespace Knossos.NET.Models
                             fso.StartInfo.FileName = prefixCMD[0];
                             if (prefixCMD.Length > 1)
                             {
-                                fso.StartInfo.Arguments = prefixCMD[1] + " " + execPath + " " + cmdline;
+                                fso.StartInfo.Arguments = $"{prefixCMD[1]} \"{execPath}\" {cmdline}";
                             }
                             else
                             {
-                                fso.StartInfo.Arguments = execPath + " " + cmdline;
+                                fso.StartInfo.Arguments = $"\"{execPath}\" {cmdline}";
                             }
                         }
 

--- a/Knossos.NET/Classes/Wine.cs
+++ b/Knossos.NET/Classes/Wine.cs
@@ -53,7 +53,7 @@ namespace Knossos.NET.Classes
                 using (var wine = new Process())
                 {
                     wine.StartInfo.FileName = "wine";
-                    wine.StartInfo.Arguments = exePath + " " + exeCmdLine;
+                    wine.StartInfo.Arguments = $"\"{exePath}\" {exeCmdLine}";
                     if (workingFolder != null)
                     {
                         wine.StartInfo.WorkingDirectory = workingFolder;
@@ -102,7 +102,7 @@ namespace Knossos.NET.Classes
                 using (var wine = new Process())
                 {
                     wine.StartInfo.FileName = "wine";
-                    wine.StartInfo.Arguments = exePath + " " + exeCmdLine;
+                    wine.StartInfo.Arguments = $"\"{exePath}\" {exeCmdLine}";
                     if (workingFolder != null)
                     {
                         wine.StartInfo.WorkingDirectory = workingFolder;


### PR DESCRIPTION
Fix issue running binaries via Wine if the exec path contains spaces or other special characters.

A similar issue was noted from the code if running FSO builds with the `prefix_cmd` option set. However it was not clear if this option could be set via the GUI or just the json config and a proper test was not conducted to confirm it still works as expected.