### PR TITLE
change talos to hestia

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -75,7 +75,7 @@ namespace Knossos.NET.Models
         //https://dl.fsnebula.org/storage/repo.json
         //https://fsnebula.org/storage/repo.json"
 
-        public static string[] nebulaMirrors = { "cf.fsnebula.org", "dl.fsnebula.org", "fsnebula.org", "talos.feralhosting.com", "fsnebula.global.ssl.fastly.net" }; //lowercase, last one is the image host
+        public static string[] nebulaMirrors = { "cf.fsnebula.org", "dl.fsnebula.org", "fsnebula.org", "hestia.feralhosting.com", "fsnebula.global.ssl.fastly.net" }; //lowercase, last one is the image host
         private static readonly string repoUrl = @"https://fsnebula.org/storage/repo_minimal.json";
         private static readonly string apiURL = @"https://api.fsnebula.org/api/1/";
         private static readonly string nebulaURL = @"https://fsnebula.org/";

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -85,11 +85,11 @@ namespace Knossos.NET.ViewModels
             set { if (blDlNebula != value) { this.SetProperty(ref blDlNebula, value); UnCommitedChanges = true; } }
         }
 
-        private bool blTalos = false;
-        internal bool BlTalos
+        private bool blHestia = false;
+        internal bool BlHestia
         {
-            get { return blTalos; }
-            set { if (blTalos != value) { this.SetProperty(ref blTalos, value); UnCommitedChanges = true; } }
+            get { return blHestia; }
+            set { if (blHestia != value) { this.SetProperty(ref blHestia, value); UnCommitedChanges = true; } }
         }
 
         private bool enableLogFile = true;
@@ -638,7 +638,7 @@ namespace Knossos.NET.ViewModels
 
             BlDlNebula = false;
             BlCfNebula = false;
-            BlTalos = false;
+            BlHestia = false;
             if (Knossos.globalSettings.mirrorBlacklist != null)
             {
                 if (Knossos.globalSettings.mirrorBlacklist.Contains("dl.fsnebula.org"))
@@ -649,9 +649,9 @@ namespace Knossos.NET.ViewModels
                 {
                     BlCfNebula = true;
                 }
-                if (Knossos.globalSettings.mirrorBlacklist.Contains("talos.feralhosting.com"))
+                if (Knossos.globalSettings.mirrorBlacklist.Contains("hestia.feralhosting.com"))
                 {
-                    BlTalos = true;
+                    BlHestia = true;
                 }
             }
 
@@ -1218,9 +1218,9 @@ namespace Knossos.NET.ViewModels
             {
                 blMirrors.Add("cf.fsnebula.org");
             }
-            if (BlTalos)
+            if (BlHestia)
             {
-                blMirrors.Add("talos.feralhosting.com");
+                blMirrors.Add("hestia.feralhosting.com");
             }
             if (blMirrors.Any() && blMirrors.Count() != 3 /*Invalid!*/)
             {
@@ -1231,7 +1231,7 @@ namespace Knossos.NET.ViewModels
                 Knossos.globalSettings.mirrorBlacklist = null;
                 BlDlNebula = false;
                 BlCfNebula = false;
-                BlTalos = false;
+                BlHestia = false;
             }
 
             Knossos.globalSettings.modCompression = ModCompression;

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -125,7 +125,7 @@
 							<WrapPanel Grid.Column="1" Margin="8,0,0,0">
 								<CheckBox Margin="0,0,0,0" IsChecked="{Binding !BlDlNebula}">dl.fsnebula.org</CheckBox>
 								<CheckBox Margin="25,0,0,0" IsChecked="{Binding !BlCfNebula}">cf.fsnebula.org</CheckBox>
-								<CheckBox Margin="25,0,0,0" IsChecked="{Binding !BlTalos}">talos.feralhosting.com</CheckBox>
+								<CheckBox Margin="25,0,0,0" IsChecked="{Binding !BlHestia}">hestia.feralhosting.com</CheckBox>
 							</WrapPanel>
 						</Grid>
 						<!-- Log File -->


### PR DESCRIPTION
Talos reached capacity, so we migrated to Hestia.  Just like the Aigaion to Talos migration, all files and functionality remain the same.