### PR TITLE
Install VC Runtime On Downloading windows builds if not installed

### DIFF
--- a/Knossos.NET/Knossos.NET.csproj
+++ b/Knossos.NET/Knossos.NET.csproj
@@ -64,12 +64,6 @@
     <AvaloniaResource Include="Assets\utils\osx\**" />
   </ItemGroup>
   <ItemGroup>
-    <AvaloniaResource Remove="Assets\utils\win\VC_redist.x64.exe" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="Assets\utils\win\VC_redist.x64.exe" />
-  </ItemGroup>
-  <ItemGroup>
     <!--This helps with theme dll-s trimming.
 	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
 	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->

--- a/Knossos.NET/Knossos.NET.csproj
+++ b/Knossos.NET/Knossos.NET.csproj
@@ -64,6 +64,12 @@
     <AvaloniaResource Include="Assets\utils\osx\**" />
   </ItemGroup>
   <ItemGroup>
+    <AvaloniaResource Remove="Assets\utils\win\VC_redist.x64.exe" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Assets\utils\win\VC_redist.x64.exe" />
+  </ItemGroup>
+  <ItemGroup>
     <!--This helps with theme dll-s trimming.
 	If you will publish your application in self-contained mode with p:PublishTrimmed=true and it will use Fluent theme Default theme will be trimmed from the output and vice versa.
 	https://github.com/AvaloniaUI/Avalonia/issues/5593 -->

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Threading;
@@ -18,6 +17,63 @@ namespace Knossos.NET.ViewModels
 {
     public partial class TaskItemViewModel : ViewModelBase
     {
+        private async Task<bool> InstallVCRedist(bool is86 = false) {
+            var fileTask = new TaskItemViewModel(); // Crete new task
+            await Dispatcher.UIThread.InvokeAsync(() => TaskList.Insert(0, fileTask)); //insert task into this job TaskList
+            Info = "Tasks: " + ProgressCurrent + "/" + (++ProgressBarMax); //Update progress  
+            var path = "";
+            if (is86) { path = Path.Combine(KnUtils.GetKnossosDataFolderPath(), "vc_redist.x86.exe"); }
+            else { path = Path.Combine(KnUtils.GetKnossosDataFolderPath(), "vc_redist.x64.exe"); }
+            var fileUrl = "";
+            if (is86)
+            {
+                fileUrl = "https://aka.ms/vc14/vc_redist.x86.exe";
+            } //installs both x64 and arm versons
+            else { fileUrl = "https://aka.ms/vc14/vc_redist.x64.exe"; }
+            var result = await fileTask.DownloadFile(fileUrl, path, "Downloading VCRedist", false, null, cancellationTokenSource); // Start and await to finish
+                                                                                                                                       //Always check for cancel before executing the file
+            if (cancellationTokenSource.IsCancellationRequested)
+            {
+                throw new TaskCanceledException();
+            }
+
+            if (result.HasValue && result.Value)
+            {
+                //Assembly assembly = Assembly.GetExecutingAssembly();
+                //using Stream resourceStream = assembly.GetManifestResourceStream(resourceName)??throw new Exception("Resource not found!");
+                //Execute the installer
+                Info = "Tasks: " + (++ProgressCurrent) + "/" + ProgressBarMax;
+                //Retry a couple of times incase we get locked out by av temporealy
+                int retries = 5;
+                while (retries > 0)
+                {
+                    try
+                    {     
+                        Process.Start(new ProcessStartInfo
+                        {
+                            FileName = path,
+                            Arguments = "/install /quiet /norestart",
+                            Verb = "runas",
+                            UseShellExecute = true
+                        }).WaitForExit();
+                        break; // Success!
+                    }
+                    catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 32) // Error code for "File in use"
+                    {
+                        retries--;
+                        if (retries == 0) throw;
+                        System.Threading.Thread.Sleep(500); // Wait 500ms for AV to finish scanning
+                    }
+                }
+
+                if (File.Exists(path)) File.Delete(path);
+                return true;
+            }
+            else
+            {
+                throw new Exception("Error while downloading file: " + fileUrl);
+            }     
+        }
         public async Task<FsoBuild?> InstallBuild(FsoBuild build, FsoBuildItemViewModel sender, CancellationTokenSource? cancelSource = null, Mod? modJson = null, List<ModPackage>? modifyPkgs = null, bool cleanupOldVersions = false)
         {
             string? modPath = null;
@@ -439,57 +495,59 @@ namespace Knossos.NET.ViewModels
                         }
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                         {
-                            bool Vruninstalled = false;
-                            string keyPath = @"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64";
-                            using (RegistryKey key = Registry.LocalMachine.OpenSubKey(keyPath))
+                            bool installx86 = false;
+                        bool install64 = false;
+                        //Determine the cpu arch for vcredist that we need to download, if we need to download, from the FSO build arch NOT the host cpu arch.
+                        foreach (var ex in newBuild.executables)
+                        {
+                            if (ex.arch == FsoExecArch.x86 || ex.arch == FsoExecArch.x86_avx || ex.arch == FsoExecArch.x86_avx2)
                             {
-                                if (key != null)
-                                {
-                                    // 'Bld' is a DWORD representing the build version
-                                    object bldValue = key.GetValue("Bld");
-                                    if (bldValue != null && int.TryParse(bldValue.ToString(), out int bld))
-                                    {
-                                        // Example: 2022 runtimes typically have build numbers > 30000
-                                        Vruninstalled = true;
-                                    }
-                                }
+                                installx86 = true;
                             }
-                            if (!Vruninstalled)
+                            if (ex.arch == FsoExecArch.arm64 || ex.arch == FsoExecArch.x64 || ex.arch == FsoExecArch.x64_avx || ex.arch == FsoExecArch.x64_avx2)
                             {
-                                string resourceName = "Knossos.NET.Assets.utils.win.VC_redist.x64.exe";
-                                string tempFilePath = Path.Combine(Path.GetTempPath(), "vc_redist.x64.exe");
-                                Assembly assembly = Assembly.GetExecutingAssembly();
-                                using Stream resourceStream = assembly.GetManifestResourceStream(resourceName)??throw new Exception("Resource not found!");
-                                using (FileStream fileStream = new(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+                                install64 = true;
+                            }
+                        }
+                            if (installx86)
+                            {
+                                string keyPath = @"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86";
+                                using (RegistryKey key = Registry.LocalMachine.OpenSubKey(keyPath))
                                 {
-                                    resourceStream.CopyTo(fileStream);
-                                    fileStream.Flush();
-                                }
-                                //Retry a couple of times incase we get locked out by av temporealy
-                                int retries = 5;
-                                while (retries > 0)
-                                {
-                                    try
+                                    if (key != null)
                                     {
-                                        Process.Start(new ProcessStartInfo
+                                        // 'Bld' is a DWORD representing the build version
+                                        object bldValue = key.GetValue("Bld");
+                                        if (bldValue != null && int.TryParse(bldValue.ToString(), out int bld))
                                         {
-                                            FileName = tempFilePath,
-                                            Arguments = "/install /quiet /norestart",
-                                            Verb = "runas",
-                                            UseShellExecute = true
-                                        }).WaitForExit();
-                                        break; // Success!
-                                    }
-                                    catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 32) // Error code for "File in use"
-                                    {
-                                        retries--;
-                                        if (retries == 0) throw;
-                                        System.Threading.Thread.Sleep(500); // Wait 500ms for AV to finish scanning
+                                            // Example: 2022 runtimes typically have build numbers > 30000
+                                            installx86 = false;
+                                        }
                                     }
                                 }
-
-                                if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
                             }
+                            if (install64)
+                            {
+                                string keyPath = @"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64";
+                                using (RegistryKey key = Registry.LocalMachine.OpenSubKey(keyPath))
+                                {
+                                    if (key != null)
+                                    {
+                                        // 'Bld' is a DWORD representing the build version
+                                        object bldValue = key.GetValue("Bld");
+                                        if (bldValue != null && int.TryParse(bldValue.ToString(), out int bld))
+                                        {
+                                            // Example: 2022 runtimes typically have build numbers > 30000
+                                            install64 = false;
+                                        }
+                                    }
+                                }
+                            }
+                            if (installx86)
+                            {
+                                await InstallVCRedist(true);
+                            }
+                            if (install64) { await InstallVCRedist(false); }                         
                         }
                     
                         IsCompleted = true;

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
@@ -1,14 +1,18 @@
 ﻿using Avalonia.Threading;
+using Knossos.NET.Classes;
 using Knossos.NET.Models;
 using Knossos.NET.Views;
+using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using System.Threading.Tasks;
 using System.Threading;
-using Knossos.NET.Classes;
+using System.Threading.Tasks;
 
 namespace Knossos.NET.ViewModels
 {
@@ -433,9 +437,63 @@ namespace Knossos.NET.ViewModels
                             //Update version editor if needed
                             DeveloperModsViewModel.Instance?.UpdateVersionManager(modJson.id);
                         }
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            bool Vruninstalled = false;
+                            string keyPath = @"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64";
+                            using (RegistryKey key = Registry.LocalMachine.OpenSubKey(keyPath))
+                            {
+                                if (key != null)
+                                {
+                                    // 'Bld' is a DWORD representing the build version
+                                    object bldValue = key.GetValue("Bld");
+                                    if (bldValue != null && int.TryParse(bldValue.ToString(), out int bld))
+                                    {
+                                        // Example: 2022 runtimes typically have build numbers > 30000
+                                        Vruninstalled = true;
+                                    }
+                                }
+                            }
+                            if (!Vruninstalled)
+                            {
+                                string resourceName = "Knossos.NET.Assets.utils.win.VC_redist.x64.exe";
+                                string tempFilePath = Path.Combine(Path.GetTempPath(), "vc_redist.x64.exe");
+                                Assembly assembly = Assembly.GetExecutingAssembly();
+                                using Stream resourceStream = assembly.GetManifestResourceStream(resourceName)??throw new Exception("Resource not found!");
+                                using (FileStream fileStream = new(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+                                {
+                                    resourceStream.CopyTo(fileStream);
+                                    fileStream.Flush();
+                                }
+                                //Retry a couple of times incase we get locked out by av temporealy
+                                int retries = 5;
+                                while (retries > 0)
+                                {
+                                    try
+                                    {
+                                        Process.Start(new ProcessStartInfo
+                                        {
+                                            FileName = tempFilePath,
+                                            Arguments = "/install /quiet /norestart",
+                                            Verb = "runas",
+                                            UseShellExecute = true
+                                        }).WaitForExit();
+                                        break; // Success!
+                                    }
+                                    catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == 32) // Error code for "File in use"
+                                    {
+                                        retries--;
+                                        if (retries == 0) throw;
+                                        System.Threading.Thread.Sleep(500); // Wait 500ms for AV to finish scanning
+                                    }
+                                }
+
+                                if (File.Exists(tempFilePath)) File.Delete(tempFilePath);
+                            }
+                        }
+                    
                         IsCompleted = true;
                         CancelButtonVisible = false;
-
                         //Re-run Dependencies checks 
                         MainWindowViewModel.Instance?.RunModStatusChecks();
 


### PR DESCRIPTION
Does what the title says. Accompaniment to https://github.com/scp-fs2open/fs2open.github.com/pull/7334 to make sure that users have the necessary dlls installed when we start compiling dynamically.