### PR TITLE
Fix weird nebula log and incorrect success mod upload report on fail + (H8, H9 fix)

### DIFF
--- a/Knossos.NET/Models/Nebula.cs
+++ b/Knossos.NET/Models/Nebula.cs
@@ -789,7 +789,7 @@ namespace Knossos.NET.Models
                                 {
                                     var reply = JsonSerializer.Deserialize<ApiReply>(jsonReply);
                                     if (!reply.result && resourceUrl != "mod/check_id")
-                                        Log.Add(Log.LogSeverity.Error, "Nebula.ApiCall(" + resourceUrl + ")", "An error has ocurred during nebula api POST call: " + response.StatusCode + "(" + (int)response.StatusCode + ")\n" + data);
+                                        Log.Add(Log.LogSeverity.Error, "Nebula.ApiCall(" + resourceUrl + ")", "An error has ocurred during nebula api POST call. Status: " + response.StatusCode + "(" + (int)response.StatusCode + "). Reply: \n" + jsonReply + "\n");
 
                                     return reply;
                                 }
@@ -924,7 +924,10 @@ namespace Knossos.NET.Models
                     }
                     else
                     {
-                        Log.Add(Log.LogSeverity.Error, "Nebula.GetModJson", "Unable to get mod json data. ID: " + modid + " Version: " + version + " Reason: " + reply.Value.reason);
+                        if(reply.Value.reason == "not_found")
+                            Log.Add(Log.LogSeverity.Warning, "Nebula.GetModJson", "Mod ID + Version not found on Nebula. ID: " + modid + " Version: " + version + " Reason: " + reply.Value.reason);
+                        else
+                            Log.Add(Log.LogSeverity.Error, "Nebula.GetModJson", "Unable to get mod json data. ID: " + modid + " Version: " + version + " Reason: " + reply.Value.reason);
                     }
                 }
             }

--- a/Knossos.NET/ViewModels/Templates/Tasks/PreFlightCheck.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/PreFlightCheck.cs
@@ -55,12 +55,11 @@ namespace Knossos.NET.ViewModels
                     {
                         if (result != null)
                         {
-                            Info = "Preflight check failed. Reason: " + result;
+                            throw new TaskCanceledException("Preflight failed. Reason: " + result);
                         }
                         else
                         {
-                            Info = "Preflight check failed for unknown reasons.";
-                            throw new TaskCanceledException();
+                            throw new TaskCanceledException("Preflight failed for unknown reasons.");
                         }
                     }
                     Info = result;
@@ -74,13 +73,13 @@ namespace Knossos.NET.ViewModels
                     throw new Exception("The task is already set, it cant be changed or re-assigned.");
                 }
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException tc)
             {
                 //Task cancel requested by user
                 IsCompleted = false;
                 IsCancelled = true;
                 CancelButtonVisible = false;
-                Info = "Task Cancelled";
+                Info = tc.InnerException?.Message != null ? tc.InnerException.Message : "Task Cancelled";
                 //Only dispose the token if it was created locally
                 if (cancelSource == null)
                 {

--- a/Knossos.NET/ViewModels/Templates/Tasks/ReleaseMod.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/ReleaseMod.cs
@@ -87,12 +87,11 @@ namespace Knossos.NET.ViewModels
                     {
                         if (result != null)
                         {
-                            Info = "Release Mod failed. Reason: " + result;
+                            throw new TaskCanceledException("Release Mod failed. Reason: " + result);
                         }
                         else
                         {
-                            Info = "Release Mod failed for unknown reasons.";
-                            throw new TaskCanceledException();
+                            throw new TaskCanceledException("Release Mod failed for unknown reasons.");
                         }
                     }
                     Info = result;
@@ -106,13 +105,13 @@ namespace Knossos.NET.ViewModels
                     throw new Exception("The task is already set, it cant be changed or re-assigned.");
                 }
             }
-            catch (TaskCanceledException)
+            catch (TaskCanceledException tc)
             {
                 //Task cancel requested by user
                 IsCompleted = false;
                 IsCancelled = true;
                 CancelButtonVisible = false;
-                Info = "Task Cancelled";
+                Info = tc.InnerException?.Message != null ? tc.InnerException.Message : "Task cancelled";
                 //Only dispose the token if it was created locally
                 if (cancelSource == null)
                 {


### PR DESCRIPTION
This will fix the weird api reply logs without a reply 

*Error* : (Nebula.ApiCall(mod/release)) An error has ocurred during nebula api POST call: OK(200)
System.Net.Http.StringContent

the expected getmodid with not found when checking if the mod is already uploaded

*Error* : (Nebula.GetModJson) Unable to get mod json data. ID: SF_EH Version: 0.8.42 Reason: not_found

and the incorrect UI reporting the mod upload completed successfully when it failed.

4/6/2026 1:17:01 PM - *Information* : (Nebula.UpdateMod) UpdateMod: Star Fox Event Horizon 0.8.42 OK!
4/6/2026 1:17:18 PM - *Error* : (Nebula.ApiCall(mod/release)) An error has ocurred during nebula api POST call: OK(200)
System.Net.Http.StringContent
4/6/2026 1:17:18 PM - *Error* : (Nebula.ReleaseMod) ReleaseMod: Star Fox Event Horizon 0.8.42 error. Reason: archive missing
