### PR TITLE
Return a copy of installedmods, enginebuilds and modtools instead of references (C4 fix)

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1484,7 +1484,7 @@ namespace Knossos.NET
             }
             else
             {
-                return installedMods;
+                return installedMods.ToList();
             }
         }
 
@@ -1527,7 +1527,7 @@ namespace Knossos.NET
                 }
                 else
                 {
-                    return engineBuilds;
+                    return engineBuilds.ToList();
                 }
             }
         }
@@ -1903,7 +1903,7 @@ namespace Knossos.NET
         /// <returns>List of tools or empty list</returns>
         public static List<Tool> GetTools()
         {
-            return modTools;
+            return modTools.ToList();
         }
     }
 }


### PR DESCRIPTION
File: `Knossos.NET/Classes/Knossos.cs:25-27`
```csharp
private static List<Mod> installedMods = new List<Mod>();
private static List<FsoBuild> engineBuilds = new List<FsoBuild>();
private static List<Tool> modTools = new List<Tool>();
```
These are accessed from multiple threads (UI, background tasks, Nebula loading, install tasks) with zero synchronization -- there are no `lock` statements anywhere in the codebase. `GetInstalledModList(null)` and `GetInstalledBuildsList()` return the raw list references, allowing callers to mutate them (e.g., `App.axaml.cs` calls `mods.Sort()` on the shared list). Concurrent read+write on `List<T>` causes `InvalidOperationException`, `IndexOutOfRangeException`, or silent corruption.

This should be enoght to make sure it cant happen, when the entire list is returned, a copy is sent instead of a reference.