### PR TITLE
Add extra notes to Library Folder

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -1629,7 +1629,7 @@ namespace Knossos.NET
                     if (MainWindow.instance != null)
                     {
                         Dispatcher.UIThread.Invoke(() => {
-                            MessageBox.Show(MainWindow.instance!, "KnossosNET either cannot find or does not have permission to read a previously selected library folder.\nEither select a new library folder in KnossosNET's settings, or check if the folder is now protected.", "Knossos.NET Library Folder Error" , MessageBox.MessageBoxButtons.OK);
+                            MessageBox.Show(MainWindow.instance!, "KnossosNET either cannot find or does not have permission to read a previously selected Library Folder.\nEither select a new Library Folder in KnossosNET's settings, or check if the folder is now protected.", "Knossos.NET Library Folder Error" , MessageBox.MessageBoxButtons.OK);
                         });
                     }
                 }

--- a/Knossos.NET/ViewModels/CustomHomeViewModel.cs
+++ b/Knossos.NET/ViewModels/CustomHomeViewModel.cs
@@ -512,7 +512,7 @@ namespace Knossos.NET.ViewModels
                 {
                     Log.Add(Log.LogSeverity.Error, "CustomHomeViewModel.BrowseFolderCommand() - test read/write was not successful: ", ex);
                     await Dispatcher.UIThread.Invoke(async () => {
-                        await MessageBox.Show(null, "We were not able to write to this folder.  Please select another library folder.", "Cannot Select Folder", MessageBox.MessageBoxButtons.OK);
+                        await MessageBox.Show(null, "We were not able to write to this folder.  Please select another Library Folder.", "Cannot Select Folder", MessageBox.MessageBoxButtons.OK);
                     }).ConfigureAwait(false);
                 }
             }

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -1175,7 +1175,7 @@ namespace Knossos.NET.ViewModels
                 {
                     Log.Add(Log.LogSeverity.Error, "GlobalSettings.BrowseFolderCommand() - test read/write was not successful: ", ex);
                     await Dispatcher.UIThread.Invoke(async () => {
-                        await MessageBox.Show(null, "KnossosNET was not able to write to this folder.  Please select another library folder.", "Cannot Select Folder", MessageBox.MessageBoxButtons.OK);
+                        await MessageBox.Show(null, "KnossosNET was not able to write to this folder.  Please select another Library Folder.", "Cannot Select Folder", MessageBox.MessageBoxButtons.OK);
                     }).ConfigureAwait(false);
                 }
             }

--- a/Knossos.NET/ViewModels/TaskViewModel.cs
+++ b/Knossos.NET/ViewModels/TaskViewModel.cs
@@ -257,7 +257,7 @@ namespace Knossos.NET.ViewModels
             {
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    await MessageBox.Show(MainWindow.instance!, "KnossosNET library path is not set! Before installing mods go to settings and select a library folder.", "Error", MessageBox.MessageBoxButtons.OK);
+                    await MessageBox.Show(MainWindow.instance!, "KnossosNET Library Folder path is not set! Before installing mods go to settings and select a Library Folder.", "Error", MessageBox.MessageBoxButtons.OK);
                 });
                 return null;
             }
@@ -296,7 +296,7 @@ namespace Knossos.NET.ViewModels
             {
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    await MessageBox.Show(MainWindow.instance!, "KnossosNET library path is not set! Before installing mods go to settings and select a library folder.", "Error", MessageBox.MessageBoxButtons.OK);
+                    await MessageBox.Show(MainWindow.instance!, "KnossosNET Library Folder path is not set! Before installing mods go to settings and select a Library Folder.", "Error", MessageBox.MessageBoxButtons.OK);
                 });
                 return;
             }

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -32,13 +32,13 @@
 						<WrapPanel Margin="7,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Library Folder </TextBlock>
 							<TextBox HorizontalAlignment="Left" Width="400" Text="{Binding BasePath}" Margin="10,0,0,0" IsReadOnly="True" ></TextBox>
-							<Button IsVisible="{Binding !IsPortableMode}" Margin="5,0,0,0" Classes="Quaternary" Command="{Binding BrowseFolderCommand}">Browse</Button>
+							<Button IsVisible="{Binding !IsPortableMode}" Margin="5,0,0,0" Classes="Quaternary" Command="{Binding BrowseFolderCommand}" ToolTip.Tip="It is highly recommended to set this as an empty folder in a location with a large amount of available storage. Do not set it to a shared or cloud drive (such as OneDrive or Google Drive) because syncing issues will prevent Knossos from downloading mod files correctly.">Browse</Button>
 						</WrapPanel>
 						<!-- Lib Info -->
 						<Grid ColumnDefinitions="Auto,Auto,Auto" RowDefinitions="Auto, Auto" Margin="6,10,0,0">
 							<TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Width="200">Stats</TextBlock>
 							<WrapPanel Grid.Column="1" Grid.Row="0"  Margin="8,2,0,0">
-								<Label Margin="0,5,0,0" FontWeight="Bold" ToolTip.Tip="How many standalone games and modifications (collectively known as mods) are installed in your KnossosNET library.">Mods:</Label>
+								<Label Margin="0,5,0,0" FontWeight="Bold" ToolTip.Tip="How many standalone games and modifications (collectively known as mods) are installed in your KnossosNET Library Folder.">Mods:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfMods}"></TextBlock>
 								<Label Margin="40,5,0,0" FontWeight="Bold">Builds:</Label>
 								<TextBlock Margin="5,8,0,0" Text="{Binding NumberOfBuilds}"></TextBlock>

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -36,17 +36,17 @@
 		<!--Page2-->
 		<StackPanel IsVisible="{Binding Page2}" Grid.Row="0" >
 			<StackPanel IsVisible="{Binding !IsPortableMode}">
-				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Setting up the library folder</TextBlock>
-				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">First, you must set a library folder. Go to the "Settings" tab and under the "KnossosNET" section click on the "Browse" button and choose or create a folder for KnossosNET to use. It is highly recommended to set this as an empty folder in a location with a large amount of available storage. </TextBlock>
-				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The KnossosNET library folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
+				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Setting up the Library Folder</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">First, you must set a Library Folder. Go to the "Settings" tab and under the "KnossosNET" section click on the "Browse" button and choose or create a folder for KnossosNET to use. It is highly recommended to set this as an empty folder in a location with a large amount of available storage. Do not set your Library Folder to a shared or cloud drive (such as OneDrive or Google Drive) because syncing issues will prevent Knossos from downloading mod files correctly.</TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The KnossosNET Library Folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>
-				<TextBlock IsVisible="{Binding !CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Go to the "Settings" tab and set the library folder to continue.</TextBlock>
+				<TextBlock IsVisible="{Binding !CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Go to the "Settings" tab and set the Library Folder to continue.</TextBlock>
 				<Button IsVisible="{Binding !CanContinue}" Command="{Binding ClickSettingsButton}" Margin="20,0,0,0" Classes="Quaternary">Show me where</Button>
 			</StackPanel>
 			<StackPanel IsVisible="{Binding IsPortableMode}">
 				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >KnossosNET is running in portable mode</TextBlock>
-				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">This means KnossosNET settings and FSO pilots, settings and data are saved inside the 'kn_portable' folder, you cannot set a library folder in this mode. </TextBlock>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">This means KnossosNET settings and FSO pilots, settings and data are saved inside the 'kn_portable' folder, you cannot set a Library Folder in this mode. </TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">If you ever need to stop using the portable mode move, rename or delete the 'kn_portable' folder.</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>


### PR DESCRIPTION
Person on Discord had set their KNet Library Folder to a cloud drive, which cause mods to not install correctly due to auto syncing issues. This PR adds a warning to the help guide and tooltip to ideally prevent this. It also makes the public facing capitalization of Library Folder consistent.

Happy to discuss or edit however warranted, too.