### PR TITLE
Validate API-supplied paths to prevent directory traversal

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -630,6 +630,28 @@ namespace Knossos.NET
         }
 
         /// <summary>
+        /// Returns true if candidatePath resolves to a location within basePath.
+        /// Rejects absolute paths, null bytes, and path traversal sequences such as "..".
+        /// </summary>
+        public static bool IsSubPath(string basePath, string candidatePath)
+        {
+            if (string.IsNullOrEmpty(candidatePath))
+                return true;
+            if (Path.IsPathRooted(candidatePath))
+                return false;
+            try
+            {
+                var fullBase = Path.GetFullPath(basePath).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                var fullTarget = Path.GetFullPath(Path.Combine(basePath, candidatePath));
+                return fullTarget.StartsWith(fullBase, StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Gets the complete size of all files in a folder and subdirectories in bytes
         /// </summary>
         /// <param name="folderPath"></param>
@@ -1009,7 +1031,24 @@ namespace Knossos.NET
                             {
                                 if (!reader.Entry.IsDirectory)
                                 {
-                                    reader.WriteEntryToDirectory(destFolderPath, new ExtractionOptions() { ExtractFullPath = extractFullPath, Overwrite = true, WriteSymbolicLink = (source, target) => { File.CreateSymbolicLink(source, target); } });
+                                    var entryKey = reader.Entry.Key?.Replace('\\', '/').Replace('/', Path.DirectorySeparatorChar);
+                                    if (entryKey != null && extractFullPath && !IsSubPath(destFolderPath, entryKey))
+                                    {
+                                        Log.Add(Log.LogSeverity.Warning, "KnUtils.DecompressFileSharpCompress()", $"Skipping potentially dangerous archive entry: {reader.Entry.Key}");
+                                        continue;
+                                    }
+                                    reader.WriteEntryToDirectory(destFolderPath, new ExtractionOptions() { ExtractFullPath = extractFullPath, Overwrite = true, WriteSymbolicLink = (source, target) =>
+                                    {
+                                        var resolvedTarget = Path.IsPathRooted(target)
+                                            ? target
+                                            : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(source)!, target));
+                                        if (!IsSubPath(destFolderPath, Path.GetRelativePath(destFolderPath, resolvedTarget)))
+                                        {
+                                            Log.Add(Log.LogSeverity.Warning, "KnUtils.DecompressFileSharpCompress()", $"Skipping symlink escaping destination: {source} -> {target}");
+                                            return;
+                                        }
+                                        File.CreateSymbolicLink(source, target);
+                                    }});
                                 }
                                 if (cancellationTokenSource!.IsCancellationRequested)
                                 {
@@ -1028,6 +1067,12 @@ namespace Knossos.NET
                             {
                                 if (!reader.Entry.IsDirectory)
                                 {
+                                    var entryKey = reader.Entry.Key?.Replace('\\', '/').Replace('/', Path.DirectorySeparatorChar);
+                                    if (entryKey != null && extractFullPath && !IsSubPath(destFolderPath, entryKey))
+                                    {
+                                        Log.Add(Log.LogSeverity.Warning, "KnUtils.DecompressFileSharpCompress()", $"Skipping potentially dangerous archive entry: {reader.Entry.Key}");
+                                        continue;
+                                    }
                                     reader.WriteEntryToDirectory(destFolderPath, new ExtractionOptions() { ExtractFullPath = extractFullPath, Overwrite = true });
                                 }
                                 if (cancellationTokenSource!.IsCancellationRequested)

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
@@ -231,8 +231,13 @@ namespace Knossos.NET.ViewModels
                         {
                             if (file.dest != null && file.dest.Trim() != string.Empty)
                             {
-                                var path = file.dest;
-                                Directory.CreateDirectory(modPath + Path.DirectorySeparatorChar + path);
+                                if (!KnUtils.IsSubPath(modPath, file.dest))
+                                {
+                                    Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", $"Unsafe dest path in build '{build.id}': {file.dest}");
+                                    CancelTaskCommand();
+                                    return false;
+                                }
+                                Directory.CreateDirectory(modPath + Path.DirectorySeparatorChar + file.dest);
                             }
                         }
 
@@ -277,6 +282,12 @@ namespace Knossos.NET.ViewModels
                             }
 
                             Info = "Tasks: " + ProgressCurrent + "/" + ProgressBarMax;
+                            if (!KnUtils.IsSubPath(modPath, file.filename))
+                            {
+                                Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", $"Unsafe filename in build '{build.id}': {file.filename}");
+                                CancelTaskCommand();
+                                throw new TaskCanceledException();
+                            }
                             var fileFullPath = modPath + Path.DirectorySeparatorChar + file.filename;
                             var result = await fileTask.DownloadFile(file.urls!, fileFullPath, "Downloading " + file.filename, false, null, cancellationTokenSource);
 

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
@@ -235,7 +235,6 @@ namespace Knossos.NET.ViewModels
                                 {
                                     Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", $"Unsafe dest path in build '{build.id}': {file.dest}");
                                     CancelTaskCommand();
-                                    return false;
                                 }
                                 Directory.CreateDirectory(modPath + Path.DirectorySeparatorChar + file.dest);
                             }
@@ -282,7 +281,7 @@ namespace Knossos.NET.ViewModels
                             }
 
                             Info = "Tasks: " + ProgressCurrent + "/" + ProgressBarMax;
-                            if (!KnUtils.IsSubPath(modPath, file.filename))
+                            if (string.IsNullOrEmpty(file.filename) || !KnUtils.IsSubPath(modPath, file.filename))
                             {
                                 Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", $"Unsafe filename in build '{build.id}': {file.filename}");
                                 CancelTaskCommand();

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
@@ -351,7 +351,7 @@ namespace Knossos.NET.ViewModels
                             {
                                 file.dest = string.Empty;
                             }
-                            if (!KnUtils.IsSubPath(modPath, file.filename))
+                            if (string.IsNullOrEmpty(file.filename) || !KnUtils.IsSubPath(modPath, file.filename))
                             {
                                 Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallMod()", $"Unsafe filename in mod '{mod.id}': {file.filename}");
                                 CancelTaskCommand();

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
@@ -263,8 +263,13 @@ namespace Knossos.NET.ViewModels
                     {
                         if (file.dest != null && file.dest.Trim() != string.Empty)
                         {
-                            var path = file.dest;
-                            Directory.CreateDirectory(modPath + Path.DirectorySeparatorChar + path);
+                            if (!KnUtils.IsSubPath(modPath, file.dest))
+                            {
+                                Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallMod()", $"Unsafe dest path in mod '{mod.id}': {file.dest}");
+                                CancelTaskCommand();
+                                return false;
+                            }
+                            Directory.CreateDirectory(modPath + Path.DirectorySeparatorChar + file.dest);
                         }
                     }
 
@@ -345,6 +350,12 @@ namespace Knossos.NET.ViewModels
                             if (file.dest == null)
                             {
                                 file.dest = string.Empty;
+                            }
+                            if (!KnUtils.IsSubPath(modPath, file.filename))
+                            {
+                                Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallMod()", $"Unsafe filename in mod '{mod.id}': {file.filename}");
+                                CancelTaskCommand();
+                                throw new TaskCanceledException();
                             }
                             var fileFullPath = modPath + Path.DirectorySeparatorChar + file.filename;
                             var result = await fileTask.DownloadFile(file.urls!, fileFullPath, "Downloading " + file.filename, false, null, cancellationTokenSource);


### PR DESCRIPTION
file.dest and file.filename values from the Nebula API were used directly in filesystem operations (directory creation, download target paths, decompression destinations) with no validation, allowing a compromised server or MITM to write files outside the mod library.

Adds IsSubPath() to KnUtils using Path.GetFullPath containment to reject absolute paths and "../" traversal sequences. InstallMod and InstallBuild now validate both fields before use and cancel the task if either escapes the mod directory.

Also adds belt-and-suspenders entry path validation to the SharpCompress extraction loops and fixes the WriteSymbolicLink lambda to reject symlink targets that resolve outside the destination directory.