### PR TITLE
add < and > to dependency version operators

### DIFF
--- a/Knossos.NET/Classes/SemanticVersion.cs
+++ b/Knossos.NET/Classes/SemanticVersion.cs
@@ -258,7 +258,7 @@ namespace Knossos.NET.Classes
 
         /// <summary>
         /// Compares a semantic version string to the version string in the mod dependency to see if it sastifies the requirement.
-        /// Version : null -> Any, Version: "4.6.1" -> Only that version, Version: "~4.6.1" -> >=4.6.1 < 4.7.0, Version: ">=4.6.1"->equal or better
+        /// Version : null -> Any, Version: "4.6.1" -> Only that version, Version: "~4.6.1" -> >=4.6.1 < 4.7.0, Version: ">=4.6.1" -> equal or newer, Version: "<=4.6.1" -> equal or older, Version: ">4.6.1" -> newer, Version: "<4.6.1" -> older
         /// </summary>
         /// <param name="dependencyVersion"></param>
         /// <param name="version"></param>
@@ -276,7 +276,7 @@ namespace Knossos.NET.Classes
         */
         /// <summary>
         /// Compares a semantic version to the version string in the mod dependency to see if it sastifies the requirement.
-        /// Version : null -> Any, Version: "4.6.1" -> Only that version, Version: "~4.6.1" -> >=4.6.1 < 4.7.0, Version: ">=4.6.1"->equal or better
+        /// Version : null -> Any, Version: "4.6.1" -> Only that version, Version: "~4.6.1" -> >=4.6.1 < 4.7.0, Version: ">=4.6.1" -> equal or newer, Version: "<=4.6.1" -> equal or older, Version: ">4.6.1" -> newer, Version: "<4.6.1" -> older
         /// </summary>
         /// <param name="dependencyVersion"></param>
         /// <param name="version"></param>
@@ -333,6 +333,18 @@ namespace Knossos.NET.Classes
                     }
 
                     return false;
+                }
+
+                if (dependencyVersion.Contains(">"))
+                {
+                    var versionDep = new SemanticVersion(dependencyVersion.Replace(">", ""));
+                    return Compare(version, versionDep) > 0;
+                }
+
+                if (dependencyVersion.Contains("<"))
+                {
+                    var versionDep = new SemanticVersion(dependencyVersion.Replace("<", ""));
+                    return Compare(version, versionDep) < 0;
                 }
 
                 if (Compare(version, new SemanticVersion(dependencyVersion)) == 0)

--- a/Knossos.NET/Models/Mod.cs
+++ b/Knossos.NET/Models/Mod.cs
@@ -427,6 +427,10 @@ namespace Knossos.NET.Models
                                         {
                                             revisions.Add(d);
                                         }
+                                        else if (d.version.Contains("<=") || d.version.Contains(">") || d.version.Contains("<"))
+                                        {
+                                            //<=, >, < are not yet handled by the dedup logic below; leave them in temp as-is
+                                        }
                                         else
                                         {
                                             equal.Add(d);

--- a/Knossos.NET/ViewModels/Templates/DependencyItemViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DependencyItemViewModel.cs
@@ -236,6 +236,42 @@ namespace Knossos.NET.ViewModels
                         itemVer.Content = "~" + mod.version;
                         VersionItems.Add(itemVer);
                     }
+
+                    separator = new ComboBoxItem();
+                    separator.Content = "--- <= ---";
+                    separator.IsEnabled = false;
+                    VersionItems.Add(separator);
+
+                    foreach (var mod in mods)
+                    {
+                        var itemVer = new ComboBoxItem();
+                        itemVer.Content = "<=" + mod.version;
+                        VersionItems.Add(itemVer);
+                    }
+
+                    separator = new ComboBoxItem();
+                    separator.Content = "--- > ---";
+                    separator.IsEnabled = false;
+                    VersionItems.Add(separator);
+
+                    foreach (var mod in mods)
+                    {
+                        var itemVer = new ComboBoxItem();
+                        itemVer.Content = ">" + mod.version;
+                        VersionItems.Add(itemVer);
+                    }
+
+                    separator = new ComboBoxItem();
+                    separator.Content = "--- < ---";
+                    separator.IsEnabled = false;
+                    VersionItems.Add(separator);
+
+                    foreach (var mod in mods)
+                    {
+                        var itemVer = new ComboBoxItem();
+                        itemVer.Content = "<" + mod.version;
+                        VersionItems.Add(itemVer);
+                    }
                 }
                 else
                 {
@@ -264,6 +300,42 @@ namespace Knossos.NET.ViewModels
                         {
                             var itemVer = new ComboBoxItem();
                             itemVer.Content = ">=" + build.version;
+                            VersionItems.Add(itemVer);
+                        }
+
+                        separator = new ComboBoxItem();
+                        separator.Content = "--- <= ---";
+                        separator.IsEnabled = false;
+                        VersionItems.Add(separator);
+
+                        foreach (var build in builds)
+                        {
+                            var itemVer = new ComboBoxItem();
+                            itemVer.Content = "<=" + build.version;
+                            VersionItems.Add(itemVer);
+                        }
+
+                        separator = new ComboBoxItem();
+                        separator.Content = "--- > ---";
+                        separator.IsEnabled = false;
+                        VersionItems.Add(separator);
+
+                        foreach (var build in builds)
+                        {
+                            var itemVer = new ComboBoxItem();
+                            itemVer.Content = ">" + build.version;
+                            VersionItems.Add(itemVer);
+                        }
+
+                        separator = new ComboBoxItem();
+                        separator.Content = "--- < ---";
+                        separator.IsEnabled = false;
+                        VersionItems.Add(separator);
+
+                        foreach (var build in builds)
+                        {
+                            var itemVer = new ComboBoxItem();
+                            itemVer.Content = "<" + build.version;
                             VersionItems.Add(itemVer);
                         }
                     }

--- a/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
@@ -90,7 +90,7 @@ namespace Knossos.NET.ViewModels
 
                     FillAllVersions();
 
-                    var currentVersion = VersionItems.FirstOrDefault(x => x.Content != null && dep.version != null && x.Content.ToString() == dep.version.Trim().Replace(">=", "").Replace("~", ""));
+                    var currentVersion = VersionItems.FirstOrDefault(x => x.Content != null && dep.version != null && x.Content.ToString() == dep.version.Trim().Replace(">=", "").Replace("<=", "").Replace(">", "").Replace("<", "").Replace("~", ""));
                     if (currentVersion != null)
                     {
                         versionSelectedIndex = VersionItems.IndexOf(currentVersion);
@@ -98,16 +98,25 @@ namespace Knossos.NET.ViewModels
                         {
                             versionTypeIndex = 2;
                         }
+                        else if (dep.version!.Contains(">="))
+                        {
+                            versionTypeIndex = 1;
+                        }
+                        else if (dep.version!.Contains("<="))
+                        {
+                            versionTypeIndex = 3;
+                        }
+                        else if (dep.version!.Contains(">"))
+                        {
+                            versionTypeIndex = 4;
+                        }
+                        else if (dep.version!.Contains("<"))
+                        {
+                            versionTypeIndex = 5;
+                        }
                         else
                         {
-                            if (dep.version!.Contains(">="))
-                            {
-                                versionTypeIndex = 1;
-                            }
-                            else
-                            {
-                                versionTypeIndex = 0;
-                            }
+                            versionTypeIndex = 0;
                         }
                     }
                     else
@@ -132,22 +141,31 @@ namespace Knossos.NET.ViewModels
                         {
                             VersionTypeIndex = 2;
                         }
+                        else if (dep.version!.Contains(">="))
+                        {
+                            VersionTypeIndex = 1;
+                        }
+                        else if (dep.version!.Contains("<="))
+                        {
+                            VersionTypeIndex = 3;
+                        }
+                        else if (dep.version!.Contains(">"))
+                        {
+                            VersionTypeIndex = 4;
+                        }
+                        else if (dep.version!.Contains("<"))
+                        {
+                            VersionTypeIndex = 5;
+                        }
                         else
                         {
-                            if (dep.version!.Contains(">="))
-                            {
-                                VersionTypeIndex = 1;
-                            }
-                            else
-                            {
-                                VersionTypeIndex = 0;
-                            }
+                            VersionTypeIndex = 0;
                         }
                     } else {
                         VersionTypeIndex = 0;
                     }
                     var itemVer = new ComboBoxItem();
-                    itemVer.Content = dep.version != null ? dep.version.Replace(">=","").Replace("~", "") : "Any";
+                    itemVer.Content = dep.version != null ? dep.version.Replace(">=", "").Replace("<=", "").Replace(">", "").Replace("<", "").Replace("~", "") : "Any";
                     VersionItems.Add(itemVer);
                 }
             }
@@ -301,7 +319,15 @@ namespace Knossos.NET.ViewModels
                     if(depId != "-1" && depId != null)
                     {
                         Dependency.id = depId;
-                        var versionType = VersionTypeIndex == 0 ? string.Empty : VersionTypeIndex == 1 ? ">=" : "~";
+                        var versionType = VersionTypeIndex switch
+                        {
+                            1 => ">=",
+                            2 => "~",
+                            3 => "<=",
+                            4 => ">",
+                            5 => "<",
+                            _ => string.Empty
+                        };
                         Dependency.version = depVersion != "Any" ? versionType+depVersion : null;
                         var newPkgs = new List<string>();
                         foreach (var pkg in Packages)

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
@@ -70,7 +70,7 @@ namespace Knossos.NET.ViewModels
                             try
                             {
                                 var fso = mod.GetDependency("FSO");
-                                if (fso != null && (fso.version == null || SemanticVersion.Compare(fso.version.Replace(">=", "").Replace("<", "").Replace(">", "").Trim(), VPCompression.MinimumFSOVersion) > 0))
+                                if (fso != null && (fso.version == null || SemanticVersion.Compare(fso.version.Replace(">=", "").Replace("<=", "").Replace(">", "").Replace("<", "").Replace("~", "").Trim(), VPCompression.MinimumFSOVersion) > 0))
                                     compressMod = true;
                             }
                             catch (Exception ex)

--- a/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
+++ b/Knossos.NET/Views/Templates/DevModPkgMgrView.axaml
@@ -78,6 +78,9 @@
 											<ComboBoxItem ToolTip.Tip="Only the selected version">==</ComboBoxItem>
 											<ComboBoxItem ToolTip.Tip="Higher or equal than the selected version">>=</ComboBoxItem>
 											<ComboBoxItem ToolTip.Tip="Same minor version, revision equal or better:&#x0a;Dependency: ~1.5.2&#x0a;1.5.1 ->Not Valid&#x0a;1.5.6 -> Valid&#x0a;1.6.0 -> Not valid">~</ComboBoxItem>
+											<ComboBoxItem ToolTip.Tip="Lower or equal than the selected version">&lt;=</ComboBoxItem>
+											<ComboBoxItem ToolTip.Tip="Strictly higher than the selected version">></ComboBoxItem>
+											<ComboBoxItem ToolTip.Tip="Strictly lower than the selected version">&lt;</ComboBoxItem>
 										</ComboBox>
 										<ComboBox SelectedIndex="{Binding VersionSelectedIndex}" ItemsSource="{Binding VersionItems}" Grid.Column="3" MinWidth="75" Margin="2" FontWeight="Bold" FontSize="14" VerticalContentAlignment="Top" HorizontalContentAlignment="Center" Background="White" Foreground="Black"></ComboBox>
 										<!--Packages-->


### PR DESCRIPTION
SastifiesDependency now supports strict-less and strict-greater in addition to the existing ~, >=, <=. Dev mod editor pickers now expose <=, >, and < (the first was already supported but unexposed, the latter two are new).

Also fixes two latent bugs that mishandled the new operators:
- InstallMod's FSO compression check missed <= and ~ in its strip chain, silently parsing to 0.0.0
- Mod.FilterDependencies miscategorized non-(>=, ~) deps as exact matches; they now pass through dedup unchanged