### PR TITLE
Fix dev UI showing == Any when dependency version isn't installed

### DIFF
--- a/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModPkgMgrViewModel.cs
@@ -90,34 +90,21 @@ namespace Knossos.NET.ViewModels
 
                     FillAllVersions();
 
-                    var currentVersion = VersionItems.FirstOrDefault(x => x.Content != null && dep.version != null && x.Content.ToString() == dep.version.Trim().Replace(">=", "").Replace("<=", "").Replace(">", "").Replace("<", "").Replace("~", ""));
+                    versionTypeIndex = OperatorTypeIndexFromVersion(dep.version);
+
+                    var bareVersion = dep.version != null ? StripVersionOperators(dep.version) : null;
+                    var currentVersion = VersionItems.FirstOrDefault(x => x.Content != null && bareVersion != null && x.Content.ToString() == bareVersion);
                     if (currentVersion != null)
                     {
                         versionSelectedIndex = VersionItems.IndexOf(currentVersion);
-                        if (dep.version!.Contains("~"))
-                        {
-                            versionTypeIndex = 2;
-                        }
-                        else if (dep.version!.Contains(">="))
-                        {
-                            versionTypeIndex = 1;
-                        }
-                        else if (dep.version!.Contains("<="))
-                        {
-                            versionTypeIndex = 3;
-                        }
-                        else if (dep.version!.Contains(">"))
-                        {
-                            versionTypeIndex = 4;
-                        }
-                        else if (dep.version!.Contains("<"))
-                        {
-                            versionTypeIndex = 5;
-                        }
-                        else
-                        {
-                            versionTypeIndex = 0;
-                        }
+                    }
+                    else if (!string.IsNullOrEmpty(bareVersion))
+                    {
+                        //Requested version isn't installed — surface it as its own entry so the UI matches the JSON.
+                        var itemVer = new ComboBoxItem();
+                        itemVer.Content = bareVersion;
+                        VersionItems.Add(itemVer);
+                        versionSelectedIndex = VersionItems.Count - 1;
                     }
                     else
                     {
@@ -135,37 +122,9 @@ namespace Knossos.NET.ViewModels
                     itemMod.IsEnabled = false; //Important! This signals that on writing to return the original depedency data to avoid possible loss of dep data
                     ModItems.Insert(0, itemMod);
                     ModSelectedIndex = 0;
-                    if (dep.version != null) // Make sure we hae a version to read.
-                    {
-                        if (dep.version!.Contains("~"))
-                        {
-                            VersionTypeIndex = 2;
-                        }
-                        else if (dep.version!.Contains(">="))
-                        {
-                            VersionTypeIndex = 1;
-                        }
-                        else if (dep.version!.Contains("<="))
-                        {
-                            VersionTypeIndex = 3;
-                        }
-                        else if (dep.version!.Contains(">"))
-                        {
-                            VersionTypeIndex = 4;
-                        }
-                        else if (dep.version!.Contains("<"))
-                        {
-                            VersionTypeIndex = 5;
-                        }
-                        else
-                        {
-                            VersionTypeIndex = 0;
-                        }
-                    } else {
-                        VersionTypeIndex = 0;
-                    }
+                    VersionTypeIndex = OperatorTypeIndexFromVersion(dep.version);
                     var itemVer = new ComboBoxItem();
-                    itemVer.Content = dep.version != null ? dep.version.Replace(">=", "").Replace("<=", "").Replace(">", "").Replace("<", "").Replace("~", "") : "Any";
+                    itemVer.Content = dep.version != null ? StripVersionOperators(dep.version) : "Any";
                     VersionItems.Add(itemVer);
                 }
             }
@@ -291,6 +250,25 @@ namespace Knossos.NET.ViewModels
                 {
                     Log.Add(Log.LogSeverity.Error, "EditorDependencyItem.FillPackages()", ex);
                 }
+            }
+
+            //Maps a dependency version string to the matching index in the version-type combobox
+            //(0 == exact, 1 >=, 2 ~, 3 <=, 4 >, 5 <).
+            private static int OperatorTypeIndexFromVersion(string? version)
+            {
+                if (version == null) return 0;
+                if (version.Contains("~")) return 2;
+                if (version.Contains(">=")) return 1;
+                if (version.Contains("<=")) return 3;
+                if (version.Contains(">")) return 4;
+                if (version.Contains("<")) return 5;
+                return 0;
+            }
+
+            private static string StripVersionOperators(string version)
+            {
+                return version.Trim().Replace(">=", "").Replace("<=", "")
+                                     .Replace(">", "").Replace("<", "").Replace("~", "");
             }
 
             internal void DeleteDependency()


### PR DESCRIPTION
In the package manager dev UI, opening a mod whose dependency targets
a version that isn't currently installed showed the operator as '=='
and the version as 'Any', regardless of what the JSON specified.

The operator-detection block in EditorDependencyItem's constructor was
nested inside `if (currentVersion != null)`, so when the requested
version wasn't found in the installed list, the version dropdown
correctly fell back to 'Any' but the operator type incorrectly stayed
at its default 0 ('==').

Move the operator detection out of that conditional so it always runs,
and surface the requested version as its own dropdown entry when it
isn't installed -- mirroring what the missing-mod branch already does.
Extract the operator detection and operator stripping into two private
static helpers shared by both branches.

~~Depends on #402; in draft until that is merged.~~