### PR TITLE
fix task cancellation

### DIFF
--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallBuild.cs
@@ -235,6 +235,7 @@ namespace Knossos.NET.ViewModels
                                 {
                                     Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", $"Unsafe dest path in build '{build.id}': {file.dest}");
                                     CancelTaskCommand();
+                                    return null;
                                 }
                                 Directory.CreateDirectory(modPath + Path.DirectorySeparatorChar + file.dest);
                             }
@@ -359,6 +360,7 @@ namespace Knossos.NET.ViewModels
                             {
                                 Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallBuild()", "Error while decompressing the file " + fileFullPath);
                                 CancelTaskCommand();
+                                throw new TaskCanceledException();
                             }
                             //sender.ProgressBarCurrent = ++ProgressCurrent;
                             ++ProgressCurrent;

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallMod.cs
@@ -415,6 +415,7 @@ namespace Knossos.NET.ViewModels
                             {
                                 Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallMod()", "Error while decompressing the file " + fileFullPath);
                                 CancelTaskCommand();
+                                throw new TaskCanceledException();
                             }
                             File.Delete(fileFullPath);
                             ++ProgressCurrent;

--- a/Knossos.NET/ViewModels/Templates/Tasks/InstallTool.cs
+++ b/Knossos.NET/ViewModels/Templates/Tasks/InstallTool.cs
@@ -110,6 +110,7 @@ namespace Knossos.NET.ViewModels
                     {
                         Log.Add(Log.LogSeverity.Error, "TaskItemViewModel.InstallTool()", "Error while decompressing the file " + fileFullPath);
                         CancelTaskCommand();
+                        throw new TaskCanceledException();
                     }
 
                     if (cancellationTokenSource.IsCancellationRequested)


### PR DESCRIPTION
Removing `return false` in the second commit to #398 was the wrong fix; it should have been changed to `return null`.  But this had an unexpected benefit as it turns out several other places in the code need proper handling of task cancellation.