### PR TITLE
Downgrade Tmds.DBus.Protocol to 0.21.3 and bump to 1.3.7

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -17,7 +17,7 @@ namespace Knossos.NET
 {
     public static class Knossos
     {
-        public static readonly string AppVersion = "1.3.6";
+        public static readonly string AppVersion = "1.3.7";
         public readonly static string ToolRepoURL = "https://raw.githubusercontent.com/KnossosNET/Knet-Tool-Repo/main/knet_tools.json";
         public readonly static string GitHubUpdateRepoURL = "https://api.github.com/repos/KnossosNET/Knossos.NET";
         public readonly static string FAQURL = "https://raw.githubusercontent.com/KnossosNET/KNet-General-Resources-Repo/main/communityfaq.json";

--- a/Knossos.NET/Knossos.NET.csproj
+++ b/Knossos.NET/Knossos.NET.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="ObservableCollections" Version="3.3.3" />
     <PackageReference Include="SharpCompress" Version="0.48.0" />
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.93.0" />
+    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageReference Include="WindowsShortcutFactory" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Tmds.DBus.Protocol 0.93.0 does not work on Linux with current version of Avalonia. Downgraded to 0.21.3 that is nor marked as vulnerable, altrought im not sure this is real or an oversight.

Note: merge #413 first