### PR TITLE
Add legacy update channel

### DIFF
--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -1391,5 +1391,28 @@ namespace Knossos.NET
                 Log.Add(Log.LogSeverity.Error, "KnUtils.CreateDesktopShortcut()", ex);
             }
         }
+
+        /// <summary>
+        /// Determines if the current OS meets the requirements for .NET 10 / "latest" channel updates.
+        /// Windows 10+ or macOS 12.2+ qualify.
+        /// </summary>
+        public static bool IsModernOS()
+        {
+            if (IsWindows)
+            {
+                // Windows build 10240 = Windows 10 RTM
+                return Environment.OSVersion.Version.Major >= 10;
+            }
+
+            if (IsMacOS)
+            {
+                var ver = Environment.OSVersion.Version;
+                // macOS 12.0
+                return ver.Major >= 12;
+            }
+
+            // Linux and anything else: treat as modern (no restriction planned)
+            return true;
+        }
     }
 }

--- a/Knossos.NET/Classes/KnUtils.cs
+++ b/Knossos.NET/Classes/KnUtils.cs
@@ -1394,7 +1394,7 @@ namespace Knossos.NET
 
         /// <summary>
         /// Determines if the current OS meets the requirements for .NET 10 / "latest" channel updates.
-        /// Windows 10+ or macOS 12.2+ qualify.
+        /// Windows 10+ or macOS 12.0+ qualify.
         /// </summary>
         public static bool IsModernOS()
         {

--- a/Knossos.NET/Models/GitHubApi.cs
+++ b/Knossos.NET/Models/GitHubApi.cs
@@ -1,6 +1,10 @@
-﻿using System;
+﻿using Knossos.NET.Classes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -9,11 +13,27 @@ namespace Knossos.NET.Models
     public static class GitHubApi
     {
         /// <summary>
-        /// Get the last release on Knet github repo
-        /// URL of this repo is set on the Knossos class
+        /// Gets the latest applicable release from GitHub.
+        /// - Modern platforms (Win10+ / macOS 12.2+): uses /releases/latest (current behaviour).
+        /// - Legacy platforms: scans /releases, keeps only v1.3.x tags, returns the newest one.
         /// </summary>
-        /// <returns>GitHubRelease or null if the api call failed</returns>
+        /// <returns>GitHubRelease or null if the API call failed.</returns>
         public static async Task<GitHubRelease?> GetLastRelease()
+        {
+            if (KnUtils.IsModernOS())
+            {
+                return await GetLatestRelease();
+            }
+            else
+            {
+                return await GetLatestLegacyRelease();
+            }
+        }
+
+        /// <summary>
+        /// Calls /releases/latest — for modern platforms.
+        /// </summary>
+        private static async Task<GitHubRelease?> GetLatestRelease()
         {
             try
             {
@@ -21,15 +41,98 @@ namespace Knossos.NET.Models
                 client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("product", "1"));
                 using var response = await client.GetAsync(Knossos.GitHubUpdateRepoURL + "/releases/latest");
                 var json = await response.Content.ReadAsStringAsync();
-                return JsonSerializer.Deserialize<GitHubRelease>(json)!;
+                return JsonSerializer.Deserialize<GitHubRelease>(json);
             }
             catch (Exception ex)
             {
-                Log.Add(Log.LogSeverity.Error, "GitHubApi.GetLastRelease()", ex);
+                Log.Add(Log.LogSeverity.Error, "GitHubApi.GetLatestRelease()", ex);
                 return null;
             }
         }
+
+        /// <summary>
+        /// Scans /releases pages looking for v1.3.x tags and returns the newest one.
+        /// Stops paginating early once tags leave the 1.3.x range (assumes releases
+        /// are returned newest-first by the API).
+        /// </summary>
+        private static async Task<GitHubRelease?> GetLatestLegacyRelease()
+        {
+            try
+            {
+                var client = KnUtils.GetHttpClient();
+                client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("product", "1"));
+
+                var candidates = new List<GitHubRelease>();
+                int page = 1;
+                const int perPage = 30; // GitHub default; max is 100
+
+                while (true)
+                {
+                    var url = $"{Knossos.GitHubUpdateRepoURL}/releases?per_page={perPage}&page={page}";
+                    using var response = await client.GetAsync(url);
+                    var json = await response.Content.ReadAsStringAsync();
+                    var releases = JsonSerializer.Deserialize<List<GitHubRelease>>(json);
+
+                    if (releases == null || releases.Count == 0)
+                        break;
+
+                    foreach (var release in releases)
+                    {
+                        if (IsLegacyTag(release.tag_name))
+                        {
+                            candidates.Add(release);
+                        }
+                    }
+
+                    // If the oldest release on this page is already below 1.3.7, no need to go further
+                    var lastTag = releases.Last().tag_name;
+                    if (lastTag != null && IsBelowLegacyMinor(lastTag))
+                        break;
+
+                    if (releases.Count < perPage)
+                        break; // last page
+
+                    page++;
+                }
+
+                // Return the candidate with the highest semantic version
+                return candidates
+                    .Where(r => r.tag_name != null)
+                    .MaxBy(r => new SemanticVersion(NormalizeTag(r.tag_name!)));
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Error, "GitHubApi.GetLatestLegacyRelease()", ex);
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the tag is a v1.3.x release (e.g. "v1.3.7", "v1.3.10-rc1").
+        /// </summary>
+        private static bool IsLegacyTag(string? tag)
+        {
+            if (string.IsNullOrWhiteSpace(tag)) return false;
+            var version = new SemanticVersion(NormalizeTag(tag));
+            // Check major == 1 and minor == 3 by comparing against sentinels
+            return SemanticVersion.Compare(NormalizeTag(tag), "1.3.0") >= 0 &&
+                   SemanticVersion.Compare(NormalizeTag(tag), "1.4.0") < 0;
+        }
+
+        /// <summary>
+        /// Returns true if the tag is strictly older than 1.3.7 — used as an early-exit
+        /// hint while paginating (GitHub returns releases newest-first).
+        /// </summary>
+        private static bool IsBelowLegacyMinor(string tag)
+        {
+            return SemanticVersion.Compare(NormalizeTag(tag), "1.3.7") < 0;
+        }
+
+        /// <summary>Strips the leading "v" that GitHub tags typically have.</summary>
+        private static string NormalizeTag(string tag) =>
+            tag.ToLower().Replace("v", "").Trim();
     }
+
 
     public class GitHubRelease
     {

--- a/Knossos.NET/Models/GitHubApi.cs
+++ b/Knossos.NET/Models/GitHubApi.cs
@@ -14,7 +14,7 @@ namespace Knossos.NET.Models
     {
         /// <summary>
         /// Gets the latest applicable release from GitHub.
-        /// - Modern platforms (Win10+ / macOS 12.2+): uses /releases/latest (current behaviour).
+        /// - Modern platforms (Win10+ / macOS 12.0+): uses /releases/latest (current behaviour).
         /// - Legacy platforms: scans /releases, keeps only v1.3.x tags, returns the newest one.
         /// </summary>
         /// <returns>GitHubRelease or null if the API call failed.</returns>

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -36,7 +36,9 @@ namespace Knossos.NET.ViewModels
         private const long speed10MB = 170000000;
 
         /* For display only */
-		[ObservableProperty]
+        [ObservableProperty]
+        internal string knossosUpdateChannelInfo = "";
+        [ObservableProperty]
         internal bool isPortableMode = false;
         [ObservableProperty]
         internal bool flagDataLoaded = false;
@@ -552,6 +554,14 @@ namespace Knossos.NET.ViewModels
         public GlobalSettingsViewModel()
         {
             isPortableMode = Knossos.inPortableMode;
+            if (KnUtils.IsModernOS())
+            {
+                knossosUpdateChannelInfo = "(Main Update Channel)";
+            }
+            else
+            {
+                knossosUpdateChannelInfo = "(Legacy Update Channel)";
+            }
         }
 
         public void CheckDisplaySettingsWarning()

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -39,6 +39,8 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string knossosUpdateChannelInfo = "";
         [ObservableProperty]
+        internal string knossosUpdateTooltip = "";
+        [ObservableProperty]
         internal bool isPortableMode = false;
         [ObservableProperty]
         internal bool flagDataLoaded = false;
@@ -554,13 +556,12 @@ namespace Knossos.NET.ViewModels
         public GlobalSettingsViewModel()
         {
             isPortableMode = Knossos.inPortableMode;
-            if (KnUtils.IsModernOS())
+            if (!KnUtils.IsModernOS())
             {
-                knossosUpdateChannelInfo = "(Main Update Channel)";
-            }
-            else
-            {
-                knossosUpdateChannelInfo = "(Legacy Update Channel)";
+                KnossosUpdateChannelInfo = "(Legacy Update Channel)";
+                var current = KnUtils.IsWindows ? $"Windows {Environment.OSVersion.Version.Major}" : $"MacOS {Environment.OSVersion.Version}";
+                var minimum = KnUtils.IsWindows ? "Windows 10+" : "MacOS 12+";
+                KnossosUpdateTooltip = $"Your version of {current} is not compatible with version 1.4 of Knossos.NET and above. To receive new features, you should upgrade to version {minimum}. You will still receive bugfix updates when they apply to version 1.3.";
             }
         }
 

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -73,6 +73,7 @@
 						<WrapPanel Margin="5,10,0,0">
 							<Label Margin="0,5,0,0" Width="205">Auto Update KnosssosNET</Label>
 							<ToggleSwitch IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input."></ToggleSwitch>
+							<Label Margin="10,1,0,0" Content="{Binding KnossosUpdateChannelInfo}" VerticalAlignment="Center"/>
 						</WrapPanel>
 						<WrapPanel Margin="5,10,0,0">
 							<Label Margin="0,5,0,0" Width="205">Auto Update FSO Builds</Label>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -73,7 +73,7 @@
 						<WrapPanel Margin="5,10,0,0">
 							<Label Margin="0,5,0,0" Width="205">Auto Update KnosssosNET</Label>
 							<ToggleSwitch IsVisible="{Binding CheckUpdates}" Margin="5,0,0,0" IsChecked="{Binding AutoUpdate}" ToolTip.Tip="The update will be automatically downloaded and installed. KnossosNET will be restarted without any user input."></ToggleSwitch>
-							<Label Margin="10,1,0,0" Content="{Binding KnossosUpdateChannelInfo}" VerticalAlignment="Center"/>
+							<Label Margin="10,1,0,0" IsVisible="{Binding KnossosUpdateChannelInfo.Length}" Content="{Binding KnossosUpdateChannelInfo}" ToolTip.Tip="{Binding KnossosUpdateTooltip}" VerticalAlignment="Center"/>
 						</WrapPanel>
 						<WrapPanel Margin="5,10,0,0">
 							<Label Margin="0,5,0,0" Width="205">Auto Update FSO Builds</Label>


### PR DESCRIPTION
From now on, any OS below Win10 or MacOS 12 is considered legacy and only look for updates on the with tags "v1.3.x" those updates must be generated from the 1.3.x branch and NOT be tagged as the lastest one when creating the release here. This new system will find them.

1.3.x version will still recive fixes and maybe some of the new features provided if we backport them from the main to the 1.3.x branch.

All other OS will still look for the latest update here as always.

This is preparation for the move to Avalonia 12 / .NET 10 from 1.4.0.