### PR TITLE
Set default library path without user input and update quick start guide

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -79,6 +79,129 @@ namespace Knossos.NET
         }
 
         /// <summary>
+        /// Run only on first installs, determines the default first library path by OS
+        /// </summary>
+        private static void DetermineDefaultBasePath()
+        {
+            //Load base path from knossos legacy, if it exists
+            var legacyBasePath = KnUtils.GetBasePathFromKnossosLegacy();
+            if (Directory.Exists(legacyBasePath) && TrySetDefaultBasePath(legacyBasePath))
+            {
+                Log.Add(Log.LogSeverity.Information, "Knossos.DetermineDefaultBasePath()", $"Loading library path '{globalSettings.basePath}' from Knossos Legacy.");
+                globalSettings.Save(false);
+                return;
+            }
+
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            if (KnUtils.IsAndroid)
+            {
+                TrySetDefaultBasePath(AndroidHelper.GetDefaultLibraryDir());
+            }
+            else if (KnUtils.IsWindows)
+            {
+                var systemRoot = Path.GetPathRoot(Environment.GetFolderPath(Environment.SpecialFolder.System));
+                if (string.IsNullOrWhiteSpace(systemRoot))
+                    systemRoot = @"C:\";
+
+                TrySetDefaultBasePath(Path.Combine(systemRoot, "Games", "KnossosNET", "FreespaceOpen"));
+
+                if (globalSettings.basePath == null)
+                {
+                    var publicProfile = Environment.GetEnvironmentVariable("PUBLIC");
+                    if (string.IsNullOrWhiteSpace(publicProfile))
+                    {
+                        var commonDocuments = Environment.GetFolderPath(Environment.SpecialFolder.CommonDocuments);
+                        if (!string.IsNullOrWhiteSpace(commonDocuments))
+                            publicProfile = Directory.GetParent(commonDocuments)?.FullName;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(publicProfile))
+                        TrySetDefaultBasePath(Path.Combine(publicProfile, "KnossosNET", "FreespaceOpen"));
+                }
+            }
+            else if (KnUtils.IsMacOS)
+            {
+                TrySetDefaultBasePath(Path.Combine(userProfile, "Library", "Application Support", "io.github.KnossosNET.Knossos_NET", "FreespaceOpen"));
+            }
+            else if (KnUtils.IsLinux)
+            {
+                TrySetDefaultBasePath(Path.Combine(userProfile, "KnossosNET", "FreespaceOpen"));
+            }
+
+            // General fallbacks for an unknown OS, or when the preferred OS path is not writable.
+            if (globalSettings.basePath == null && !string.IsNullOrWhiteSpace(userProfile))
+                TrySetDefaultBasePath(Path.Combine(userProfile, "KnossosNET", "FreespaceOpen"));
+
+            if (globalSettings.basePath == null)
+            {
+                var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                if (!string.IsNullOrWhiteSpace(localAppData))
+                    TrySetDefaultBasePath(Path.Combine(localAppData, "KnossosNET", "FreespaceOpen"));
+            }
+
+            if (globalSettings.basePath == null)
+                TrySetDefaultBasePath(Path.Combine(KnUtils.GetKnossosDataFolderPath(), "FreespaceOpen"));
+
+            if (globalSettings.basePath != null)
+            {
+                Log.Add(Log.LogSeverity.Information, "Knossos.DetermineDefaultBasePath()", $"Choosing '{globalSettings.basePath}' as default library path.");
+                globalSettings.Save(false);
+            }
+            else
+            {
+                Log.Add(Log.LogSeverity.Error, "Knossos.DetermineDefaultBasePath()", "Unable to find a writable default library path.");
+            }
+        }
+
+        /// <summary>
+        /// Creates and verifies a possible default library path before selecting it.
+        /// </summary>
+        private static bool TrySetDefaultBasePath(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return false;
+
+            string? writeTestPath = null;
+            try
+            {
+                var fullPath = Path.GetFullPath(path);
+                Directory.CreateDirectory(fullPath);
+
+                writeTestPath = Path.Combine(fullPath, $".knossos_write_test_{Guid.NewGuid():N}.tmp");
+                using (var writeTest = new FileStream(writeTestPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+                {
+                    writeTest.WriteByte(0);
+                    writeTest.Flush(true);
+                }
+
+                File.Delete(writeTestPath);
+                writeTestPath = null;
+                globalSettings.basePath = fullPath;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Add(Log.LogSeverity.Warning, "Knossos.TrySetDefaultBasePath()", $"Cannot use '{path}' as the default library path: {ex.Message}");
+                return false;
+            }
+            finally
+            {
+                if (writeTestPath != null)
+                {
+                    try
+                    {
+                        File.Delete(writeTestPath);
+                    }
+                    catch
+                    {
+                        // Best-effort cleanup of the temporary write test.
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// StartUp sequence
         /// </summary>
         /// <param name="isQuickLaunch"></param>
@@ -153,20 +276,14 @@ namespace Knossos.NET
                     }
                 }
 
-                //Load base path from knossos legacy
-                if (globalSettings.basePath == null && KnUtils.IsAndroid)
-                {
-                    globalSettings.basePath = AndroidHelper.GetDefaultLibraryDir();
-                } 
                 if (globalSettings.basePath == null && !inSingleTCMode)
                 {
-                    globalSettings.basePath = KnUtils.GetBasePathFromKnossosLegacy();
+                    DetermineDefaultBasePath();
+                    if (!isQuickLaunch)
+                        OpenQuickSetup();
                 }
 
                 LoadBasePath(isQuickLaunch);
-
-                if (globalSettings.basePath == null && !isQuickLaunch && !inSingleTCMode)
-                    OpenQuickSetup();
             }
             catch(Exception ex)
             {

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -79,7 +79,16 @@ namespace Knossos.NET
         }
 
         /// <summary>
-        /// Run only on first installs, determines the default first library path by OS
+        /// Run only on first install, determines the default first library path by OS
+        /// Write checks are done to make sure we can write to this folder
+        /// 
+        /// Rutes:
+        /// -First try to look and use a library from Knossos Legacy
+        /// -Windows: C:\Games\KnossosNET\FreespaceOpen; If not writtable: %PUBLIC%\KnossosNET\FreespaceOpen
+        /// -MacOS: ~/Library/Application Support/io.github.KnossosNET.Knossos_NET/FreespaceOpen
+        /// -Linux: ~/KnossosNET/FreespaceOpen
+        /// -Android: {internal storage}/Android/data/com.knossosnet.knossosnet/files/library
+        /// Fallbacks: {user profile}\KnossosNET\FreespaceOpen, then {LocalApplicationData}\KnossosNET\FreespaceOpen
         /// </summary>
         private static void DetermineDefaultBasePath()
         {
@@ -274,6 +283,15 @@ namespace Knossos.NET
                             CleanUpdateFiles();
                         });
                     }
+                }
+
+                if(globalSettings.basePath != null && !isQuickLaunch && !Directory.Exists(globalSettings.basePath))
+                {
+                    //Reset and warn
+                    Dispatcher.UIThread.Invoke(() => {
+                        MessageBox.Show(MainWindow.instance, $"The previusly selected library folder:\n\n'{globalSettings.basePath}'\n\nNot longer exists, the library folder will be reset back to default.", "Library folder not found" , MessageBox.MessageBoxButtons.OK);
+                    });
+                    globalSettings.basePath = null;
                 }
 
                 if (globalSettings.basePath == null && !inSingleTCMode)

--- a/Knossos.NET/Models/GlobalSettings.cs
+++ b/Knossos.NET/Models/GlobalSettings.cs
@@ -17,7 +17,7 @@ namespace Knossos.NET.Models
 {
     /// <summary>
     /// Disabled = No option to compress is ever show
-    /// Manual = User can select to compress mods manually during install and in mod settings
+    /// Manual = Mods are not compressed during install; the user can compress them later in mod settings
     /// Always = Always compress all mods during install, no matter what.
     /// ModSupport = Compress only if the mod depends on a FSO verson that is higher or equal than the minimal required (23.2.0)
     /// </summary>

--- a/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
+++ b/Knossos.NET/ViewModels/GlobalSettingsViewModel.cs
@@ -166,6 +166,14 @@ namespace Knossos.NET.ViewModels
             set { if (modCompression != value) { this.SetProperty(ref modCompression, value); UnCommitedChanges = true; } }
         }
 
+        internal void UpdateModCompressionFromQuickSetup(CompressionSettings value)
+        {
+            if (modCompression != value)
+            {
+                this.SetProperty(ref modCompression, value, nameof(ModCompression));
+            }
+        }
+
         private int compressionMaxParallelism = 2;
         internal int CompressionMaxParallelism
         {

--- a/Knossos.NET/ViewModels/MainViewModel.cs
+++ b/Knossos.NET/ViewModels/MainViewModel.cs
@@ -497,7 +497,6 @@ namespace Knossos.NET.ViewModels
         public void UpdateBuildInstallButtons()
         {
             DeveloperModView?.UpdateBuildNames(LatestStable, LatestNightly);
-            QuickSetupViewModel.Instance?.UpdateBuildName(LatestStable);
         }
 
         /// <summary>

--- a/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
@@ -26,6 +26,9 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string? libraryPath = null;
 
+        [ObservableProperty]
+        internal string retailFs2Status = string.Empty;
+
         private CompressionSettings modCompression = CompressionSettings.Manual;
         internal CompressionSettings ModCompression
         {
@@ -80,6 +83,13 @@ namespace Knossos.NET.ViewModels
             LibraryPath = Knossos.globalSettings.basePath;
         }
 
+        private void EnterPage4()
+        {
+            RetailFs2Status = Knossos.retailFs2RootFound
+                ? "Current Status: Freespace 2 Game Data is Installed"
+                : "Current Status: Freespace 2 Game Data is NOT Installed";
+        }
+
         internal void GoBackCommand()
         {
             pageNumber--;
@@ -105,7 +115,7 @@ namespace Knossos.NET.ViewModels
                 case 1: CanGoBack = false; CanContinue = true; Page1 = true; Page2 = false; LastPage = false;  break;
                 case 2: CanGoBack = true; CanContinue = true; Page1 = false; Page2 = true; Page3 = false; EnterPage2(); LastPage = false;  break;
                 case 3: CanGoBack = true; CanContinue = true; Page2 = false; Page3 = true; Page4 = false; LastPage = false;  break;
-                case 4: CanGoBack = true; CanContinue = true; Page3 = false; Page4 = true; Page5 = false; LastPage = false; break;
+                case 4: CanGoBack = true; CanContinue = true; Page3 = false; Page4 = true; Page5 = false; EnterPage4(); LastPage = false; break;
                 case 5: CanGoBack = true; CanContinue = true; Page4 = false; Page5 = true; LastPage = true; break;
             }
         }

--- a/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
@@ -1,9 +1,7 @@
 ﻿using Avalonia.Controls;
-using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Knossos.NET.Models;
 using Knossos.NET.Views;
-using System.Threading.Tasks;
 
 namespace Knossos.NET.ViewModels
 {
@@ -15,8 +13,6 @@ namespace Knossos.NET.ViewModels
     {
         private int pageNumber = 1;
 
-        [ObservableProperty]
-        internal bool repoDownloaded = false;
         [ObservableProperty]
         internal bool canGoBack = false;
         [ObservableProperty]
@@ -30,10 +26,21 @@ namespace Knossos.NET.ViewModels
         [ObservableProperty]
         internal string? libraryPath = null;
 
-        [ObservableProperty]
-        public string latestBuild = string.Empty;
-        [ObservableProperty]
-        internal bool buildAvailable = false;
+        private CompressionSettings modCompression = CompressionSettings.Manual;
+        internal CompressionSettings ModCompression
+        {
+            get { return modCompression; }
+            set
+            {
+                if (modCompression != value)
+                {
+                    this.SetProperty(ref modCompression, value);
+                    Knossos.globalSettings.modCompression = value;
+                    MainViewModel.Instance?.GlobalSettingsView?.UpdateModCompressionFromQuickSetup(value);
+                    Knossos.globalSettings.Save(false);
+                }
+            }
+        }
 
         [ObservableProperty]
         internal bool page1 = true;
@@ -45,44 +52,22 @@ namespace Knossos.NET.ViewModels
         internal bool page4 = false;
         [ObservableProperty]
         internal bool page5 = false;
-        [ObservableProperty]
-        internal bool page6 = false;
 
         private KnossosWindow? dialog;
-
-        public static QuickSetupViewModel? Instance;
 
         public QuickSetupViewModel() 
         {
             isPortableMode = Knossos.inPortableMode;
+            libraryPath = Knossos.globalSettings.basePath;
+            modCompression = Knossos.globalSettings.modCompression;
         }
 
         public QuickSetupViewModel(KnossosWindow dialog) 
         {
             this.dialog = dialog;
             isPortableMode = Knossos.inPortableMode;
-            Instance = this;
-            UpdateBuildName(MainViewModel.Instance!.LatestStable);
-            TrackRepoStatus();
-        }
-
-        /// <summary>
-        /// Wait until repo_minimal.json has been parsed
-        /// </summary>
-        private void TrackRepoStatus()
-        {
-            Task.Run(async () =>
-            {
-                do
-                {
-                    await Task.Delay(1000);
-                } while (!Nebula.repoLoaded);
-
-                await Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    RepoDownloaded = Nebula.repoLoaded;
-                });
-            });
+            libraryPath = Knossos.globalSettings.basePath;
+            modCompression = MainViewModel.Instance?.GlobalSettingsView?.ModCompression ?? Knossos.globalSettings.modCompression;
         }
 
         internal void OpenDiscordQuickSetup()
@@ -90,48 +75,9 @@ namespace Knossos.NET.ViewModels
             KnUtils.OpenBrowserURL(@"https://discord.gg/raSEhVeTGw");
         }
 
-        /// <summary>
-        /// Wait until the Knossos library path is set
-        /// </summary>
         private void EnterPage2()
         {
-            Task.Run(() => 
-            {
-                Dispatcher.UIThread.InvokeAsync(async () =>
-                {
-                    LibraryPath = Knossos.globalSettings.basePath;
-
-                    if (Page2)
-                    {
-                        CanContinue = true;
-                    }
-                });
-            });
-        }
-
-        /// <summary>
-        /// Wait until FSO flags has been loaded
-        /// </summary>
-        private void EnterPage3()
-        {
-            Task.Run(() =>
-            {
-                Dispatcher.UIThread.InvokeAsync(async () =>
-                {
-                    if (Page3)
-                    {
-                        if (!Knossos.flagDataLoaded)
-                        {
-                            await Task.Delay(1000);
-                            EnterPage3();
-                        }
-                        else
-                        {
-                            CanContinue = true;
-                        }
-                    }
-                });
-            });
+            LibraryPath = Knossos.globalSettings.basePath;
         }
 
         internal void GoBackCommand()
@@ -157,56 +103,10 @@ namespace Knossos.NET.ViewModels
             switch(pageNumber)
             {
                 case 1: CanGoBack = false; CanContinue = true; Page1 = true; Page2 = false; LastPage = false;  break;
-                case 2: CanGoBack = true; CanContinue = false; Page1 = false; Page2 = true; Page3 = false; EnterPage2(); LastPage = false;  break;
-                case 3: CanGoBack = true; CanContinue = false; Page2 = false; Page3 = true; Page4 = false; EnterPage3(); LastPage = false;  break;
+                case 2: CanGoBack = true; CanContinue = true; Page1 = false; Page2 = true; Page3 = false; EnterPage2(); LastPage = false;  break;
+                case 3: CanGoBack = true; CanContinue = true; Page2 = false; Page3 = true; Page4 = false; LastPage = false;  break;
                 case 4: CanGoBack = true; CanContinue = true; Page3 = false; Page4 = true; Page5 = false; LastPage = false; break;
-                case 5: CanGoBack = true; CanContinue = true; Page4 = false; Page5 = true; Page6 = false; LastPage = false; break;
-                case 6: CanGoBack = true; CanContinue = false; Page5 = false; Page6 = true; LastPage = true; break;
-            }
-        }
-
-        public void UpdateBuildName(string stableIn){
-            LatestBuild = stableIn;
-            UpdateBuildInstallButton();
-        }
-
-        public void UpdateBuildInstallButton()
-        {
-            if (LatestBuild == "")
-            {
-                BuildAvailable = false;
-            }
-            else 
-            {
-                var installed = Knossos.GetInstalledBuild("FSO", LatestBuild);
-                if (installed != null)
-                {
-                    LatestBuild = "";
-                    BuildAvailable = false;
-                } 
-                else 
-                {
-                    BuildAvailable = true;
-                }
-            } 
-        }
-
-        public void DownloadLatestStable()
-        {
-            if (LatestBuild != ""){
-                var stable = new Mod();
-                stable.id = "FSO";
-                stable.version = LatestBuild;
-                stable.type = ModType.engine;
-                stable.stability = "stable";
-
-                MainViewModel.Instance!.FsoBuildsView!.RelayInstallBuild(stable);
-
-                var installed = Knossos.GetInstalledBuild("FSO", LatestBuild);
-                if (installed != null){
-                    LatestBuild = "";
-                    UpdateBuildInstallButton();
-                }
+                case 5: CanGoBack = true; CanContinue = true; Page4 = false; Page5 = true; LastPage = true; break;
             }
         }
         
@@ -215,11 +115,5 @@ namespace Knossos.NET.ViewModels
             MainViewModel.Instance?.ClickOnMenuButton("Settings");
             MainViewModel.Instance?.GlobalSettingsView?.ExpandKnossosSection();
         }
-
-        public void ClickEngineButton()
-        {
-            MainViewModel.Instance?.ClickOnMenuButton("Engine");
-        }
-
     }
 }

--- a/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
+++ b/Knossos.NET/ViewModels/Windows/QuickSetupViewModel.cs
@@ -103,15 +103,7 @@ namespace Knossos.NET.ViewModels
 
                     if (Page2)
                     {
-                        if (LibraryPath == null)
-                        {
-                            await Task.Delay(1000);
-                            EnterPage2();
-                        }
-                        else
-                        {
-                            CanContinue = true;
-                        }
+                        CanContinue = true;
                     }
                 });
             });

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -65,7 +65,7 @@
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 								<ComboBoxItem Tag="1">Manual</ComboBoxItem>
 								<ComboBoxItem Tag="2">Forced On</ComboBoxItem>
-								<ComboBoxItem Tag="3">Automatic (Recommended)</ComboBoxItem>
+								<ComboBoxItem Tag="3">Automatic</ComboBoxItem>
 							</ComboBox>
 							<NumericUpDown IsEnabled="{Binding ModCompression}" Margin="10,0,0,0" Width="120" Grid.Column="2" Minimum="1" Maximum="8" Value="{Binding CompressionMaxParallelism}" ToolTip.Tip="Max number of parallel compression tasks"></NumericUpDown>
 						</WrapPanel>

--- a/Knossos.NET/Views/GlobalSettingsView.axaml
+++ b/Knossos.NET/Views/GlobalSettingsView.axaml
@@ -14,7 +14,7 @@
 
 	<Grid RowDefinitions="Auto,*">
 		<WrapPanel Margin="5,5,0,5" Grid.Row="0" VerticalAlignment="Center">
-			<Button Margin="0,5,30,0" IsVisible="{Binding QuickStartButtonVisibility}" Command="{Binding QuickSetupCommand}" FontSize="20" ToolTip.Tip="Open the initial 'Getting Started' guide window" Classes="Quaternary">Quick Setup Guide</Button>
+			<Button Margin="0,5,30,0" IsVisible="{Binding QuickStartButtonVisibility}" Command="{Binding QuickSetupCommand}" FontSize="20" ToolTip.Tip="Open the initial 'Getting Started' guide window" Classes="Quaternary">Quick Start Guide</Button>
 			<Button Margin="0,5,30,0" Command="{Binding ResetCommand}" FontWeight="Bold" FontSize="20" ToolTip.Tip="Reset all settings to defaults" Classes="Cancel">Reset to defaults</Button>
 			<Button Margin="0,5,30,0" Command="{Binding ReloadFlagData}" FontSize="20" ToolTip.Tip="Reload all settings from the configuration file and reload system data.">Reload Data</Button>
 		</WrapPanel>
@@ -61,11 +61,11 @@
 						</WrapPanel>
 						<WrapPanel Margin="8,10,0,0">
 							<TextBlock VerticalAlignment="Center" Width="200">Mod Compression</TextBlock>
-							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="KnossosNET can try to compress mod files in order to save disk space, and in some cases reduce loading times. 'Manual' means you will have to change a modpack's compression from mod settings or during installation. 'Always' means KnossosNET will compress all mods during install. 'Mod Support' means KnossosNET will compress the files only if the mod FSO engine dependency set by the mod is over the minimum, and if the mod uses an official build." Grid.Column="1" Width="150" Margin="10,0,0,0">
+							<ComboBox SelectedIndex="{Binding ModCompression}" ToolTip.Tip="KnossosNET can compress supported mod files to save disk space, although installations may take longer. 'Manual' only allows compression from an installed mod's individual settings. 'Forced On' compresses all non-developer mods during installation. 'Automatic' compresses mods during installation only when they meet the minimum FSO build requirements." Grid.Column="1" Width="210" Margin="10,0,0,0">
 								<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 								<ComboBoxItem Tag="1">Manual</ComboBoxItem>
-								<ComboBoxItem Tag="2">Always</ComboBoxItem>
-								<ComboBoxItem Tag="3">Mod Support</ComboBoxItem>
+								<ComboBoxItem Tag="2">Forced On</ComboBoxItem>
+								<ComboBoxItem Tag="3">Automatic (Recommended)</ComboBoxItem>
 							</ComboBox>
 							<NumericUpDown IsEnabled="{Binding ModCompression}" Margin="10,0,0,0" Width="120" Grid.Column="2" Minimum="1" Maximum="8" Value="{Binding CompressionMaxParallelism}" ToolTip.Tip="Max number of parallel compression tasks"></NumericUpDown>
 						</WrapPanel>

--- a/Knossos.NET/Views/Windows/ModInstallView.axaml
+++ b/Knossos.NET/Views/Windows/ModInstallView.axaml
@@ -69,6 +69,9 @@
 		<StackPanel IsVisible="{Binding CompressVisible}" Grid.Row="3" HorizontalAlignment="Center">
 			<StackPanel IsVisible="{Binding !IsInstalled}">
 				<StackPanel IsVisible="{Binding DataLoaded}">
+					<StackPanel IsVisible="{Binding CompressVisible}">
+						<CheckBox IsVisible="{Binding !InstallInDevMode}" IsChecked="{Binding Compress}" ToolTip.Tip="Compression mode is on Manual. If you compress the mods you are installing they will use less space on disk. But installing time is longer and the minimum FSO version to support mod compression is 23.2.0.">Compress mods during install</CheckBox>
+					</StackPanel>
 					<CheckBox IsVisible="{Binding HasWriteAccess}" IsChecked="{Binding InstallInDevMode}" IsEnabled="{Binding !ForceDevMode}" ToolTip.Tip="This is for mod developers ONLY. Enable only if you know what you are doing. If you enable this all packages for this mod will be installed regardless of your selection. If you, for some reason, have both devmode versions and non-devmode versions for this mod and you are modifying a non-devmode version this option will have no effect. Mod compression can not be enabled with this mode.">Install Mod in Developer Mode</CheckBox>
 				</StackPanel>
 			</StackPanel>

--- a/Knossos.NET/Views/Windows/ModInstallView.axaml
+++ b/Knossos.NET/Views/Windows/ModInstallView.axaml
@@ -69,7 +69,6 @@
 		<StackPanel IsVisible="{Binding CompressVisible}" Grid.Row="3" HorizontalAlignment="Center">
 			<StackPanel IsVisible="{Binding !IsInstalled}">
 				<StackPanel IsVisible="{Binding DataLoaded}">
-					<CheckBox IsVisible="{Binding !InstallInDevMode}" IsChecked="{Binding Compress}" ToolTip.Tip="Compression mode is on Manual. If you compress the mods you are installing they will use less space on disk. But installing time is longer and the minimum FSO version to support mod compression is 23.2.0.">Compress mods during install</CheckBox>
 					<CheckBox IsVisible="{Binding HasWriteAccess}" IsChecked="{Binding InstallInDevMode}" IsEnabled="{Binding !ForceDevMode}" ToolTip.Tip="This is for mod developers ONLY. Enable only if you know what you are doing. If you enable this all packages for this mod will be installed regardless of your selection. If you, for some reason, have both devmode versions and non-devmode versions for this mod and you are modifying a non-devmode version this option will have no effect. Mod compression can not be enabled with this mode.">Install Mod in Developer Mode</CheckBox>
 				</StackPanel>
 			</StackPanel>

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -37,7 +37,7 @@
 		<!--Page2-->
 		<StackPanel IsVisible="{Binding Page2}" Grid.Row="0" >
 			<StackPanel IsVisible="{Binding !IsPortableMode}">
-				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Knossos Library Folder (Optional)</TextBlock>
+				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Knossos Library Folder</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The KnossosNET Library Folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>
@@ -55,18 +55,18 @@
 		
 		<!--Page3-->
 		<StackPanel IsVisible="{Binding Page3}" Grid.Row="0" >
-			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Mod Compression (Optional)</TextBlock>
+			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Mod Compression</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">KnossosNET can compress supported mod files in your library as mods are installed. This can reduce their size on disk, but compression requires additional processing and can make installations take longer.</TextBlock>
 			<TextBlock Margin="20,10,20,5" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Choose how KnossosNET handles mod compression:</TextBlock>
 			<ComboBox SelectedIndex="{Binding ModCompression}" HorizontalAlignment="Left" Width="230" Margin="20,0,20,10">
 				<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
 				<ComboBoxItem Tag="1">Manual</ComboBoxItem>
 				<ComboBoxItem Tag="2">Forced On</ComboBoxItem>
-				<ComboBoxItem Tag="3">Automatic (Recommended)</ComboBoxItem>
+				<ComboBoxItem Tag="3">Automatic</ComboBoxItem>
 			</ComboBox>
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Disabled:</Run> Mod compression is unavailable.</TextBlock>
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Manual:</Run> Mods are not compressed during installation. To compress a mod, install it first, open its individual Mod Settings, and use the compression option there.</TextBlock>
-			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Automatic (Recommended):</Run> Mods are compressed during installation only when they meet the minimum FSO build requirements for mod compression.</TextBlock>
+			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Automatic:</Run> Mods are compressed during installation only when they meet the minimum FSO build requirements for mod compression.</TextBlock>
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Forced On:</Run> All non-developer mods are compressed during installation.</TextBlock>
 			<TextBlock Margin="20,20,20,5" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">You can change this option at any time in "Settings" under the "KnossosNET Settings" section.</TextBlock>
 			<Button Command="{Binding ClickSettingsButton}" Margin="20,0,0,0" Classes="Quaternary">Show me where</Button>
@@ -74,7 +74,8 @@
 
 		<!--Page4-->
 		<StackPanel IsVisible="{Binding Page4}" Grid.Row="0" >
-			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Freespace 2 Retail (Optional)</TextBlock>
+			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Installing Freespace 2 Retail</TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left" Text="{Binding RetailFs2Status}"/>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">In order to have access to Freespace 1 and 2 content and visual improvements you need to install Freespace 2 Retail game data in KnossosNET. If you do not install Freespace 2 Retail, then any content that needs the full Freespace 2 retail files will not be displayed on the "Explore" tab.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">If you do not have the retail FS2 installed into KnossosNET you can still play total conversion mods, which are mods that are completely standalone and do not depend on any of the Freespace content.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">To install Freespace 2 go to the "Settings" tab and open the "FS2 Retail Installer" button under the "KnossosNET Settings" section. Then follow the instructions there. If you already have FS2 installed this button is not available.</TextBlock>
@@ -83,7 +84,7 @@
 
 		<!--Page5-->
 		<StackPanel IsVisible="{Binding Page5}" Grid.Row="0"  >
-			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Installing mods (Optional)</TextBlock>
+			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Installing mods and total conversions</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The "Freespace" tab is where the most relevant mods to Freespace, including Freespace 2 retail, Freespace 1 and their graphics upgrades are listed for easy access. If you are just starting to KnossosNET we recommend you start there. </TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The "Play" tab is where all your installed mods are displayed, while the "Explore" tab shows only uninstalled mods. If you have installed Freespace 2 Retail, the FS2 retail mod card will already be added to your "Play" tab, but if you click "Play" right now you will be playing Freespace 2 in only its original 1999 glory. At this point you are probably looking for the visual improvements, so go to the "Explore" tab and lets download and install some mods!</TextBlock>
 			<TextBlock Margin="20,0,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The following mods are some of the main projects related to improving visuals and Freespace story:</TextBlock>

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -36,13 +36,12 @@
 		<!--Page2-->
 		<StackPanel IsVisible="{Binding Page2}" Grid.Row="0" >
 			<StackPanel IsVisible="{Binding !IsPortableMode}">
-				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Setting up the Library Folder</TextBlock>
-				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">First, you must set a Library Folder. Go to the "Settings" tab and under the "KnossosNET" section click on the "Browse" button and choose or create a folder for KnossosNET to use. It is highly recommended to set this as an empty folder in a location with a large amount of available storage. Do not set your Library Folder to a shared or cloud drive (such as OneDrive or Google Drive) because syncing issues will prevent Knossos from downloading mod files correctly.</TextBlock>
+				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Knossos Library Folder</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The KnossosNET Library Folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>
-				<TextBlock IsVisible="{Binding !CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Go to the "Settings" tab and set the Library Folder to continue.</TextBlock>
-				<Button IsVisible="{Binding !CanContinue}" Command="{Binding ClickSettingsButton}" Margin="20,0,0,0" Classes="Quaternary">Show me where</Button>
+				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">This is the current library folder path, if you want to change its location you can go to "Settings" and change it.</TextBlock>
+				<Button Command="{Binding ClickSettingsButton}" Margin="20,0,0,0" Classes="Quaternary">Show me where</Button>
 			</StackPanel>
 			<StackPanel IsVisible="{Binding IsPortableMode}">
 				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >KnossosNET is running in portable mode</TextBlock>
@@ -88,7 +87,7 @@
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">&#8226; Freespace Upgrade MediaVPs - Visual improvements for Freespace 2. It is also used by most, if not all, other FS related mods. This mod has optional visual improvements components (like MV_AdvancedX) and it is recommended to select them all during install.</TextBlock>
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">&#8226; FreeSpace Port MediaVPs - Visual improvements for the Freespace 1 port. This will also install the Freespace 1 port mod, which gives you access to the full Freespace 1 missions and story.</TextBlock>
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">&#8226; Silent Threat: Reborn - Fan made replacement and improvement of the original Silent Threat FS1 expansion. The story elements happen after the main FS1 story and before FS2.</TextBlock>
-			<TextBlock Margin="20,20,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Remember that you can always play total conversion mods, which do not require Freespace 2 Retail files. There are many great options, such as Wing Commander Saga, Diaspora, Solaris and more.</TextBlock>
+			<TextBlock Margin="20,20,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Remember that you can always play total conversion mods, which do not require Freespace 2 Retail files. There are many great options, such as Event Horizon, Wing Commander Saga, Diaspora, Solaris and more.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">This step is optional and you can continue at any time.</TextBlock>
 		</StackPanel>
 

--- a/Knossos.NET/Views/Windows/QuickSetupView.axaml
+++ b/Knossos.NET/Views/Windows/QuickSetupView.axaml
@@ -11,7 +11,7 @@
 		Icon="/Assets/knossos-icon.ico"
 		Topmost="True"
 		WindowStartupLocation="CenterOwner"
-		Title="Quick Setup Guide" 
+		Title="Quick Start Guide" 
 		SizeToContent="WidthAndHeight"
 		MaxWidth="800"
 		MinHeight="400"
@@ -28,6 +28,7 @@
 		<StackPanel IsVisible="{Binding Page1}" Grid.Row="0">
 			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Welcome To Knossos.NET</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" >This quick setup guide will help you through the basics of configuring the KnossosNET launcher for the first time. If you already know how to configure the launcher you can close this window.</TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Every step in this guide is optional, so you can continue or close the guide at any time.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" >Note, you can reopen this guide at any time, just go to the "Settings" tab and click the "Quick Setup Guide" button.</TextBlock>
       <TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" >If you ever need assistance with KnossosNET please ask on the Discord channel linked below.</TextBlock>
       <Button Margin="20, 10" Command="{Binding OpenDiscordQuickSetup}">Discord Help for KnossosNET</Button>
@@ -36,7 +37,7 @@
 		<!--Page2-->
 		<StackPanel IsVisible="{Binding Page2}" Grid.Row="0" >
 			<StackPanel IsVisible="{Binding !IsPortableMode}">
-				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Knossos Library Folder</TextBlock>
+				<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left" >Knossos Library Folder (Optional)</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">The KnossosNET Library Folder is where all game and mod data will be saved to. Make sure you always have space available on this drive before installing a new mod or update.</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Current Library Folder</TextBlock>
 				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left" Text="{Binding LibraryPath}"></TextBlock>
@@ -54,28 +55,30 @@
 		
 		<!--Page3-->
 		<StackPanel IsVisible="{Binding Page3}" Grid.Row="0" >
-			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Download an FSO engine build</TextBlock>
-			<TextBlock IsVisible="{Binding !RepoDownloaded}" Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Wait for repo_minimal.json to finish downloading before you continue...</TextBlock>
-			<StackPanel IsVisible="{Binding RepoDownloaded}">
-				<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Now you need a game engine build, which are known as "FSO Builds". These builds are what mods run on, and KnossosNET also uses it to get and display system data. This is why you are not going to be able to set most of the settings in the "Settings" tab before downloading one. </TextBlock>
-				<TextBlock IsVisible="{Binding BuildAvailable}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Click the button below to download the latest stable build, which is what most casual players use. You can also go to the "Engine" tab, and pick a specific build. The most recent build should be always the top one on the list.</TextBlock>
-				<TextBlock IsVisible="{Binding !BuildAvailable}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Go to the "Engine" tab, select "Stable Builds" and download the newest stable, it should be always the top one on the list.</TextBlock>
-				<Button IsVisible="{Binding BuildAvailable}" Margin="0,10,0,10" HorizontalAlignment="Center" Classes="Primary" Content="Download Latest Stable Build" Command="{Binding DownloadLatestStable}"/>
-				<TextBlock IsVisible="{Binding !CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">A FSO build must be downloaded before you continue...</TextBlock>
-				<Button IsVisible="{Binding !CanContinue}" Command="{Binding ClickEngineButton}" Margin="20,0,0,0" Classes="Quaternary">Show me where</Button>
-				<TextBlock IsVisible="{Binding CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Engine build detected!</TextBlock>
-				<TextBlock IsVisible="{Binding CanContinue}" Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Keep in mind that some mods may download and run on different versions of the FSO engine. This is because some mods cannot run on newer builds or they require a specific FSO build version. You can always change the FSO build used by a mod by opening the "Mod Settings" on the mod card, but keep in mind not all mods can run on all engine builds.</TextBlock>
-			</StackPanel>
+			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Mod Compression (Optional)</TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">KnossosNET can compress supported mod files in your library as mods are installed. This can reduce their size on disk, but compression requires additional processing and can make installations take longer.</TextBlock>
+			<TextBlock Margin="20,10,20,5" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">Choose how KnossosNET handles mod compression:</TextBlock>
+			<ComboBox SelectedIndex="{Binding ModCompression}" HorizontalAlignment="Left" Width="230" Margin="20,0,20,10">
+				<ComboBoxItem Tag="0">Disabled</ComboBoxItem>
+				<ComboBoxItem Tag="1">Manual</ComboBoxItem>
+				<ComboBoxItem Tag="2">Forced On</ComboBoxItem>
+				<ComboBoxItem Tag="3">Automatic (Recommended)</ComboBoxItem>
+			</ComboBox>
+			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Disabled:</Run> Mod compression is unavailable.</TextBlock>
+			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Manual:</Run> Mods are not compressed during installation. To compress a mod, install it first, open its individual Mod Settings, and use the compression option there.</TextBlock>
+			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Automatic (Recommended):</Run> Mods are compressed during installation only when they meet the minimum FSO build requirements for mod compression.</TextBlock>
+			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left"><Run FontWeight="Bold">Forced On:</Run> All non-developer mods are compressed during installation.</TextBlock>
+			<TextBlock Margin="20,20,20,5" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">You can change this option at any time in "Settings" under the "KnossosNET Settings" section.</TextBlock>
+			<Button Command="{Binding ClickSettingsButton}" Margin="20,0,0,0" Classes="Quaternary">Show me where</Button>
 		</StackPanel>
 
 		<!--Page4-->
 		<StackPanel IsVisible="{Binding Page4}" Grid.Row="0" >
 			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Freespace 2 Retail (Optional)</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">In order to have access to Freespace 1 and 2 content and visual improvements you need to install Freespace 2 Retail in KnossosNET. If you do not install Freespace 2 Retail, then any content that needs the full Freespace 2 retail files will not be displayed on the "Explore" tab.</TextBlock>
+			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">In order to have access to Freespace 1 and 2 content and visual improvements you need to install Freespace 2 Retail game data in KnossosNET. If you do not install Freespace 2 Retail, then any content that needs the full Freespace 2 retail files will not be displayed on the "Explore" tab.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">If you do not have the retail FS2 installed into KnossosNET you can still play total conversion mods, which are mods that are completely standalone and do not depend on any of the Freespace content.</TextBlock>
 			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">To install Freespace 2 go to the "Settings" tab and open the "FS2 Retail Installer" button under the "KnossosNET Settings" section. Then follow the instructions there. If you already have FS2 installed this button is not available.</TextBlock>
 			<Button Command="{Binding ClickSettingsButton}" Margin="20,0,0,0" Classes="Quaternary">Show me where</Button>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">This step is optional and you can continue at any time.</TextBlock>
 		</StackPanel>
 
 		<!--Page5-->
@@ -88,21 +91,13 @@
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">&#8226; FreeSpace Port MediaVPs - Visual improvements for the Freespace 1 port. This will also install the Freespace 1 port mod, which gives you access to the full Freespace 1 missions and story.</TextBlock>
 			<TextBlock Margin="30,5,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">&#8226; Silent Threat: Reborn - Fan made replacement and improvement of the original Silent Threat FS1 expansion. The story elements happen after the main FS1 story and before FS2.</TextBlock>
 			<TextBlock Margin="20,20,20,0" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Remember that you can always play total conversion mods, which do not require Freespace 2 Retail files. There are many great options, such as Event Horizon, Wing Commander Saga, Diaspora, Solaris and more.</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" FontWeight="Bold" HorizontalAlignment="Left">This step is optional and you can continue at any time.</TextBlock>
-		</StackPanel>
-
-		<!--Page6-->
-		<StackPanel IsVisible="{Binding Page6}" Grid.Row="0" >
-			<TextBlock Margin="10" TextWrapping="Wrap" FontWeight="Bold" FontSize="36" HorizontalAlignment="Left">Finishing</TextBlock>
-			<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">Finally, before launching a mod go to the "Settings" tab and configure video and audio settings, as well as any joysticks you may have installed.</TextBlock>
-      <!--<TextBlock Margin="20" TextWrapping="Wrap" FontSize="15" HorizontalAlignment="Left">It is recommended to run in windowed mode at the same resolution as your system display. There is no need to enable the borderless mode, as windowed mode is already borderless at native resolution.</TextBlock>-->
 		</StackPanel>
 		
 		<!--Navigation-->
 		<WrapPanel Grid.Row="1" HorizontalAlignment="Center">
 			<Button Command="{Binding GoBackCommand}" IsVisible="{Binding CanGoBack}" Margin="5" Classes="Secondary">Back</Button>
 			<Button Command="{Binding ContinueCommand}" IsEnabled="{Binding CanContinue}" IsVisible="{Binding !LastPage}" Margin="5" Classes="Accept">Next</Button>
-			<Button Command="{Binding Finish}" IsVisible="{Binding LastPage}" Margin="5" Classes="Accept">Finish</Button>
+			<Button Command="{Binding Finish}" IsVisible="{Binding LastPage}" Margin="5" Classes="Accept">Finish and close</Button>
 		</WrapPanel>
 	</Grid>
 	</ScrollViewer>


### PR DESCRIPTION
Quick Start Guide:
-All steps are optional
-Set library path is now a suggestion
-Removed the get flags page and replaced for a mod compression explanation and setup page
-Removed page 6 that talked about setting the legacy video and audio settings on knossos

Auto Default Library path setting in new installs:
-Warn about the library folder being missing and reset path
-Get path from Knossos Legacy, but first check it actually exists.

Then it is set by OS:
-Windows: C:\Games\KnossosNET\FreespaceOpen; If not writtable: %PUBLIC%\KnossosNET\FreespaceOpen
-MacOS: ~/Library/Application Support/io.github.KnossosNET.Knossos_NET/FreespaceOpen
-Linux: ~/KnossosNET/FreespaceOpen
-Android: {internal storage}/Android/data/com.knossosnet.knossosnet/files/library

Fallbacks: {user profile}\KnossosNET\FreespaceOpen, then {LocalApplicationData}\KnossosNET\FreespaceOpen