### PR TITLE
Integrate Android to knet update system

### DIFF
--- a/Knossos.NET.Android/MainActivity.cs
+++ b/Knossos.NET.Android/MainActivity.cs
@@ -22,6 +22,9 @@ namespace Knossos.NET.Android;
     ScreenOrientation = ScreenOrientation.SensorLandscape)]
 public class MainActivity : AvaloniaMainActivity<App>
 {
+    private const string ApkMimeType = "application/vnd.android.package-archive";
+    private static string? pendingApkInstallPath;
+
     public static MainActivity? Instance { get; private set; }
 
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
@@ -66,6 +69,7 @@ public class MainActivity : AvaloniaMainActivity<App>
         AndroidHelper.ShareTextAsyncFunc = ShareTextFileAndroidAsync;
         AndroidHelper.ShareFileAsyncFunc = OpenFileExternalApp;
         AndroidHelper.OpenUrlAsyncFunc = OpenExternalURLAsync;
+        AndroidHelper.InstallApkAsyncFunc = InstallApkAndroidAsync;
         hideSystemUI();
     }
 
@@ -73,6 +77,63 @@ public class MainActivity : AvaloniaMainActivity<App>
     {
         base.OnResume();
         hideSystemUI();
+
+        if (pendingApkInstallPath != null && PackageManager?.CanRequestPackageInstalls() == true)
+        {
+            var apkPath = pendingApkInstallPath;
+            pendingApkInstallPath = null;
+            OpenPackageInstaller(apkPath);
+        }
+    }
+
+    private static async Task InstallApkAndroidAsync(string fullPath)
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            if (!System.IO.File.Exists(fullPath) || Instance == null)
+                return;
+
+            try
+            {
+                if (Instance.PackageManager?.CanRequestPackageInstalls() != true)
+                {
+                    pendingApkInstallPath = fullPath;
+                    var packageUri = AndroidNet.Uri.Parse($"package:{Instance.PackageName}");
+                    var permissionIntent = new Intent(global::Android.Provider.Settings.ActionManageUnknownAppSources, packageUri);
+                    Instance.StartActivity(permissionIntent);
+                    return;
+                }
+
+                OpenPackageInstaller(fullPath);
+            }
+            catch (Exception ex)
+            {
+                pendingApkInstallPath = null;
+                Log.Add(Log.LogSeverity.Error, "MainActivity.InstallApkAndroidAsync", ex);
+            }
+        });
+    }
+
+    private static void OpenPackageInstaller(string fullPath)
+    {
+        if (!System.IO.File.Exists(fullPath) || Instance == null)
+            return;
+
+        try
+        {
+            var javaFile = new Java.IO.File(fullPath);
+            var authority = $"{Instance.PackageName}.fileprovider";
+            var uri = FileProvider.GetUriForFile(Instance, authority, javaFile);
+
+            var intent = new Intent(Intent.ActionView);
+            intent.SetDataAndType(uri, ApkMimeType);
+            intent.AddFlags(ActivityFlags.GrantReadUriPermission);
+            Instance.StartActivity(intent);
+        }
+        catch (Exception ex)
+        {
+            Log.Add(Log.LogSeverity.Error, "MainActivity.OpenPackageInstaller", ex);
+        }
     }
 
     private static async Task ShareTextFileAndroidAsync(string texto)

--- a/Knossos.NET.Android/Properties/AndroidManifest.xml
+++ b/Knossos.NET.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto" package="com.knossosnet.knossosnet">
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 	<uses-feature android:glEsVersion="0x00030002" android:required="false" />
 	<!-- Touchscreen support -->
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />

--- a/Knossos.NET/Classes/AndroidHelper.cs
+++ b/Knossos.NET/Classes/AndroidHelper.cs
@@ -19,6 +19,7 @@ public static class AndroidHelper
     public static Func<string, Task>? ShareTextAsyncFunc { get; set; }
     public static Func<string, string, Task>? ShareFileAsyncFunc { get; set; }
     public static Func<string, Task>? OpenUrlAsyncFunc { get; set; }
+    public static Func<string, Task>? InstallApkAsyncFunc { get; set; }
 
     /// <summary>
     /// Open URL on external android web browser
@@ -53,6 +54,17 @@ public static class AndroidHelper
         if (text.Length == 0 || ShareFileAsyncFunc == null)
             return Task.CompletedTask;
         return ShareFileAsyncFunc.Invoke(text, mimeType);
+    }
+
+    /// <summary>
+    /// Sends an APK to Android's package installer.
+    /// </summary>
+    /// <param name="fullPath">Full path to the downloaded APK.</param>
+    public static Task InstallApkAsync(string fullPath)
+    {
+        if (string.IsNullOrWhiteSpace(fullPath) || InstallApkAsyncFunc == null)
+            return Task.CompletedTask;
+        return InstallApkAsyncFunc.Invoke(fullPath);
     }
 
 #if ANDROID
@@ -114,6 +126,16 @@ public static class AndroidHelper
     public static string GetDefaultFSODataDir()
     {
         return GetInternalAppFilesDir();
+    }
+
+    /// <summary>
+    /// APK update destination. The internal cache is already exposed through the
+    /// app FileProvider and can be cleared safely by Android after installation.
+    /// </summary>
+    public static string GetUpdateApkPath()
+    {
+        var cacheDir = Application.Context.CacheDir?.AbsolutePath ?? GetInternalAppFilesDir();
+        return Path.Combine(cacheDir, "update.apk");
     }
 
     /// <summary>
@@ -261,6 +283,7 @@ public static class AndroidHelper
     public static string GetDefaultKnetDir() => "";
     public static string GetDefaultKnetDataDir() => "";
     public static string GetDefaultFSODataDir() => "";
+    public static string GetUpdateApkPath() => "";
     public static void LaunchFSO(string engineLibPath, string? workingFolder, string cmdline) {  }
     public static async Task<string> GetFlagsStringFSOAsync(string engineLibPath, int timeoutMs = 30000) { await Task.Delay(1); return ""; }
 #endif

--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -271,7 +271,7 @@ namespace Knossos.NET
                 Log.Add(Log.LogSeverity.Information, "Knossos.StartUp()", "The selected decompressor type is set to " + globalSettings.decompressor.ToString());
 
                 //Check for updates
-                if (globalSettings.checkUpdate && !isQuickLaunch && !KnUtils.IsAndroid && !KnUtils.IsBrowser)
+                if (globalSettings.checkUpdate && !isQuickLaunch && !KnUtils.IsBrowser)
                 {
                     await CheckKnetUpdates().ConfigureAwait(false);
                     //Check for .old files and delete them
@@ -571,7 +571,15 @@ namespace Knossos.NET
                             GitHubReleaseAsset? releaseAsset = null;
                             foreach (GitHubReleaseAsset a in latest.assets)
                             {
-                                if (KnUtils.IsAppImage)
+                                if (KnUtils.IsAndroid)
+                                {
+                                    if (a.name != null && a.name.EndsWith(".apk", StringComparison.OrdinalIgnoreCase))
+                                    {
+                                        releaseAsset = a;
+                                        break;
+                                    }
+                                }
+                                else if (KnUtils.IsAppImage)
                                 {
                                     if (a.name != null)
                                     {
@@ -637,7 +645,10 @@ namespace Knossos.NET
                                 {
                                     MessageBox.MessageBoxResult result = MessageBox.MessageBoxResult.Cancel;
                                     await Dispatcher.UIThread.Invoke(async () => {
-                                        result = await MessageBox.Show(null, "Knossos.NET " + latest.tag_name + ":\n" + latest.body + "\n\n\nIf you continue Knossos.NET will be re-started after download.", "An update is available", MessageBox.MessageBoxButtons.ContinueCancelSkipVersion);
+                                        var updateAction = KnUtils.IsAndroid
+                                            ? "If you continue, the APK will be downloaded and Android will ask you to install it."
+                                            : "If you continue Knossos.NET will be re-started after download.";
+                                        result = await MessageBox.Show(null, "Knossos.NET " + latest.tag_name + ":\n" + latest.body + "\n\n\n" + updateAction, "An update is available", MessageBox.MessageBoxButtons.ContinueCancelSkipVersion);
                                     }).ConfigureAwait(false);
                                     if(result == MessageBox.MessageBoxResult.SkipVersion)
                                     {
@@ -661,15 +672,24 @@ namespace Knossos.NET
                                 {
                                     extension = ".tar.gz";
                                 }
-                                var download = await Dispatcher.UIThread.InvokeAsync(async () => await TaskViewModel.Instance!.AddFileDownloadTask(releaseAsset.browser_download_url, KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "update"+ extension, "Downloading "+latest.tag_name+" "+releaseAsset.name, true, "This is a Knossos.NET update"), DispatcherPriority.Background).ConfigureAwait(false);
+                                var updateFilePath = KnUtils.IsAndroid
+                                    ? AndroidHelper.GetUpdateApkPath()
+                                    : KnUtils.GetKnossosDataFolderPath() + Path.DirectorySeparatorChar + "update" + extension;
+                                var download = await Dispatcher.UIThread.InvokeAsync(async () => await TaskViewModel.Instance!.AddFileDownloadTask(releaseAsset.browser_download_url, updateFilePath, "Downloading "+latest.tag_name+" "+releaseAsset.name, true, "This is a Knossos.NET update"), DispatcherPriority.Background).ConfigureAwait(false);
                                 if (download != null && download == true)
                                 {
-                                    var appDirPath = Path.GetDirectoryName(Environment.ProcessPath);
-                                    var execFullPath = Environment.ProcessPath;
-
                                     //Decompress new files / 2nd phase
                                     try
                                     {
+                                        if (KnUtils.IsAndroid)
+                                        {
+                                            await AndroidHelper.InstallApkAsync(updateFilePath).ConfigureAwait(false);
+                                            return;
+                                        }
+
+                                        var appDirPath = Path.GetDirectoryName(Environment.ProcessPath);
+                                        var execFullPath = Environment.ProcessPath;
+
                                         // no extraction needed for AppImage, just move exec over and restart
                                         // NOTE: exeName is already the full path to the AppImage
                                         if (KnUtils.IsAppImage)


### PR DESCRIPTION
Support app updates in android by downloading the apk from the releases and start the install process.

User will have to give permission to install packages when requested