### PR TITLE
Fix tools loading incorrectly and hide tools system in Android

### DIFF
--- a/Knossos.NET/Classes/Knossos.cs
+++ b/Knossos.NET/Classes/Knossos.cs
@@ -26,6 +26,7 @@ namespace Knossos.NET
         private static List<Mod> installedMods = new List<Mod>();
         private static List<FsoBuild> engineBuilds = new List<FsoBuild>();
         private static List<Tool> modTools = new List<Tool>();
+        private static readonly TaskCompletionSource<bool> initialLibraryScanCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         public static GlobalSettings globalSettings = new GlobalSettings();
         public static bool retailFs2RootFound = false;
         public static bool flagDataLoaded = false;
@@ -926,6 +927,7 @@ namespace Knossos.NET
                 MainViewModel.Instance?.tagFilter.Clear();
 
                 await FolderSearchRecursive(globalSettings.basePath, isQuickLaunch).ConfigureAwait(false);
+                initialLibraryScanCompletion.TrySetResult(true);
 
                 Log.Add(Log.LogSeverity.Information, "Knossos.LoadBasePath()", "Loaded: " + installedMods.Count() +" installed mods or tcs and " + engineBuilds.Count() + " engine builds." );
 
@@ -972,6 +974,18 @@ namespace Knossos.NET
 
                 initIsComplete = true;
             }
+            else
+            {
+                initialLibraryScanCompletion.TrySetResult(true);
+            }
+        }
+
+        /// <summary>
+        /// Wait until the initial library scan has discovered locally installed tools.
+        /// </summary>
+        public static Task WaitForInitialLibraryScanAsync()
+        {
+            return initialLibraryScanCompletion.Task;
         }
 
         /// <summary>
@@ -1687,7 +1701,7 @@ namespace Knossos.NET
                     Log.Add(Log.LogSeverity.Warning, "Knossos.FolderSearchRecursive()", "Deleting incomplete download found at "+path);
                     Directory.Delete(path, true);
                 }
-                else if (File.Exists(path + Path.DirectorySeparatorChar + "tool.json"))
+                else if (!KnUtils.IsAndroid && File.Exists(path + Path.DirectorySeparatorChar + "tool.json"))
                 {
                     Knossos.AddTool(new Tool(path));
                 }

--- a/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
+++ b/Knossos.NET/ViewModels/DeveloperModsViewModel.cs
@@ -80,6 +80,7 @@ namespace Knossos.NET.ViewModels
         internal NebulaLoginViewModel nebulaLoginVM = new NebulaLoginViewModel();
         [ObservableProperty]
         internal DevToolManagerViewModel devToolManager = new DevToolManagerViewModel();
+        internal bool ToolsAvailable { get; } = !KnUtils.IsAndroid;
         [ObservableProperty]
         public string latestStable = string.Empty;
         [ObservableProperty]
@@ -104,7 +105,8 @@ namespace Knossos.NET.ViewModels
                     }
                     if (tabIndex == 1) //Tools
                     {
-                        DevToolManager.LoadTools();
+                        if (ToolsAvailable)
+                            DevToolManager.LoadTools();
                     }
                     if (tabIndex == 2) //Nebula Login
                     {

--- a/Knossos.NET/ViewModels/Templates/DevModEditorViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevModEditorViewModel.cs
@@ -33,6 +33,7 @@ namespace Knossos.NET.ViewModels
         internal ObservableCollection<ComboBoxItem> toolItems = new ObservableCollection<ComboBoxItem>();
         [ObservableProperty]
         internal int toolIndex = 0;
+        internal bool ToolsAvailable { get; } = !KnUtils.IsAndroid;
 
         internal int tabIndex = 0;
         internal int TabIndex
@@ -145,7 +146,8 @@ namespace Knossos.NET.ViewModels
                 DetailsView = null;
                 MembersView = null;
                 IsEngineBuild = false;
-                LoadTools();
+                if (ToolsAvailable)
+                    LoadTools();
                 ModImage = new Bitmap(AssetLoader.Open(new Uri("avares://Knossos.NET/Assets/general/NebulaDefault.png")));
                 index = 0;
                 //Get all installed mods with this ID

--- a/Knossos.NET/ViewModels/Templates/DevToolManagerViewModel.cs
+++ b/Knossos.NET/ViewModels/Templates/DevToolManagerViewModel.cs
@@ -162,6 +162,7 @@ namespace Knossos.NET.ViewModels
         internal ObservableCollection<ToolItem> tools = new ObservableCollection<ToolItem>();
 
         private bool toolsRepoLoaded = false;
+        private bool toolsLoading = false;
 
         public DevToolManagerViewModel()
         {
@@ -169,14 +170,26 @@ namespace Knossos.NET.ViewModels
 
         public async void LoadTools()
         {
-            if (!toolsRepoLoaded)
+            if (KnUtils.IsAndroid || toolsRepoLoaded || toolsLoading)
+                return;
+
+            toolsLoading = true;
+            try
             {
-                foreach (var installedTool in Knossos.GetTools())
+                await Knossos.WaitForInitialLibraryScanAsync().ConfigureAwait(false);
+                await Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    InsertInOrder(installedTool);
-                }
+                    foreach (var installedTool in Knossos.GetTools())
+                    {
+                        InsertInOrder(installedTool);
+                    }
+                });
                 await LoadToolRepo().ConfigureAwait(false);
                 toolsRepoLoaded = true;
+            }
+            finally
+            {
+                toolsLoading = false;
             }
         }
 
@@ -195,6 +208,9 @@ namespace Knossos.NET.ViewModels
 
         private async Task LoadToolRepo()
         {
+            if (KnUtils.IsAndroid)
+                return;
+
             try
             {
                 using var response = await KnUtils.GetHttpClient().GetAsync(Knossos.ToolRepoURL).ConfigureAwait(false);

--- a/Knossos.NET/Views/DeveloperModsView.axaml
+++ b/Knossos.NET/Views/DeveloperModsView.axaml
@@ -47,7 +47,7 @@
 				</SplitView>
 			</TabItem>
 
-			<TabItem Header="Modding Tools">
+			<TabItem Header="Modding Tools" IsVisible="{Binding ToolsAvailable}">
 				<Grid>
 					<Button ToolTip.Tip="You want to add your tool to Knossos.NET tool section?" Command="{Binding OpenAddToolGuide}" Margin="0,-50,5,0" VerticalAlignment="Top" HorizontalAlignment="Right" ZIndex="1">How to add or update my tool?</Button>
 					<v:DevToolManagerView Content="{Binding DevToolManager}"/>

--- a/Knossos.NET/Views/Templates/DevModEditorView.axaml
+++ b/Knossos.NET/Views/Templates/DevModEditorView.axaml
@@ -34,7 +34,7 @@
 					<Button Command="{Binding OpenModFolder}" Classes="Quaternary" Margin="2" Width="150">Open Folder</Button>
 				</StackPanel>
 				<!--Tools-->
-				<StackPanel IsVisible="true" Margin="20,10,20,10" HorizontalAlignment="Center">
+				<StackPanel IsVisible="{Binding ToolsAvailable}" Margin="20,10,20,10" HorizontalAlignment="Center">
 					<TextBlock HorizontalAlignment="Center" Text="Tools" FontWeight="Bold" FontSize="14" TextWrapping="Wrap" Margin="0,0,0,3"></TextBlock>
 					<ComboBox ItemsSource="{Binding ToolItems}" Width="154" SelectedIndex="{Binding ToolIndex}"></ComboBox>
 					<Button Classes="Quaternary" Command="{Binding OpenTool}" HorizontalAlignment="Center" Margin="2,4,0,0" Width="150">Open</Button>


### PR DESCRIPTION
Tools were loading incorrectly if you get to the modding tool menu before the tool repo was loaded.

ALso hide the entire tool system on android as its not going to be supported there.